### PR TITLE
feat(web-v2): add automations and testing-arena routes

### DIFF
--- a/apps/web-v2/src/routes/_repo/$owner/$repo/automations/$id.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/automations/$id.tsx
@@ -1,0 +1,41 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { Spinner } from "@conductor/ui";
+import { AutomationClient } from "./AutomationClient";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/automations/$id")({
+  component: AutomationDetailRoute,
+});
+
+function AutomationDetailRoute() {
+  const { id, owner, repo } = Route.useParams();
+  const automation = useQuery(api.automations.get, {
+    id: id as Id<"automations">,
+  });
+
+  if (automation === undefined) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (automation === null) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-muted-foreground">
+        <p>Automation not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <AutomationClient
+      automation={automation}
+      repoOwner={owner}
+      repoName={repo}
+    />
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/automations/AutomationClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/automations/AutomationClient.tsx
@@ -1,0 +1,530 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api, CLAUDE_MODELS, type ClaudeModel } from "@conductor/backend";
+import type { Doc } from "@conductor/backend";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import { CronScheduleCard } from "@/lib/components/CronScheduleCard";
+import {
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Textarea,
+  Spinner,
+  Badge,
+  ActivitySteps,
+  useElapsedSeconds,
+  formatElapsed,
+  cn,
+} from "@conductor/ui";
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconChevronDown,
+  IconChevronRight,
+  IconExternalLink,
+  IconPlayerPlay,
+  IconPlayerStop,
+} from "@tabler/icons-react";
+import { FindingsList } from "./_components/FindingsList";
+import dayjs from "@conductor/shared/dates";
+import { formatDuration } from "@/lib/utils/formatDuration";
+import { parseActivitySteps } from "@/lib/utils/parseActivitySteps";
+import { Streamdown } from "streamdown";
+import { cjk } from "@streamdown/cjk";
+import { math } from "@streamdown/math";
+import { mermaid } from "@streamdown/mermaid";
+
+const summaryPlugins = { cjk, math, mermaid };
+
+type Automation = Doc<"automations">;
+
+interface AutomationClientProps {
+  automation: Automation;
+  repoOwner: string;
+  repoName: string;
+}
+
+export function AutomationClient({
+  automation,
+  repoOwner,
+  repoName,
+}: AutomationClientProps) {
+  const updateAutomation = useMutation(api.automations.update);
+  const runNow = useMutation(api.automations.runNow);
+  const runs = useQuery(api.automations.listRuns, {
+    automationId: automation._id,
+  });
+  const hasActiveRun = runs?.some(
+    (r) => r.status === "queued" || r.status === "running",
+  );
+
+  return (
+    <PageWrapper
+      title={
+        <div className="flex items-center gap-3">
+          <span>{automation.title}</span>
+          <button
+            type="button"
+            onClick={() =>
+              updateAutomation({
+                id: automation._id,
+                enabled: !automation.enabled,
+              })
+            }
+            className={cn(
+              "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              automation.enabled ? "bg-emerald-500" : "bg-muted-foreground/30",
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none block h-5 w-5 rounded-full bg-white transition-transform",
+                automation.enabled ? "translate-x-5" : "translate-x-0",
+              )}
+            />
+          </button>
+        </div>
+      }
+      headerRight={
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={hasActiveRun === true || !automation.description}
+          onClick={() => runNow({ automationId: automation._id })}
+        >
+          <IconPlayerPlay size={14} />
+          Run Now
+        </Button>
+      }
+    >
+      <Tabs defaultValue="history" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="history">Run History</TabsTrigger>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="history">
+          <RunHistory
+            runs={runs}
+            actionsEnabled={automation.actionsEnabled === true}
+            repoOwner={repoOwner}
+            repoName={repoName}
+          />
+        </TabsContent>
+
+        <TabsContent value="settings">
+          <SettingsForm automation={automation} />
+        </TabsContent>
+      </Tabs>
+    </PageWrapper>
+  );
+}
+
+function RunHistory({
+  runs,
+  actionsEnabled,
+  repoOwner,
+  repoName,
+}: {
+  runs: Doc<"automationRuns">[] | undefined;
+  actionsEnabled: boolean;
+  repoOwner: string;
+  repoName: string;
+}) {
+  const acknowledgeRun = useMutation(api.automations.acknowledgeRun);
+
+  if (runs === undefined) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="rounded-lg bg-muted/40 p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No runs yet. Enable the automation and wait for the cron schedule to
+          trigger, or click &quot;Run Now&quot;.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {runs.map((run) => (
+        <RunAccordion
+          key={run._id}
+          run={run}
+          actionsEnabled={actionsEnabled}
+          repoOwner={repoOwner}
+          repoName={repoName}
+          onAcknowledge={() => acknowledgeRun({ runId: run._id })}
+        />
+      ))}
+    </div>
+  );
+}
+
+function RunAccordion({
+  run,
+  actionsEnabled,
+  repoOwner,
+  repoName,
+  onAcknowledge,
+}: {
+  run: Doc<"automationRuns">;
+  actionsEnabled: boolean;
+  repoOwner: string;
+  repoName: string;
+  onAcknowledge: () => void;
+}) {
+  const isActive = run.status === "running" || run.status === "queued";
+  const [expanded, setExpanded] = useState(isActive);
+  const cancelRun = useMutation(api.automations.cancelRun);
+
+  const streamingEntityId = `automation-run-${run._id}`;
+  const streaming = useQuery(
+    api.streaming.get,
+    isActive ? { entityId: streamingEntityId } : "skip",
+  );
+
+  const elapsed = useElapsedSeconds(run.startedAt, isActive);
+
+  const badgeVariant =
+    run.status === "success"
+      ? "success"
+      : run.status === "error"
+        ? "destructive"
+        : run.status === "running"
+          ? "warning"
+          : "secondary";
+
+  const duration =
+    run.finishedAt && run.startedAt
+      ? formatDuration(run.startedAt, run.finishedAt)
+      : isActive && run.startedAt
+        ? formatElapsed(elapsed)
+        : "";
+
+  const liveSteps = streaming?.currentActivity
+    ? parseActivitySteps(streaming.currentActivity)
+    : null;
+  const completedSteps = run.activityLog
+    ? parseActivitySteps(run.activityLog)
+    : null;
+
+  return (
+    <div className="rounded-lg bg-muted/40 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => {
+          const willExpand = !expanded;
+          setExpanded(willExpand);
+          if (willExpand && !run.acknowledged && !isActive) {
+            onAcknowledge();
+          }
+        }}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/30 transition-colors"
+      >
+        {expanded ? (
+          <IconChevronDown
+            size={14}
+            className="shrink-0 text-muted-foreground"
+          />
+        ) : (
+          <IconChevronRight
+            size={14}
+            className="shrink-0 text-muted-foreground"
+          />
+        )}
+        <Badge variant={badgeVariant}>{run.status}</Badge>
+        <span className="text-sm text-muted-foreground">
+          {dayjs(run.startedAt).format("DD/MM/YYYY HH:mm")}
+        </span>
+        <span className="flex-1 truncate text-sm font-medium">
+          {run.resultSummary
+            ? run.resultSummary.slice(0, 80)
+            : run.error
+              ? run.error.slice(0, 80)
+              : ""}
+        </span>
+        {duration && (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {duration}
+          </span>
+        )}
+        {isActive && (
+          <Button
+            size="sm"
+            variant="destructive"
+            className="shrink-0 h-7 text-xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              cancelRun({ runId: run._id });
+            }}
+          >
+            <IconPlayerStop size={12} />
+            Stop
+          </Button>
+        )}
+        {!run.acknowledged &&
+          run.status !== "queued" &&
+          run.status !== "running" && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="shrink-0 h-7 text-xs"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAcknowledge();
+              }}
+            >
+              <IconCheck size={12} />
+              Read
+            </Button>
+          )}
+        {run.acknowledged && (
+          <span className="shrink-0 text-xs text-emerald-600">Read</span>
+        )}
+      </button>
+      {expanded && (
+        <div className="px-4 py-3 space-y-3">
+          {isActive && liveSteps && (
+            <ActivitySteps steps={liveSteps} isStreaming />
+          )}
+          {!isActive && completedSteps && (
+            <ActivitySteps steps={completedSteps} />
+          )}
+          {actionsEnabled && run.findings && run.findings.length > 0 ? (
+            <FindingsList run={run} repoOwner={repoOwner} repoName={repoName} />
+          ) : (
+            <>
+              {actionsEnabled &&
+                run.resultSummary &&
+                !run.findings &&
+                run.status === "success" && (
+                  <div className="flex items-center gap-2 rounded-lg bg-yellow-500/10 px-3 py-2">
+                    <IconAlertTriangle
+                      size={14}
+                      className="shrink-0 text-yellow-600"
+                    />
+                    <p className="text-xs text-yellow-700 dark:text-yellow-400">
+                      Could not parse findings from report
+                    </p>
+                  </div>
+                )}
+              {run.resultSummary && (
+                <div>
+                  <Streamdown
+                    className="text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                    plugins={summaryPlugins}
+                  >
+                    {run.resultSummary}
+                  </Streamdown>
+                </div>
+              )}
+            </>
+          )}
+          {run.error && (
+            <div>
+              <p className="text-xs font-medium text-red-500 mb-1">Error</p>
+              <p className="text-sm text-red-600 whitespace-pre-wrap">
+                {run.error}
+              </p>
+            </div>
+          )}
+          {run.prUrl && (
+            <div>
+              <a
+                href={run.prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+              >
+                <IconExternalLink size={14} />
+                View Pull Request
+              </a>
+            </div>
+          )}
+          {!isActive && !run.resultSummary && !run.error && !completedSteps && (
+            <p className="text-sm text-muted-foreground">
+              No details available.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SettingsForm({ automation }: { automation: Automation }) {
+  const updateAutomation = useMutation(api.automations.update);
+  const [title, setTitle] = useState(automation.title);
+  const [description, setDescription] = useState(automation.description);
+  const [cronSchedule, setCronSchedule] = useState(automation.cronSchedule);
+  const [model, setModel] = useState<ClaudeModel>(automation.model ?? "sonnet");
+  const [readOnly, setReadOnly] = useState(automation.readOnly === true);
+  const [actionsEnabled, setActionsEnabled] = useState(
+    automation.actionsEnabled === true,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  const hasChanges =
+    title !== automation.title ||
+    description !== automation.description ||
+    cronSchedule !== automation.cronSchedule ||
+    model !== (automation.model ?? "sonnet") ||
+    readOnly !== (automation.readOnly === true) ||
+    actionsEnabled !== (automation.actionsEnabled === true);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await updateAutomation({
+        id: automation._id,
+        title,
+        description,
+        cronSchedule,
+        model,
+        readOnly,
+        actionsEnabled: readOnly ? actionsEnabled : false,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <CronScheduleCard value={cronSchedule} onChange={setCronSchedule} />
+
+      <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+        <h3 className="text-sm font-medium">Description</h3>
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            Title
+          </label>
+          <Input
+            className="h-8 text-xs"
+            placeholder="Automation title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            Prompt
+          </label>
+          <Textarea
+            className="min-h-[120px] text-xs"
+            placeholder="Describe what this automation should do..."
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            The prompt that will be executed on each run.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium">Report Only</h3>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              Analyze and report without making code changes, branches, or PRs
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setReadOnly(!readOnly)}
+            className={cn(
+              "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              readOnly ? "bg-emerald-500" : "bg-muted-foreground/30",
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none block h-5 w-5 rounded-full bg-white transition-transform",
+                readOnly ? "translate-x-5" : "translate-x-0",
+              )}
+            />
+          </button>
+        </div>
+      </div>
+
+      {readOnly && (
+        <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-sm font-medium">Actions</h3>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Parse findings into actionable items you can convert to tasks
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setActionsEnabled(!actionsEnabled)}
+              className={cn(
+                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                actionsEnabled ? "bg-emerald-500" : "bg-muted-foreground/30",
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none block h-5 w-5 rounded-full bg-white transition-transform",
+                  actionsEnabled ? "translate-x-5" : "translate-x-0",
+                )}
+              />
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+        <h3 className="text-sm font-medium">Model</h3>
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            Claude Model
+          </label>
+          <Select
+            value={model}
+            onValueChange={(val) => {
+              const found = CLAUDE_MODELS.find((m) => m === val);
+              if (found) setModel(found);
+            }}
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CLAUDE_MODELS.map((m) => (
+                <SelectItem key={m} value={m}>
+                  {m.charAt(0).toUpperCase() + m.slice(1)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={isSaving || !hasChanges}>
+          {isSaving && <Spinner size="sm" />}
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/automations/_components/FindingsList.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/automations/_components/FindingsList.tsx
@@ -1,0 +1,217 @@
+import { useState } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Doc } from "@conductor/backend";
+import { Button, Badge, Checkbox, Spinner, cn } from "@conductor/ui";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconExternalLink,
+} from "@tabler/icons-react";
+
+type AutomationRun = Doc<"automationRuns">;
+type Finding = NonNullable<AutomationRun["findings"]>[number];
+
+const SEVERITY_COLORS: Record<Finding["severity"], string> = {
+  critical: "bg-red-500/15 text-red-700 dark:text-red-400",
+  high: "bg-orange-500/15 text-orange-700 dark:text-orange-400",
+  medium: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-400",
+  low: "bg-blue-500/15 text-blue-700 dark:text-blue-400",
+};
+
+interface FindingsListProps {
+  run: AutomationRun;
+  repoOwner: string;
+  repoName: string;
+}
+
+export function FindingsList({ run, repoOwner, repoName }: FindingsListProps) {
+  const findings = run.findings ?? [];
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [isCreating, setIsCreating] = useState(false);
+  const createTasks = useMutation(api.automations.createTasksFromFindings);
+
+  const selectableFindings = findings.filter((f) => !f.taskId);
+  const allSelected =
+    selectableFindings.length > 0 &&
+    selectableFindings.every((f) => selected.has(f.id));
+
+  function toggleFinding(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    if (allSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(selectableFindings.map((f) => f.id)));
+    }
+  }
+
+  async function handleCreate(autoRun: boolean) {
+    if (selected.size === 0) return;
+    setIsCreating(true);
+    try {
+      await createTasks({
+        runId: run._id,
+        findingIds: Array.from(selected),
+        autoRun,
+      });
+      setSelected(new Set());
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      {selectableFindings.length > 0 && (
+        <div className="flex items-center gap-2 pb-1">
+          <Checkbox checked={allSelected} onCheckedChange={toggleAll} />
+          <span className="text-xs text-muted-foreground">
+            Select all ({selectableFindings.length})
+          </span>
+        </div>
+      )}
+
+      {findings.map((finding) => (
+        <FindingRow
+          key={finding.id}
+          finding={finding}
+          selected={selected.has(finding.id)}
+          onToggle={() => toggleFinding(finding.id)}
+          repoOwner={repoOwner}
+          repoName={repoName}
+        />
+      ))}
+
+      {selectableFindings.length > 0 && (
+        <div className="flex items-center gap-2 pt-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={selected.size === 0 || isCreating}
+            onClick={() => handleCreate(false)}
+          >
+            {isCreating && <Spinner size="sm" />}
+            Create Tasks ({selected.size})
+          </Button>
+          <Button
+            size="sm"
+            disabled={selected.size === 0 || isCreating}
+            onClick={() => handleCreate(true)}
+          >
+            {isCreating && <Spinner size="sm" />}
+            Create & Run ({selected.size})
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FindingRow({
+  finding,
+  selected,
+  onToggle,
+  repoOwner,
+  repoName,
+}: {
+  finding: Finding;
+  selected: boolean;
+  onToggle: () => void;
+  repoOwner: string;
+  repoName: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasTaskCreated = finding.taskId !== undefined;
+  const taskUrl = hasTaskCreated
+    ? `/${repoOwner}/${repoName}/quick-tasks?taskId=${finding.taskId}`
+    : null;
+
+  return (
+    <div className={cn("rounded-lg bg-muted/40 overflow-hidden")}>
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <Checkbox
+          checked={hasTaskCreated ? true : selected}
+          disabled={hasTaskCreated}
+          onCheckedChange={onToggle}
+        />
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="flex flex-1 items-center gap-2 text-left min-w-0"
+        >
+          {expanded ? (
+            <IconChevronDown
+              size={14}
+              className="shrink-0 text-muted-foreground"
+            />
+          ) : (
+            <IconChevronRight
+              size={14}
+              className="shrink-0 text-muted-foreground"
+            />
+          )}
+          <span
+            className={cn(
+              "inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+              SEVERITY_COLORS[finding.severity],
+            )}
+          >
+            {finding.severity}
+          </span>
+          <span className="text-sm font-medium truncate">{finding.title}</span>
+        </button>
+        {hasTaskCreated && taskUrl && (
+          <a
+            href={taskUrl}
+            className="inline-flex items-center gap-1 text-xs text-primary hover:underline shrink-0"
+          >
+            <IconExternalLink size={12} />
+            Task created
+          </a>
+        )}
+      </div>
+      {expanded && (
+        <div className="px-3 pb-3 pl-10 space-y-2">
+          <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+            {finding.description}
+          </p>
+          {finding.filePaths && finding.filePaths.length > 0 && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-1">
+                Files
+              </p>
+              <div className="flex flex-wrap gap-1">
+                {finding.filePaths.map((fp) => (
+                  <span
+                    key={fp}
+                    className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs font-mono"
+                  >
+                    {fp}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {finding.suggestedFix && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-1">
+                Suggested Fix
+              </p>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                {finding.suggestedFix}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/automations/index.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/automations/index.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IconPlayerPlay } from "@tabler/icons-react";
+import { EmptyState } from "@/lib/components/ui/EmptyState";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/automations/")({
+  component: AutomationsPage,
+});
+
+function AutomationsPage() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <EmptyState
+        icon={<IconPlayerPlay size={24} className="text-muted-foreground" />}
+        title="Select an automation to view"
+      />
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/testing-arena/$id.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/testing-arena/$id.tsx
@@ -1,0 +1,459 @@
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useQueryState } from "nuqs";
+import { testingTabParser, branchParser } from "@/lib/search-params";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@conductor/backend";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import type { Id } from "@conductor/backend";
+import {
+  ActivitySteps,
+  Button,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Spinner,
+  TestResults,
+  TestResultsHeader,
+  TestResultsSummary,
+  TestResultsProgress,
+  TestResultsContent,
+  TestSuite,
+  TestSuiteName,
+  TestSuiteContent,
+  TestSuiteStats,
+  Test,
+  TestError,
+  TestErrorMessage,
+} from "@conductor/ui";
+import {
+  IconPlayerPlay,
+  IconWorld,
+  IconCode,
+  IconCheck,
+  IconX,
+  IconAlertTriangle,
+  IconGitPullRequest,
+  IconTool,
+} from "@tabler/icons-react";
+import dayjs from "@conductor/shared/dates";
+import { UITestingPanel } from "./UITestingPanel";
+import { parseActivitySteps } from "@/lib/utils/parseActivitySteps";
+import { BranchSelect } from "@/lib/components/BranchSelect";
+
+export const Route = createFileRoute(
+  "/_repo/$owner/$repo/testing-arena/$id",
+)({
+  component: TestingArenaDetailRoute,
+});
+
+interface EvalResult {
+  requirement: string;
+  passed: boolean;
+  detail: string;
+}
+
+interface EvaluationReport {
+  _id: Id<"evaluationReports">;
+  status: "pending" | "running" | "completed" | "error";
+  results: EvalResult[];
+  summary?: string;
+  error?: string;
+  fixStatus?: "fixing" | "fix_completed" | "fix_error";
+  fixBranchName?: string;
+  prUrl?: string;
+  createdAt: number;
+}
+
+function ReportCard({
+  report,
+  streamingActivity,
+}: {
+  report: EvaluationReport;
+  streamingActivity?: string;
+}) {
+  const passed = report.results.filter((r) => r.passed);
+  const failed = report.results.filter((r) => !r.passed);
+  const total = report.results.length;
+
+  const summary =
+    total > 0
+      ? { passed: passed.length, failed: failed.length, skipped: 0, total }
+      : undefined;
+
+  return (
+    <TestResults summary={summary}>
+      {report.status === "running" &&
+        (() => {
+          const steps = parseActivitySteps(streamingActivity);
+          return steps ? (
+            <div className="px-4 py-3">
+              <ActivitySteps steps={steps} isStreaming />
+            </div>
+          ) : (
+            <div className="flex items-center gap-3 px-4 py-3">
+              <Spinner size="sm" />
+              <span className="text-sm text-muted-foreground truncate">
+                {streamingActivity || "Evaluating codebase..."}
+              </span>
+            </div>
+          );
+        })()}
+
+      {report.status === "error" && report.error && (
+        <div className="p-4">
+          <TestError>
+            <TestErrorMessage>{report.error}</TestErrorMessage>
+          </TestError>
+        </div>
+      )}
+
+      {report.status === "completed" && (
+        <>
+          <TestResultsHeader>
+            <TestResultsSummary />
+            <div className="flex items-center gap-2">
+              {report.fixStatus === "fixing" && (
+                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Spinner size="sm" />
+                  Fixing issues...
+                </span>
+              )}
+              {report.fixStatus === "fix_error" && (
+                <span className="flex items-center gap-1.5 text-xs text-destructive">
+                  <IconAlertTriangle size={14} />
+                  Fix failed
+                </span>
+              )}
+              {report.prUrl && (
+                <a
+                  href={report.prUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
+                >
+                  <IconGitPullRequest size={14} />
+                  View Fix PR
+                </a>
+              )}
+              <span className="text-sm text-muted-foreground">
+                {dayjs(report.createdAt).fromNow()}
+              </span>
+            </div>
+          </TestResultsHeader>
+
+          <TestResultsContent>
+            <TestResultsProgress />
+
+            {report.fixStatus === "fixing" &&
+              (() => {
+                const fixSteps = parseActivitySteps(streamingActivity);
+                return fixSteps ? (
+                  <div className="rounded-md border border-primary/20 bg-primary/5 px-4 py-3">
+                    <div className="flex items-center gap-1.5 mb-2">
+                      <IconTool size={14} className="text-primary shrink-0" />
+                      <span className="text-xs font-medium text-primary">
+                        Fixing issues...
+                      </span>
+                    </div>
+                    <ActivitySteps steps={fixSteps} isStreaming />
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2">
+                    <IconTool size={14} className="text-primary shrink-0" />
+                    <span className="text-sm text-primary">
+                      {streamingActivity ||
+                        "Eva is fixing the failing requirements and will create a PR automatically..."}
+                    </span>
+                  </div>
+                );
+              })()}
+
+            {report.summary && (
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {report.summary}
+              </p>
+            )}
+
+            {failed.length > 0 && (
+              <TestSuite name="Failed" status="failed" defaultOpen>
+                <TestSuiteName>
+                  <TestSuiteStats failed={failed.length} />
+                </TestSuiteName>
+                <TestSuiteContent>
+                  {failed.map((item, idx) => (
+                    <div key={idx}>
+                      <Test name={item.requirement} status="failed" />
+                      <p className="px-4 pb-2 text-xs text-muted-foreground sm:px-6 md:px-10">
+                        {item.detail}
+                      </p>
+                    </div>
+                  ))}
+                </TestSuiteContent>
+              </TestSuite>
+            )}
+
+            {passed.length > 0 && (
+              <TestSuite name="Passed" status="passed">
+                <TestSuiteName>
+                  <TestSuiteStats passed={passed.length} />
+                </TestSuiteName>
+                <TestSuiteContent>
+                  {passed.map((item, idx) => (
+                    <div key={idx}>
+                      <Test name={item.requirement} status="passed" />
+                      <p className="px-4 pb-2 text-xs text-muted-foreground sm:px-6 md:px-10">
+                        {item.detail}
+                      </p>
+                    </div>
+                  ))}
+                </TestSuiteContent>
+              </TestSuite>
+            )}
+          </TestResultsContent>
+        </>
+      )}
+    </TestResults>
+  );
+}
+
+function RunListItem({
+  report,
+  isActive,
+  onClick,
+}: {
+  report: EvaluationReport;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  const passed = report.results.filter((r) => r.passed).length;
+  const failed = report.results.filter((r) => !r.passed).length;
+  const total = report.results.length;
+  const passRate = total > 0 ? Math.round((passed / total) * 100) : 0;
+
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-lg border transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 ${
+        isActive
+          ? "border-primary bg-primary/5 ring-1 ring-primary"
+          : "border-transparent hover:bg-muted/50"
+      }`}
+    >
+      {report.status === "completed" && (
+        <>
+          {failed === 0 ? (
+            <IconCheck size={14} className="text-success shrink-0" />
+          ) : report.prUrl ? (
+            <IconGitPullRequest size={14} className="text-primary shrink-0" />
+          ) : (
+            <IconX size={14} className="text-destructive shrink-0" />
+          )}
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm tabular-nums">
+              {passed}/{total} passed
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {passRate}% &middot; {dayjs(report.createdAt).fromNow()}
+              {report.fixStatus === "fixing" && " · Fixing..."}
+              {report.prUrl && " · PR created"}
+            </span>
+          </div>
+        </>
+      )}
+      {report.status === "error" && (
+        <>
+          <IconAlertTriangle size={14} className="text-destructive shrink-0" />
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm text-destructive">Error</span>
+            <span className="text-xs text-muted-foreground">
+              {dayjs(report.createdAt).fromNow()}
+            </span>
+          </div>
+        </>
+      )}
+      {report.status === "running" && (
+        <>
+          <Spinner size="sm" />
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm text-muted-foreground">Running...</span>
+            <span className="text-xs text-muted-foreground">
+              {dayjs(report.createdAt).fromNow()}
+            </span>
+          </div>
+        </>
+      )}
+    </button>
+  );
+}
+
+function CodeTestingContent({
+  reports,
+  streamingActivity,
+}: {
+  reports: EvaluationReport[] | undefined;
+  streamingActivity?: string;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const activeId =
+    selectedId ??
+    reports?.find((r) => r.status === "running")?._id ??
+    reports?.[0]?._id ??
+    null;
+  const activeReport = reports?.find((r) => r._id === activeId);
+
+  if (reports === undefined) {
+    return (
+      <div className="flex items-center justify-center h-32">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (reports.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-32 text-muted-foreground">
+        <p className="text-sm">No test runs yet</p>
+        <p className="text-xs mt-1">
+          Click &quot;Run Test&quot; to evaluate this doc
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden sm:flex-row">
+      <div className="w-full shrink-0 border-b overflow-y-auto scrollbar p-2 space-y-1 max-h-32 sm:max-h-none sm:w-56 sm:border-b-0 sm:border-r">
+        <p className="text-xs font-medium text-muted-foreground px-2 py-1">
+          Test runs ({reports.length})
+        </p>
+        {reports.map((report) => (
+          <RunListItem
+            key={report._id}
+            report={report}
+            isActive={report._id === activeId}
+            onClick={() => setSelectedId(report._id)}
+          />
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto scrollbar p-4">
+        {activeReport && (
+          <ReportCard
+            report={activeReport}
+            streamingActivity={
+              activeReport.status === "running" ||
+              activeReport.fixStatus === "fixing"
+                ? streamingActivity
+                : undefined
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TestingArenaDetailRoute() {
+  const { id } = Route.useParams();
+  const { repo } = useRepo();
+  const doc = useQuery(api.docs.get, { id: id as Id<"docs"> });
+  const reports = useQuery(
+    api.evaluationReports.listByDoc,
+    doc ? { docId: doc._id } : "skip",
+  );
+  const activeReport = reports?.find(
+    (r) => r.status === "running" || r.fixStatus === "fixing",
+  );
+  const streaming = useQuery(
+    api.streaming.get,
+    activeReport ? { entityId: activeReport._id } : "skip",
+  );
+  const startEvaluation = useMutation(api.evaluationWorkflow.startEvaluation);
+  const [isRunning, setIsRunning] = useState(false);
+  const [activeTab, setActiveTab] = useQueryState("tab", testingTabParser);
+  const [branch, setBranch] = useQueryState("branch", branchParser);
+
+  const handleRunTest = async () => {
+    if (!doc) return;
+    setIsRunning(true);
+    try {
+      await startEvaluation({
+        docId: doc._id,
+        repoId: repo._id,
+        installationId: repo.installationId,
+        branchName: branch !== "main" ? branch : undefined,
+      });
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  if (doc === undefined) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (doc === null) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-muted-foreground">
+        <p>Document not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      <div className="px-2 py-2 flex flex-col gap-1.5 sm:px-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => {
+              setActiveTab(v as "code" | "ui");
+            }}
+          >
+            <TabsList className="h-8">
+              <TabsTrigger value="code" className="text-xs space-x-2">
+                <IconCode size={14} />
+                <span>Code Testing</span>
+              </TabsTrigger>
+              <TabsTrigger value="ui" className="text-xs space-x-2">
+                <IconWorld size={14} />
+                <span>UI Testing</span>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <div className="flex items-center gap-2">
+            <BranchSelect
+              value={branch}
+              onValueChange={setBranch}
+              className="h-7 text-xs w-24 sm:w-36"
+            />
+            <Button
+              size="sm"
+              onClick={activeTab === "code" ? handleRunTest : undefined}
+              disabled={activeTab === "code" && isRunning}
+            >
+              <IconPlayerPlay size={16} />
+              {isRunning && activeTab === "code" ? "Running..." : "Run Test"}
+            </Button>
+          </div>
+        </div>
+      </div>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        {activeTab === "code" ? (
+          <CodeTestingContent
+            reports={reports}
+            streamingActivity={streaming?.currentActivity}
+          />
+        ) : (
+          <UITestingPanel />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/testing-arena/UITestingPanel.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/testing-arena/UITestingPanel.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import {
+  WebPreview,
+  WebPreviewNavigation,
+  WebPreviewUrl,
+  WebPreviewBody,
+  WebPreviewConsole,
+} from "@conductor/ui";
+import { IconWorld } from "@tabler/icons-react";
+
+export function UITestingPanel() {
+  const [isRunning] = useState(false);
+  const [logs] = useState<
+    { level: "log" | "warn" | "error"; message: string; timestamp: Date }[]
+  >([]);
+
+  return (
+    <WebPreview className="h-full rounded-none border-0">
+      <WebPreviewNavigation>
+        <WebPreviewUrl
+          placeholder="Enter URL to test..."
+          className="h-8 text-xs"
+        />
+      </WebPreviewNavigation>
+      <WebPreviewBody
+        loading={
+          <div className="absolute inset-0 flex flex-col items-center justify-center text-muted-foreground bg-secondary">
+            <IconWorld size={48} className="mb-3 opacity-50" />
+            <p className="text-sm">
+              Enter a URL and run the test to see Eva interact with your UI
+            </p>
+          </div>
+        }
+      />
+      <WebPreviewConsole logs={logs}>
+        {isRunning && (
+          <div className="flex items-center gap-1.5">
+            <span className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
+            <span className="text-xs text-success">Running</span>
+          </div>
+        )}
+      </WebPreviewConsole>
+    </WebPreview>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/testing-arena/index.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/testing-arena/index.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IconFileText } from "@tabler/icons-react";
+import { EmptyState } from "@/lib/components/ui/EmptyState";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/testing-arena/")({
+  component: TestingArenaPage,
+});
+
+function TestingArenaPage() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <EmptyState
+        icon={<IconFileText size={24} className="text-muted-foreground" />}
+        title="Select a document to test"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Port automations routes (index empty state, detail with AutomationClient + FindingsList + RunHistory + SettingsForm) from Next.js to TanStack Router
- Port testing-arena routes (index empty state, detail with full evaluation UI including ReportCard, RunListItem, CodeTestingContent, and UITestingPanel)
- All routes use `createFileRoute` and `Route.useParams()` instead of `use(params)`
- Imports updated from `@/*` to `@/` (same alias in Vite config)

## Test plan
- [ ] Verify automations index shows "Select an automation to view" empty state
- [ ] Verify automation detail loads and displays automation with toggle, run history, and settings
- [ ] Verify testing-arena index shows "Select a document to test" empty state
- [ ] Verify testing-arena detail loads doc, shows code/UI testing tabs, and run test functionality