### PR TITLE
feat(web-v2): add sessions routes

### DIFF
--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/$id.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/$id.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SessionDetailClient } from "./SessionDetailClient";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/sessions/$id")({
+  component: SessionDetailRoute,
+});
+
+function SessionDetailRoute() {
+  const { id } = Route.useParams();
+  return <SessionDetailClient sessionId={id} />;
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
@@ -1,0 +1,860 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+  Button,
+  Spinner,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Badge,
+  Conversation,
+  ConversationContent,
+  ConversationEmptyState,
+  ConversationScrollButton,
+  Message as AIMessage,
+  MessageContent,
+  MessageResponse,
+  PromptInput,
+  PromptInputTextarea,
+  PromptInputFooter,
+  PromptInputTools,
+  PromptInputSubmit,
+  PromptInputSpeech,
+  ModelSelect,
+  ResponseLengthSelect,
+  type PromptInputMessage,
+  Plan,
+  PlanHeader,
+  PlanTitle,
+  PlanContent,
+  PlanFooter,
+  PlanTrigger,
+} from "@conductor/ui";
+import {
+  IconPlayerPlay,
+  IconPlayerStop,
+  IconCode,
+  IconMessageCircle2,
+  IconClipboardList,
+  IconGitPullRequest,
+  IconBrandVercel,
+  IconSparkles,
+  IconSend,
+  IconCircleCheck,
+  IconLayoutSidebarRightCollapse,
+  IconLayoutSidebarRightExpand,
+} from "@tabler/icons-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useQueryState } from "nuqs";
+import { sessionModeParser } from "@/lib/search-params";
+import type { ClaudeModel, ResponseLength } from "@conductor/ui";
+import { useAction, useMutation, useQuery } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { ScreenshotPreview, VideoPreview } from "@/lib/components/MediaPreview";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import type { FunctionReturnType } from "convex/server";
+import dayjs from "@conductor/shared/dates";
+import { ChatPageWrapper } from "@/lib/components/ChatPageWrapper";
+import { EvaIcon } from "@/lib/components/EvaIcon";
+import { UserMessageAvatar } from "@/lib/components/UserMessageAvatar";
+import {
+  StreamingActivityDisplay,
+  ActivityLogDisplay,
+} from "@/lib/components/StreamingActivityDisplay";
+import { SystemAlertMessage } from "@/lib/components/SystemAlertMessage";
+import {
+  getSessionModel,
+  getSessionResponseLength,
+  useSessionModelSetter,
+  useSessionResponseLengthSetter,
+} from "@/lib/hooks/useSessionSettings";
+
+type SessionMessage = NonNullable<
+  FunctionReturnType<typeof api.messages.listByParent>
+>[number];
+type SessionMode = NonNullable<SessionMessage["mode"]>;
+
+const REVIEW_AUDITS = [
+  "Running code audits",
+  "Analyzing results",
+  "Generating report",
+];
+
+interface ChatPanelProps {
+  sessionId: Id<"sessions">;
+  title: string;
+  branchName?: string;
+  prUrl?: string;
+  summary?: string[];
+  messages: SessionMessage[];
+  planContent?: string;
+  streamingActivity?: string;
+  summaryStreamingActivity?: string;
+  isSandboxActive: boolean;
+  isSandboxToggling: boolean;
+  onSandboxToggle: (action: "start" | "stop") => void;
+  isArchived?: boolean;
+  previewUrl?: string;
+  sandboxCollapsed?: boolean;
+  onToggleSandbox?: () => void;
+}
+
+export function ChatPanel({
+  sessionId,
+  title,
+  branchName,
+  prUrl,
+  summary,
+  messages,
+  planContent,
+  streamingActivity,
+  summaryStreamingActivity,
+  isSandboxActive,
+  isSandboxToggling,
+  onSandboxToggle,
+  isArchived,
+  previewUrl,
+  sandboxCollapsed,
+  onToggleSandbox,
+}: ChatPanelProps) {
+  const { repo } = useRepo();
+  const [isSending, setIsSending] = useState(false);
+  const [isSummarizing, setIsSummarizing] = useState(false);
+  const [showSummaryModal, setShowSummaryModal] = useState(false);
+  const [showReviewModal, setShowReviewModal] = useState(false);
+  const [isCreatingPr, setIsCreatingPr] = useState(false);
+  const [reviewStep, setReviewStep] = useState<
+    "confirm" | "auditing" | "complete"
+  >("confirm");
+  const [completedAudits, setCompletedAudits] = useState(0);
+  const [mode, setMode] = useQueryState("mode", sessionModeParser);
+
+  const defaultModel = repo.defaultModel ?? "sonnet";
+  const initialModel = useMemo(
+    () => getSessionModel(sessionId, defaultModel),
+    [sessionId, defaultModel],
+  );
+  const initialResponseLength = useMemo(
+    () => getSessionResponseLength(sessionId, "default"),
+    [sessionId],
+  );
+  const [model, setModelState] = useState<ClaudeModel>(initialModel);
+  const [responseLength, setResponseLengthState] = useState<ResponseLength>(
+    initialResponseLength,
+  );
+
+  const saveModel = useSessionModelSetter(sessionId);
+  const saveResponseLength = useSessionResponseLengthSetter(sessionId);
+
+  const setModel = useCallback(
+    (m: ClaudeModel) => {
+      setModelState(m);
+      saveModel(m);
+    },
+    [saveModel],
+  );
+
+  const setResponseLength = useCallback(
+    (rl: ResponseLength) => {
+      setResponseLengthState(rl);
+      saveResponseLength(rl);
+    },
+    [saveResponseLength],
+  );
+
+  const evaIcon = <EvaIcon />;
+
+  const updateLastMessage = useMutation(api.sessions.updateLastMessage);
+  const startSummarize = useMutation(api.summarizeWorkflow.startSummarize);
+  const addMessage = useMutation(api.sessions.addMessage);
+
+  const startExecution = useMutation(api.sessionWorkflow.startExecute);
+  const createPr = useAction(api.github.createSessionPr);
+  const startAuditMutation = useMutation(api.audits.startSessionAudit);
+  const sessionAudit = useQuery(
+    api.audits.getBySession,
+    reviewStep === "auditing" ? { sessionId } : "skip",
+  );
+
+  const sendToApi = useCallback(
+    async (
+      message: string,
+      sendMode: SessionMode,
+      sendModel: ClaudeModel,
+      sendResponseLength: ResponseLength,
+    ) => {
+      await startExecution({
+        sessionId,
+        message,
+        mode: sendMode,
+        model: sendModel,
+        responseLength: sendResponseLength,
+        installationId: repo.installationId,
+      });
+    },
+    [repo.installationId, startExecution, sessionId],
+  );
+
+  const handleSend = async (text: string) => {
+    if (!text.trim()) return;
+    const content = text.trim();
+    setIsSending(true);
+    try {
+      await addMessage({ id: sessionId, role: "user", content, mode });
+      await sendToApi(content, mode, model, responseLength);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to send message";
+      await addMessage({
+        id: sessionId,
+        role: "assistant",
+        content: `Error: ${errorMessage}`,
+        mode,
+      });
+      setIsSending(false);
+    }
+  };
+
+  const handleGenerateSummary = async () => {
+    setIsSummarizing(true);
+    try {
+      await startSummarize({
+        sessionId,
+        installationId: repo.installationId,
+      });
+    } finally {
+      setIsSummarizing(false);
+    }
+  };
+
+  const handleCreatePr = async () => {
+    setReviewStep("auditing");
+    setCompletedAudits(0);
+    setIsCreatingPr(true);
+    try {
+      await createPr({ sessionId });
+      try {
+        await startAuditMutation({
+          sessionId,
+        });
+      } catch {
+        setReviewStep("complete");
+      }
+    } catch {
+      setReviewStep("confirm");
+    } finally {
+      setIsCreatingPr(false);
+    }
+  };
+
+  const handleReviewModalClose = () => {
+    setShowReviewModal(false);
+    setReviewStep("confirm");
+    setCompletedAudits(0);
+  };
+
+  useEffect(() => {
+    if (reviewStep !== "auditing") return;
+    const status = sessionAudit?.status;
+    if (status !== "completed" && status !== "error") return;
+    const timers = REVIEW_AUDITS.map((_, i) =>
+      setTimeout(() => setCompletedAudits((prev) => prev + 1), (i + 1) * 400),
+    );
+    return () => timers.forEach(clearTimeout);
+  }, [sessionAudit?.status, reviewStep]);
+
+  useEffect(() => {
+    if (reviewStep === "auditing" && completedAudits >= REVIEW_AUDITS.length) {
+      const timer = setTimeout(() => setReviewStep("complete"), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [reviewStep, completedAudits]);
+
+  const lastMessage = messages[messages.length - 1];
+  const lastAssistantHasNoContent =
+    !!lastMessage && lastMessage.role === "assistant" && !lastMessage.content;
+  const isExecuting = isSending || lastAssistantHasNoContent;
+
+  useEffect(() => {
+    if (isSending && lastMessage?.role === "assistant" && lastMessage.content) {
+      setIsSending(false);
+    }
+  }, [isSending, lastMessage]);
+
+  const cancelExecutionMutation = useMutation(
+    api.sessionWorkflow.cancelExecution,
+  );
+
+  const handleCancel = async () => {
+    await cancelExecutionMutation({ sessionId });
+  };
+
+  const isInputDisabled = !isSandboxActive || isExecuting;
+  const submitStatus = isExecuting
+    ? lastAssistantHasNoContent
+      ? "streaming"
+      : "submitted"
+    : undefined;
+
+  const handlePromptSubmit = async ({ text }: PromptInputMessage) => {
+    if (isInputDisabled) return;
+    await handleSend(text);
+  };
+
+  const hasSummary = Boolean(summary && summary.length > 0);
+  const showSummaryStreaming = Boolean(summaryStreamingActivity);
+
+  const headerLeft = (
+    <Button
+      size="icon"
+      variant={isSandboxActive ? "destructive" : "secondary"}
+      onClick={() => onSandboxToggle(isSandboxActive ? "stop" : "start")}
+      disabled={isSandboxToggling}
+      className={`motion-press h-8 w-8 hover:scale-[1.03] active:scale-[0.97] ${isSandboxActive ? "" : "text-success"}`}
+    >
+      {isSandboxToggling ? (
+        <Spinner size="sm" />
+      ) : isSandboxActive ? (
+        <IconPlayerStop className="w-4 h-4" />
+      ) : (
+        <IconPlayerPlay className="w-4 h-4" />
+      )}
+    </Button>
+  );
+
+  const headerRight = (
+    <>
+      <Button
+        size="sm"
+        variant="secondary"
+        className="motion-press text-primary hover:scale-[1.01] active:scale-[0.99]"
+        asChild={!!previewUrl}
+        disabled={!previewUrl}
+      >
+        {previewUrl ? (
+          <a href={previewUrl} target="_blank" rel="noopener noreferrer">
+            <IconBrandVercel size={14} />
+            <span className="hidden sm:inline">View Preview</span>
+          </a>
+        ) : (
+          <>
+            <IconBrandVercel size={14} />
+            <span className="hidden sm:inline">View Preview</span>
+          </>
+        )}
+      </Button>
+      {prUrl ? (
+        <a href={prUrl} target="_blank" rel="noopener noreferrer">
+          <Badge
+            variant="outline"
+            className="motion-base gap-1 cursor-pointer hover:scale-[1.01]"
+          >
+            <IconGitPullRequest size={12} />
+            View PR
+          </Badge>
+        </a>
+      ) : branchName ? (
+        <Button
+          size="sm"
+          variant="secondary"
+          className="motion-press text-success hover:scale-[1.01] active:scale-[0.99]"
+          onClick={() => setShowReviewModal(true)}
+        >
+          <IconSend size={12} />
+          <span className="hidden sm:inline">Send for Review</span>
+        </Button>
+      ) : null}
+      <Button
+        size="icon"
+        variant="secondary"
+        onClick={() => setShowSummaryModal(true)}
+        disabled={isSummarizing || !isSandboxActive || messages.length === 0}
+        className="motion-press h-8 w-8 text-primary hover:scale-[1.03] active:scale-[0.97]"
+        title={hasSummary ? "Regenerate summary" : "Generate summary"}
+      >
+        {isSummarizing ? (
+          <Spinner size="sm" />
+        ) : (
+          <IconSparkles className="w-4 h-4" />
+        )}
+      </Button>
+      {onToggleSandbox && (
+        <Button
+          size="icon"
+          variant="ghost"
+          className="size-8 motion-press hover:scale-[1.03] active:scale-[0.97]"
+          onClick={onToggleSandbox}
+          title={sandboxCollapsed ? "Show sandbox panel" : "Hide sandbox panel"}
+        >
+          {sandboxCollapsed ? (
+            <IconLayoutSidebarRightExpand className="size-4" />
+          ) : (
+            <IconLayoutSidebarRightCollapse className="size-4" />
+          )}
+        </Button>
+      )}
+    </>
+  );
+
+  return (
+    <ChatPageWrapper
+      title={title}
+      isArchived={isArchived}
+      headerLeft={headerLeft}
+      headerRight={headerRight}
+    >
+      <AnimatePresence>
+        {(showSummaryStreaming || hasSummary) && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.2 }}
+          >
+            <Accordion
+              type="single"
+              collapsible
+              defaultValue={showSummaryStreaming ? "summary" : undefined}
+              className="w-full min-w-0 px-3 sm:px-6 bg-secondary rounded-b-3xl"
+            >
+              <AccordionItem value="summary" className="border-b-0">
+                <AccordionTrigger className="py-2 text-sm">
+                  <div className="flex flex-row gap-2 items-center text-primary">
+                    <IconSparkles size={14} />
+                    <p>Session summary</p>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent className="pb-2">
+                  {showSummaryStreaming ? (
+                    <StreamingActivityDisplay
+                      activity={summaryStreamingActivity}
+                    />
+                  ) : hasSummary ? (
+                    <ul className="list-disc list-inside text-sm text-primary space-y-1 pl-4">
+                      {summary?.map((item, i) => (
+                        <li key={i}>{item}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </motion.div>
+        )}
+      </AnimatePresence>
+      <Conversation className="flex-1 min-h-0">
+        <ConversationContent className="gap-3 p-3">
+          {messages.length === 0 ? (
+            <ConversationEmptyState
+              title={
+                isSandboxActive
+                  ? "No messages yet. Start the conversation!"
+                  : "Sandbox is inactive. Start the sandbox to begin chatting."
+              }
+            />
+          ) : (
+            messages.map((message) =>
+              message.isSystemAlert ? (
+                <SystemAlertMessage
+                  key={message._id}
+                  content={message.content ?? ""}
+                  errorDetail={message.errorDetail}
+                />
+              ) : (
+                <motion.div
+                  key={message._id}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                >
+                  <AIMessage from={message.role}>
+                    <MessageContent
+                      className={
+                        message.role === "user"
+                          ? "rounded-xl bg-secondary text-foreground px-4 py-3"
+                          : "px-1 py-2"
+                      }
+                    >
+                      {message.role === "assistant" && !message.content ? (
+                        <StreamingActivityDisplay
+                          activity={streamingActivity}
+                          name="Eva"
+                          icon={evaIcon}
+                          startedAt={message.timestamp}
+                        />
+                      ) : (
+                        <>
+                          {message.role === "assistant" ? (
+                            <>
+                              {message.activityLog && (
+                                <ActivityLogDisplay
+                                  activityLog={message.activityLog}
+                                  name="Eva"
+                                  icon={evaIcon}
+                                  startedAt={message.timestamp}
+                                  finishedAt={message.finishedAt}
+                                />
+                              )}
+                              <MessageResponse className="prose prose-sm dark:prose-invert max-w-none">
+                                {message.content}
+                              </MessageResponse>
+                              {message.imageUrl && (
+                                <ScreenshotPreview url={message.imageUrl} />
+                              )}
+                              {message.videoUrl && (
+                                <VideoPreview url={message.videoUrl} />
+                              )}
+                            </>
+                          ) : (
+                            <>
+                              <p className="text-sm whitespace-pre-wrap break-words">
+                                {message.content}
+                              </p>
+                              <div className="flex items-center justify-between gap-3">
+                                {message.mode && (
+                                  <div className="flex items-center gap-1 text-[11px] text-muted-foreground/60">
+                                    {message.mode === "execute" && (
+                                      <>
+                                        <IconCode className="w-2.5 h-2.5" />{" "}
+                                        Execute
+                                      </>
+                                    )}
+                                    {message.mode === "ask" && (
+                                      <>
+                                        <IconMessageCircle2 className="w-2.5 h-2.5" />{" "}
+                                        Ask
+                                      </>
+                                    )}
+                                    {message.mode === "plan" && (
+                                      <>
+                                        <IconClipboardList className="w-2.5 h-2.5" />{" "}
+                                        PRD
+                                      </>
+                                    )}
+                                  </div>
+                                )}
+                                {message.timestamp && (
+                                  <span className="text-[11px] text-muted-foreground/60">
+                                    {dayjs(message.timestamp).format("h:mm A")}
+                                  </span>
+                                )}
+                              </div>
+                            </>
+                          )}
+                        </>
+                      )}
+                    </MessageContent>
+                    {message.role === "user" && (
+                      <div className="mt-0.5 ml-auto">
+                        <UserMessageAvatar userId={message.userId} />
+                      </div>
+                    )}
+                  </AIMessage>
+                </motion.div>
+              ),
+            )
+          )}
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
+      {!isArchived && (
+        <div className="p-2 md:p-3">
+          <AnimatePresence>
+            {mode === "plan" && planContent && (
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 8 }}
+                transition={{ duration: 0.2 }}
+              >
+                <Plan defaultOpen className="mb-2">
+                  <PlanHeader className="p-4">
+                    <PlanTitle>Product Requirements</PlanTitle>
+                    <PlanTrigger />
+                  </PlanHeader>
+                  <PlanContent className="px-3 pb-3 pt-0 max-h-40 overflow-y-auto sm:px-4 sm:pb-4 sm:max-h-64">
+                    <MessageResponse className="prose prose-sm dark:prose-invert max-w-none">
+                      {planContent}
+                    </MessageResponse>
+                  </PlanContent>
+                  <PlanFooter className="px-4 pb-4 pt-0 gap-2">
+                    <Button
+                      size="sm"
+                      className="motion-press bg-success text-success-foreground hover:bg-success/90 hover:scale-[1.01] active:scale-[0.99]"
+                      onClick={() => setMode("execute")}
+                    >
+                      <IconCode className="w-3.5 h-3.5" />
+                      Approve Plan
+                    </Button>
+                  </PlanFooter>
+                </Plan>
+              </motion.div>
+            )}
+          </AnimatePresence>
+          <div className="relative pt-4">
+            <Tabs
+              value={mode}
+              onValueChange={(v) => {
+                if (v === "execute" || v === "ask" || v === "plan") {
+                  setMode(v);
+                }
+              }}
+              className="absolute left-1.5 top-4 z-20 -translate-y-1/2 sm:left-3"
+            >
+              <TabsList className="h-8 rounded-full  p-0.5">
+                <TabsTrigger
+                  value="execute"
+                  className="rounded-full text-xs px-2.5 py-1 gap-1 transition-all data-[state=active]:text-primary"
+                >
+                  <IconCode className="w-3 h-3" />
+                  Execute
+                </TabsTrigger>
+                <TabsTrigger
+                  value="ask"
+                  className="rounded-full text-xs px-2.5 py-1 gap-1 transition-all data-[state=active]:text-primary"
+                >
+                  <IconMessageCircle2 className="w-3 h-3" />
+                  Ask
+                </TabsTrigger>
+                <TabsTrigger
+                  value="plan"
+                  className="rounded-full text-xs px-2.5 py-1 gap-1 transition-all data-[state=active]:text-primary"
+                >
+                  <IconClipboardList className="w-3 h-3" />
+                  PRD
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <PromptInput onSubmit={handlePromptSubmit}>
+              <PromptInputTextarea
+                className="pt-8"
+                placeholder={
+                  !isSandboxActive
+                    ? "Start the sandbox to begin chatting..."
+                    : mode === "execute"
+                      ? "Describe the changes to make to Eva..."
+                      : mode === "ask"
+                        ? "Ask Eva a question about the codebase..."
+                        : "Describe the feature or product requirements to Eva..."
+                }
+                disabled={isInputDisabled}
+              />
+              <PromptInputFooter>
+                <PromptInputTools>
+                  <ModelSelect
+                    value={model}
+                    onValueChange={setModel}
+                    disabled={isInputDisabled}
+                  />
+                  <ResponseLengthSelect
+                    value={responseLength}
+                    onValueChange={setResponseLength}
+                    disabled={isInputDisabled}
+                  />
+                </PromptInputTools>
+                <div className="flex items-center gap-1">
+                  <PromptInputSpeech disabled={isInputDisabled} />
+                  <PromptInputSubmit
+                    status={submitStatus}
+                    variant={submitStatus ? "destructive" : "default"}
+                    onStop={handleCancel}
+                    disabled={!submitStatus && isInputDisabled}
+                    title={submitStatus ? "Stop Eva" : "Send message"}
+                  />
+                </div>
+              </PromptInputFooter>
+            </PromptInput>
+          </div>
+        </div>
+      )}
+      <Dialog
+        open={showSummaryModal}
+        onOpenChange={(v) => {
+          if (!v) setShowSummaryModal(false);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {hasSummary ? "Regenerate Summary" : "Generate Summary"}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              {hasSummary
+                ? "This will regenerate and replace the current session summary."
+                : "This will generate a session summary from the current chat history."}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowSummaryModal(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={async () => {
+                await handleGenerateSummary();
+                setShowSummaryModal(false);
+              }}
+              disabled={isSummarizing}
+            >
+              {isSummarizing ? <Spinner size="sm" /> : "Confirm"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={showReviewModal}
+        onOpenChange={(v) => {
+          if (!v) handleReviewModalClose();
+        }}
+      >
+        <DialogContent>
+          <AnimatePresence mode="wait">
+            {reviewStep === "confirm" && (
+              <motion.div
+                key="confirm"
+                className="space-y-4"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0, x: -20 }}
+                transition={{ duration: 0.2 }}
+              >
+                <DialogHeader>
+                  <DialogTitle>Send for Code Review</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-2 text-sm text-muted-foreground">
+                  <p>
+                    By clicking this you confirm that all your changes have been
+                    tested in your session, you are happy with those changes,
+                    have generated a summary, and agree with the changes. Your
+                    session will become uneditable while a developer reviews the
+                    code changes before merging into staging/production.
+                  </p>
+                  <p>
+                    The following audits will also run automatically in the
+                    background:
+                  </p>
+                  <p>
+                    An automated code audit will run to check accessibility,
+                    testing, code quality, and other configured checks.
+                  </p>
+                </div>
+                <DialogFooter>
+                  <Button variant="ghost" onClick={handleReviewModalClose}>
+                    Cancel
+                  </Button>
+                  <Button
+                    className="bg-success text-success-foreground hover:bg-success/90"
+                    onClick={handleCreatePr}
+                    disabled={isCreatingPr}
+                  >
+                    {isCreatingPr ? <Spinner size="sm" /> : "Confirm"}
+                  </Button>
+                </DialogFooter>
+              </motion.div>
+            )}
+            {reviewStep === "auditing" && (
+              <motion.div
+                key="auditing"
+                className="space-y-4"
+                initial={{ opacity: 0, x: 20 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -20 }}
+                transition={{ duration: 0.2 }}
+              >
+                <DialogHeader>
+                  <DialogTitle>Auditing in Progress</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4 py-2">
+                  {REVIEW_AUDITS.map((audit, i) => {
+                    const isComplete = i < completedAudits;
+                    const isActive =
+                      i === completedAudits &&
+                      completedAudits < REVIEW_AUDITS.length;
+                    return (
+                      <motion.div
+                        key={audit}
+                        className="flex items-center gap-3"
+                        initial={{ opacity: 0, x: -8 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{ delay: i * 0.1, duration: 0.2 }}
+                      >
+                        <div className="flex h-5 w-5 items-center justify-center">
+                          {isComplete ? (
+                            <motion.div
+                              initial={{ scale: 0 }}
+                              animate={{ scale: 1 }}
+                              transition={{
+                                type: "spring",
+                                stiffness: 300,
+                                damping: 20,
+                              }}
+                            >
+                              <IconCircleCheck
+                                size={20}
+                                className="text-success"
+                              />
+                            </motion.div>
+                          ) : isActive ? (
+                            <Spinner size="sm" />
+                          ) : (
+                            <div className="h-4 w-4 rounded-full ring-2 ring-muted" />
+                          )}
+                        </div>
+                        <span
+                          className={`text-sm ${isComplete || isActive ? "text-foreground" : "text-muted-foreground"}`}
+                        >
+                          {audit}
+                        </span>
+                      </motion.div>
+                    );
+                  })}
+                </div>
+              </motion.div>
+            )}
+            {reviewStep === "complete" && (
+              <motion.div
+                key="complete"
+                className="space-y-4"
+                initial={{ opacity: 0, x: 20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                <DialogHeader>
+                  <DialogTitle>Review Sent</DialogTitle>
+                </DialogHeader>
+                <motion.div
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3, delay: 0.1 }}
+                  className="rounded-lg bg-success/10 p-4 text-center"
+                >
+                  <IconCircleCheck
+                    size={24}
+                    className="mx-auto mb-2 text-success"
+                  />
+                  <p className="text-sm font-medium text-success">
+                    This information has automatically been sent to the dev
+                    team.
+                  </p>
+                </motion.div>
+                <DialogFooter>
+                  <Button onClick={handleReviewModalClose}>Done</Button>
+                </DialogFooter>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </DialogContent>
+      </Dialog>
+    </ChatPageWrapper>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/DesktopPanel.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/DesktopPanel.tsx
@@ -1,0 +1,267 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useAction } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { Spinner, Button } from "@conductor/ui";
+import {
+  IconDeviceDesktop,
+  IconRefresh,
+  IconMaximize,
+  IconExternalLink,
+  IconPlayerStop,
+} from "@tabler/icons-react";
+import { ensureHttps } from "@/lib/utils/ensureHttps";
+import { dismissDaytonaWarning } from "@/lib/utils/dismissDaytonaWarning";
+import { createSessionCache } from "@/lib/utils/sessionCache";
+
+type DesktopState = "idle" | "starting" | "running" | "error";
+
+const desktopCache = createSessionCache("desktop");
+
+function appendNoVncParams(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = url.pathname.replace(/\/?$/, "/vnc_lite.html");
+  url.searchParams.set("autoconnect", "true");
+  url.searchParams.set("resize", "scale");
+  url.searchParams.set("quality", "6");
+  url.searchParams.set("compression", "2");
+  return url.toString();
+}
+
+interface DesktopPanelProps {
+  sessionId: string;
+  sandboxId: string | undefined;
+  isActive: boolean;
+  repoId: Id<"githubRepos">;
+}
+
+export function DesktopPanel({
+  sessionId,
+  sandboxId,
+  isActive,
+  repoId,
+}: DesktopPanelProps) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [desktopState, setDesktopState] = useState<DesktopState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const pollTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const attempts = useRef(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const getPreviewUrl = useAction(api.daytona.getPreviewUrl);
+  const toggleDesktopServer = useAction(api.daytona.toggleDesktopServer);
+  const launchChromeInDesktop = useAction(api.daytona.launchChromeInDesktop);
+
+  const stopPolling = useCallback(() => {
+    clearTimeout(pollTimer.current);
+    pollTimer.current = undefined;
+  }, []);
+
+  const pollForReady = useCallback(async () => {
+    if (!sandboxId || !isActive) return;
+    attempts.current = 0;
+
+    const check = async () => {
+      try {
+        const data = await getPreviewUrl({
+          sandboxId,
+          port: 6080,
+          checkReady: true,
+          repoId,
+        });
+        if (data.ready) {
+          await dismissDaytonaWarning(data.url);
+          const noVncUrl = appendNoVncParams(data.url);
+          setUrl(noVncUrl);
+          setDesktopState("running");
+          desktopCache.set(sessionId, noVncUrl);
+          launchChromeInDesktop({ sandboxId, repoId }).catch(() => {});
+          return;
+        }
+        attempts.current += 1;
+        if (attempts.current >= 40) {
+          setError("Desktop environment failed to start. Check sandbox logs.");
+          setDesktopState("error");
+          return;
+        }
+        pollTimer.current = setTimeout(check, 3000);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load desktop");
+        setDesktopState("error");
+      }
+    };
+
+    check();
+  }, [
+    sandboxId,
+    isActive,
+    getPreviewUrl,
+    repoId,
+    sessionId,
+    launchChromeInDesktop,
+  ]);
+
+  const startDesktop = useCallback(async () => {
+    if (!sandboxId) return;
+    setDesktopState("starting");
+    setError(null);
+    setUrl(null);
+    stopPolling();
+    try {
+      const existing = await getPreviewUrl({
+        sandboxId,
+        port: 6080,
+        checkReady: true,
+        repoId,
+      });
+      if (existing.ready) {
+        await dismissDaytonaWarning(existing.url);
+        const noVncUrl = appendNoVncParams(existing.url);
+        setUrl(noVncUrl);
+        setDesktopState("running");
+        desktopCache.set(sessionId, noVncUrl);
+        launchChromeInDesktop({ sandboxId, repoId }).catch(() => {});
+        return;
+      }
+      await toggleDesktopServer({ sandboxId, repoId, action: "start" });
+      await pollForReady();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start desktop");
+      setDesktopState("error");
+    }
+  }, [
+    sandboxId,
+    repoId,
+    toggleDesktopServer,
+    pollForReady,
+    stopPolling,
+    getPreviewUrl,
+    sessionId,
+    launchChromeInDesktop,
+  ]);
+
+  const stopDesktop = useCallback(async () => {
+    if (!sandboxId) return;
+    stopPolling();
+    setDesktopState("idle");
+    setUrl(null);
+    setError(null);
+    desktopCache.clear(sessionId);
+    try {
+      await toggleDesktopServer({ sandboxId, repoId, action: "stop" });
+    } catch {
+      // best-effort stop
+    }
+  }, [sandboxId, stopPolling, sessionId, toggleDesktopServer, repoId]);
+
+  useEffect(() => {
+    if (isActive && sandboxId && desktopState === "idle") {
+      const cached = desktopCache.get(sessionId);
+      if (cached) {
+        setUrl(cached);
+        setDesktopState("running");
+      }
+    }
+    if (!isActive) {
+      desktopCache.clear(sessionId);
+    }
+    return stopPolling;
+  }, [isActive, sandboxId, desktopState, stopPolling, sessionId]);
+
+  const toggleFullscreen = useCallback(() => {
+    if (!containerRef.current) return;
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+      setIsFullscreen(false);
+    } else {
+      containerRef.current.requestFullscreen();
+      setIsFullscreen(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  if (!isActive || !sandboxId) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-muted-foreground gap-3">
+        <IconDeviceDesktop className="w-12 h-12 opacity-50" />
+        <p className="text-sm">Start the sandbox to use the desktop</p>
+      </div>
+    );
+  }
+
+  if (desktopState === "idle") {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-muted-foreground gap-3">
+        <IconDeviceDesktop className="w-12 h-12 opacity-50" />
+        <p className="text-sm">Desktop is not running</p>
+        <Button size="sm" variant="secondary" onClick={startDesktop}>
+          Start Desktop
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col" ref={containerRef}>
+      {url && desktopState === "running" && (
+        <div className="flex items-center justify-end gap-1 pb-1 mb-1 px-2 py-1">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-8"
+            onClick={toggleFullscreen}
+          >
+            <IconMaximize className="w-4 h-4" />
+          </Button>
+          <Button size="icon" variant="ghost" className="size-8" asChild>
+            <a href={url} target="_blank" rel="noopener noreferrer">
+              <IconExternalLink className="w-4 h-4" />
+            </a>
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-8 text-destructive hover:bg-destructive/10"
+            onClick={stopDesktop}
+          >
+            <IconPlayerStop className="w-4 h-4" />
+          </Button>
+        </div>
+      )}
+      <div className="flex-1 min-h-0 relative">
+        {desktopState === "starting" && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-secondary z-10 gap-3">
+            <Spinner size="lg" />
+            <p className="text-sm text-muted-foreground">
+              Starting desktop environment...
+            </p>
+          </div>
+        )}
+        {desktopState === "error" && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 z-10">
+            <p className="text-sm text-destructive">{error}</p>
+            <Button size="sm" variant="secondary" onClick={startDesktop}>
+              <IconRefresh className="w-4 h-4 mr-1" />
+              Retry
+            </Button>
+          </div>
+        )}
+        {url && desktopState === "running" && (
+          <iframe
+            src={ensureHttps(url)}
+            className="absolute inset-0 w-full h-full border-0"
+            allow="clipboard-read; clipboard-write"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/EditorPanel.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/EditorPanel.tsx
@@ -1,0 +1,176 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useAction } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { Spinner, Button } from "@conductor/ui";
+import { IconCode, IconRefresh } from "@tabler/icons-react";
+import { ensureHttps } from "@/lib/utils/ensureHttps";
+import { dismissDaytonaWarning } from "@/lib/utils/dismissDaytonaWarning";
+import { createSessionCache } from "@/lib/utils/sessionCache";
+
+type EditorState = "idle" | "starting" | "running" | "error";
+
+const editorCache = createSessionCache("editor");
+
+interface EditorPanelProps {
+  sessionId: string;
+  sandboxId: string | undefined;
+  isActive: boolean;
+  repoId: Id<"githubRepos">;
+}
+
+export function EditorPanel({
+  sessionId,
+  sandboxId,
+  isActive,
+  repoId,
+}: EditorPanelProps) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [editorState, setEditorState] = useState<EditorState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const attempts = useRef(0);
+  const getPreviewUrl = useAction(api.daytona.getPreviewUrl);
+  const toggleCodeServer = useAction(api.daytona.toggleCodeServer);
+
+  const stopPolling = useCallback(() => {
+    clearTimeout(pollTimer.current);
+    pollTimer.current = undefined;
+  }, []);
+
+  const pollForReady = useCallback(async () => {
+    if (!sandboxId || !isActive) return;
+    attempts.current = 0;
+
+    const check = async () => {
+      try {
+        const data = await getPreviewUrl({
+          sandboxId,
+          port: 8080,
+          checkReady: true,
+          repoId,
+        });
+        if (data.ready) {
+          await dismissDaytonaWarning(data.url);
+          setUrl(data.url);
+          setEditorState("running");
+          editorCache.set(sessionId, data.url);
+          return;
+        }
+        attempts.current += 1;
+        if (attempts.current >= 20) {
+          setError("Editor failed to start. Check sandbox logs.");
+          setEditorState("error");
+
+          return;
+        }
+        pollTimer.current = setTimeout(check, 3000);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load editor");
+        setEditorState("error");
+      }
+    };
+
+    check();
+  }, [sandboxId, isActive, getPreviewUrl, repoId, sessionId]);
+
+  const startEditor = useCallback(async () => {
+    if (!sandboxId) return;
+    setEditorState("starting");
+    setError(null);
+    setUrl(null);
+    stopPolling();
+    try {
+      const existing = await getPreviewUrl({
+        sandboxId,
+        port: 8080,
+        checkReady: true,
+        repoId,
+      });
+      if (existing.ready) {
+        await dismissDaytonaWarning(existing.url);
+        setUrl(existing.url);
+        setEditorState("running");
+        editorCache.set(sessionId, existing.url);
+        return;
+      }
+      await toggleCodeServer({ sandboxId, repoId, action: "start" });
+      await pollForReady();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start editor");
+      setEditorState("error");
+    }
+  }, [
+    sandboxId,
+    repoId,
+    toggleCodeServer,
+    pollForReady,
+    stopPolling,
+    getPreviewUrl,
+    sessionId,
+  ]);
+
+  useEffect(() => {
+    if (isActive && sandboxId && editorState === "idle") {
+      const cached = editorCache.get(sessionId);
+      if (cached) {
+        setUrl(cached);
+        setEditorState("running");
+      }
+    }
+    if (!isActive) {
+      editorCache.clear(sessionId);
+    }
+    return stopPolling;
+  }, [isActive, sandboxId, editorState, stopPolling, sessionId]);
+
+  if (!isActive || !sandboxId) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-muted-foreground gap-3">
+        <IconCode className="w-12 h-12 opacity-50" />
+        <p className="text-sm">Start the sandbox to use the editor</p>
+      </div>
+    );
+  }
+
+  if (editorState === "idle") {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-muted-foreground gap-3">
+        <IconCode className="w-12 h-12 opacity-50" />
+        <p className="text-sm">Editor is not running</p>
+        <Button size="sm" variant="secondary" onClick={startEditor}>
+          Start Editor
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex-1 min-h-0 relative">
+        {editorState === "starting" && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-secondary z-10 gap-3">
+            <Spinner size="lg" />
+            <p className="text-sm text-muted-foreground">Starting editor...</p>
+          </div>
+        )}
+        {editorState === "error" && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 z-10">
+            <p className="text-sm text-destructive">{error}</p>
+            <Button size="sm" variant="secondary" onClick={startEditor}>
+              <IconRefresh className="w-4 h-4 mr-1" />
+              Retry
+            </Button>
+          </div>
+        )}
+        {url && editorState === "running" && (
+          <iframe
+            src={ensureHttps(url)}
+            className="absolute inset-0 w-full h-full border-0"
+            allow="clipboard-read; clipboard-write"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/SandboxPanel.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/SandboxPanel.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useAction } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { useQueryState } from "nuqs";
+import { sandboxTabParser, previewPortParser } from "@/lib/search-params";
+import { dismissDaytonaWarning } from "@/lib/utils/dismissDaytonaWarning";
+import { TerminalPanel } from "./TerminalPanel";
+import { WebPreviewPanel } from "./WebPreviewPanel";
+import { EditorPanel } from "./EditorPanel";
+import { DesktopPanel } from "./DesktopPanel";
+import { SandboxTabBar } from "./_components/SandboxTabBar";
+
+interface PreviewInfo {
+  url: string;
+  port: number;
+}
+
+function getCachedPreview(sessionId: string, port: number): PreviewInfo | null {
+  try {
+    const raw = sessionStorage.getItem(
+      `conductor:preview:${sessionId}:${port}`,
+    );
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return { url: parsed.url, port: parsed.port };
+  } catch {
+    return null;
+  }
+}
+
+function setCachedPreview(sessionId: string, info: PreviewInfo) {
+  sessionStorage.setItem(
+    `conductor:preview:${sessionId}:${info.port}`,
+    JSON.stringify({ url: info.url, port: info.port }),
+  );
+}
+
+function clearCachedPreview(sessionId: string, port: number) {
+  sessionStorage.removeItem(`conductor:preview:${sessionId}:${port}`);
+}
+
+interface SandboxPanelProps {
+  sessionId: string;
+  sandboxId: string | undefined;
+  isActive: boolean;
+  repoId: Id<"githubRepos">;
+  devPort?: number;
+  devCommand?: string;
+  previewInfo: PreviewInfo | null;
+  onPreviewInfoChange: (info: PreviewInfo | null) => void;
+}
+
+export function SandboxPanel({
+  sessionId,
+  sandboxId,
+  isActive,
+  repoId,
+  devPort,
+  devCommand,
+  previewInfo,
+  onPreviewInfoChange,
+}: SandboxPanelProps) {
+  const [activeTab, setActiveTab] = useQueryState("tab", sandboxTabParser);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [iframeKey, setIframeKey] = useState(0);
+  const [port, setPort] = useQueryState("port", previewPortParser);
+  const effectivePort = devPort ?? port;
+  const getPreviewUrl = useAction(api.daytona.getPreviewUrl);
+  const pollingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearTimeout(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
+
+  const fetchPreview = useCallback(async () => {
+    if (!sandboxId || !isActive) return;
+    setIsLoading(true);
+    setError(null);
+    stopPolling();
+    try {
+      const data = await getPreviewUrl({
+        sandboxId,
+        port: effectivePort,
+        checkReady: true,
+        repoId,
+      });
+      if (data.ready) {
+        await dismissDaytonaWarning(data.url);
+        onPreviewInfoChange(data);
+        setCachedPreview(sessionId, data);
+        setIframeKey((k) => k + 1);
+        setIsLoading(false);
+      } else {
+        pollingRef.current = setTimeout(() => {
+          fetchPreview();
+        }, 3000);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load preview");
+      setIsLoading(false);
+    }
+  }, [
+    sandboxId,
+    isActive,
+    getPreviewUrl,
+    stopPolling,
+    repoId,
+    effectivePort,
+    sessionId,
+    onPreviewInfoChange,
+  ]);
+
+  useEffect(() => {
+    if (isActive && sandboxId) {
+      const cached = getCachedPreview(sessionId, effectivePort);
+      if (cached) {
+        onPreviewInfoChange(cached);
+        return;
+      }
+      fetchPreview();
+    }
+    if (!isActive) {
+      clearCachedPreview(sessionId, effectivePort);
+    }
+    return stopPolling;
+  }, [
+    isActive,
+    sandboxId,
+    fetchPreview,
+    stopPolling,
+    sessionId,
+    effectivePort,
+    onPreviewInfoChange,
+  ]);
+
+  const terminal = useMemo(
+    () => (
+      <TerminalPanel
+        sessionId={sessionId}
+        sandboxId={sandboxId}
+        isActive={isActive}
+        devCommand={devCommand}
+      />
+    ),
+    [sessionId, sandboxId, isActive, devCommand],
+  );
+
+  const handleTabChange = useCallback(
+    (tab: "preview" | "desktop" | "editor" | "terminal") => {
+      setActiveTab(tab);
+    },
+    [setActiveTab],
+  );
+
+  return (
+    <div className="h-full flex flex-col">
+      <SandboxTabBar activeTab={activeTab} onTabChange={handleTabChange} />
+      <div className="flex-1 overflow-hidden bg-card">
+        <div className={activeTab === "preview" ? "h-full" : "hidden"}>
+          <WebPreviewPanel
+            isActive={isActive}
+            sandboxId={sandboxId}
+            previewInfo={previewInfo}
+            isLoading={isLoading}
+            error={error}
+            iframeKey={iframeKey}
+            onRefresh={fetchPreview}
+            port={effectivePort}
+            onPortChange={setPort}
+          />
+        </div>
+        <div className={activeTab === "editor" ? "h-full" : "hidden"}>
+          <EditorPanel
+            sessionId={sessionId}
+            sandboxId={sandboxId}
+            isActive={isActive}
+            repoId={repoId}
+          />
+        </div>
+        <div className={activeTab === "terminal" ? "h-full" : "hidden"}>
+          <div className="h-full flex flex-col">
+            <div className="flex-1 min-h-0">{terminal}</div>
+          </div>
+        </div>
+        <div className={activeTab === "desktop" ? "h-full" : "hidden"}>
+          <DesktopPanel
+            sessionId={sessionId}
+            sandboxId={sandboxId}
+            isActive={isActive}
+            repoId={repoId}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/SessionDetailClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/SessionDetailClient.tsx
@@ -1,0 +1,117 @@
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { useCallback, useState } from "react";
+import { ChatPanel } from "./ChatPanel";
+import { SandboxPanel } from "./SandboxPanel";
+import { Spinner } from "@conductor/ui";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { ResizablePanelLayout } from "@/lib/components/ResizablePanelLayout";
+
+export function SessionDetailClient({
+  sessionId,
+}: {
+  sessionId: string;
+}) {
+  const { installationId, repo } = useRepo();
+  const typedSessionId = sessionId as Id<"sessions">;
+  const session = useQuery(api.sessions.get, { id: typedSessionId });
+  const messages = useQuery(api.messages.listByParent, {
+    parentId: typedSessionId,
+  });
+  const streaming = useQuery(api.streaming.get, { entityId: typedSessionId });
+  const summaryStreaming = useQuery(api.streaming.get, {
+    entityId: `summary:${typedSessionId}`,
+  });
+  const startSandboxMutation = useMutation(api.sessions.startSandbox);
+  const stopSandboxMutation = useMutation(api.sessions.stopSandbox);
+  const isSandboxStarting = session?.status === "starting";
+  const [isStopPending, setIsStopPending] = useState(false);
+  const [previewInfo, setPreviewInfo] = useState<{
+    url: string;
+    port: number;
+  } | null>(null);
+  const handlePreviewInfoChange = useCallback(
+    (info: { url: string; port: number } | null) => setPreviewInfo(info),
+    [],
+  );
+
+  const handleSandboxToggle = async (action: "start" | "stop") => {
+    if (action === "start") {
+      await startSandboxMutation({
+        sessionId: typedSessionId,
+        installationId,
+      });
+    } else {
+      setIsStopPending(true);
+      try {
+        await stopSandboxMutation({ sessionId: typedSessionId });
+      } finally {
+        setIsStopPending(false);
+      }
+    }
+  };
+
+  if (session === undefined) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (session === null) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <p className="text-muted-foreground">
+            This session does not exist or has been deleted.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const isSandboxActive = session.status === "active";
+
+  return (
+    <ResizablePanelLayout
+      leftPanel={({ rightPanelCollapsed, onToggleRightPanel }) => (
+        <ChatPanel
+          sessionId={typedSessionId}
+          title={session.title}
+          branchName={session.branchName}
+          prUrl={session.prUrl}
+          summary={session.summary}
+          messages={messages ?? []}
+          planContent={session.planContent}
+          streamingActivity={streaming?.currentActivity}
+          summaryStreamingActivity={summaryStreaming?.currentActivity}
+          isSandboxActive={isSandboxActive}
+          isSandboxToggling={isSandboxStarting || isStopPending}
+          onSandboxToggle={handleSandboxToggle}
+          isArchived={session.archived === true}
+          previewUrl={previewInfo?.url}
+          sandboxCollapsed={rightPanelCollapsed}
+          onToggleSandbox={onToggleRightPanel}
+        />
+      )}
+      rightPanel={
+        <SandboxPanel
+          sessionId={typedSessionId}
+          sandboxId={session.sandboxId}
+          isActive={isSandboxActive}
+          repoId={session.repoId}
+          devPort={session.devPort}
+          devCommand={session.devCommand}
+          previewInfo={previewInfo}
+          onPreviewInfoChange={handlePreviewInfoChange}
+        />
+      }
+      leftDefaultSize="30%"
+      leftMinWidthPx={350}
+      rightMinWidthPx={300}
+      collapseCookieName="sandbox-collapsed"
+    />
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/TerminalPanel.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/TerminalPanel.tsx
@@ -1,0 +1,339 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { Button, Spinner } from "@conductor/ui";
+import { IconRefresh, IconTerminal2 } from "@tabler/icons-react";
+import { useAction } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import "@xterm/xterm/css/xterm.css";
+
+interface TerminalPanelProps {
+  sessionId: string;
+  sandboxId: string | undefined;
+  isActive: boolean;
+  devCommand?: string;
+}
+
+const MAX_RECONNECT_ATTEMPTS = 3;
+const RECONNECT_DELAY_MS = 1000;
+
+function getCssRgb(
+  styles: CSSStyleDeclaration,
+  variableName: string,
+  fallback: string,
+) {
+  const raw = styles.getPropertyValue(variableName).trim();
+  const value = raw.length > 0 ? raw : fallback;
+  return `rgb(${value.split(/\s+/).join(", ")})`;
+}
+
+function getCssRgba(
+  styles: CSSStyleDeclaration,
+  variableName: string,
+  alpha: number,
+  fallback: string,
+) {
+  const raw = styles.getPropertyValue(variableName).trim();
+  const value = raw.length > 0 ? raw : fallback;
+  return `rgba(${value.split(/\s+/).join(", ")}, ${alpha})`;
+}
+
+function isControlMessage(
+  data: unknown,
+): data is { type: string; status: string; error?: string } {
+  if (typeof data !== "object" || data === null || !("type" in data)) {
+    return false;
+  }
+  const obj: Record<string, unknown> = Object.assign({}, data);
+  return obj.type === "control";
+}
+
+export function TerminalPanel({
+  sessionId,
+  sandboxId,
+  isActive,
+  devCommand,
+}: TerminalPanelProps) {
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const terminalInstanceRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const intentionalCloseRef = useRef(false);
+  const reconnectAttemptsRef = useRef(0);
+
+  const connectPty = useAction(api.pty.connectPty);
+  const resizePtyAction = useAction(api.pty.resizePty);
+
+  const typedSessionId = sessionId as Id<"sessions">;
+
+  const resizePtyRef = useRef(resizePtyAction);
+  resizePtyRef.current = resizePtyAction;
+
+  const connectWebSocket = useCallback(
+    async (terminal: Terminal, mounted: { current: boolean }) => {
+      const { wsUrl, isNewPty } = await connectPty({
+        sessionId: typedSessionId,
+        cols: terminal.cols,
+        rows: terminal.rows,
+      });
+
+      if (!mounted.current) return;
+
+      const ws = new WebSocket(wsUrl);
+      ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
+      const decoder = new TextDecoder();
+
+      ws.onopen = () => {
+        reconnectAttemptsRef.current = 0;
+      };
+
+      ws.onmessage = (event) => {
+        if (!terminalInstanceRef.current) return;
+
+        if (typeof event.data === "string") {
+          try {
+            const parsed: unknown = JSON.parse(event.data);
+            if (isControlMessage(parsed)) {
+              if (parsed.status === "connected") {
+                terminalInstanceRef.current.writeln(
+                  "\x1b[32m* Connected to sandbox\x1b[0m\r\n",
+                );
+                if (
+                  isNewPty &&
+                  devCommand &&
+                  ws.readyState === WebSocket.OPEN
+                ) {
+                  terminalInstanceRef.current.writeln(
+                    "\x1b[33m* Starting dev server...\x1b[0m\r\n",
+                  );
+                  setTimeout(() => {
+                    if (ws.readyState === WebSocket.OPEN) {
+                      ws.send(devCommand + "\r");
+                    }
+                  }, 300);
+                }
+                return;
+              }
+              if (parsed.status === "error") {
+                terminalInstanceRef.current.writeln(
+                  `\x1b[31m* Error: ${parsed.error ?? "unknown"}\x1b[0m`,
+                );
+                return;
+              }
+              return;
+            }
+          } catch {
+            // Not JSON - treat as terminal output
+          }
+          terminalInstanceRef.current.write(event.data);
+        } else {
+          terminalInstanceRef.current.write(
+            decoder.decode(event.data, { stream: true }),
+          );
+        }
+      };
+
+      ws.onclose = () => {
+        if (
+          !mounted.current ||
+          intentionalCloseRef.current ||
+          reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS
+        ) {
+          return;
+        }
+
+        reconnectAttemptsRef.current++;
+        if (terminalInstanceRef.current) {
+          terminalInstanceRef.current.writeln(
+            `\r\n\x1b[33m* Reconnecting (${reconnectAttemptsRef.current}/${MAX_RECONNECT_ATTEMPTS})...\x1b[0m`,
+          );
+        }
+
+        setTimeout(() => {
+          if (mounted.current && terminalInstanceRef.current) {
+            connectWebSocket(terminalInstanceRef.current, mounted).catch(
+              () => {},
+            );
+          }
+        }, RECONNECT_DELAY_MS);
+      };
+
+      terminal.onData((data) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(data);
+        }
+      });
+    },
+    [connectPty, typedSessionId, devCommand],
+  );
+
+  useEffect(() => {
+    if (!isActive || !sandboxId || !terminalRef.current) {
+      return;
+    }
+
+    const mounted = { current: true };
+    const containerEl = terminalRef.current;
+
+    const initTerminal = async () => {
+      setIsLoading(true);
+      setError(null);
+      intentionalCloseRef.current = false;
+      reconnectAttemptsRef.current = 0;
+
+      try {
+        if (wsRef.current) {
+          intentionalCloseRef.current = true;
+          wsRef.current.close();
+          wsRef.current = null;
+        }
+        if (terminalInstanceRef.current) {
+          terminalInstanceRef.current.dispose();
+        }
+
+        const rootStyles = getComputedStyle(document.documentElement);
+        const terminal = new Terminal({
+          cursorBlink: true,
+          fontSize: 13,
+          fontFamily: "Menlo, Monaco, 'Courier New', monospace",
+          theme: {
+            background: getCssRgb(rootStyles, "--card", "17 24 39"),
+            foreground: getCssRgb(rootStyles, "--foreground", "226 232 240"),
+            cursor: getCssRgb(rootStyles, "--primary", "16 145 130"),
+            cursorAccent: getCssRgb(rootStyles, "--card", "17 24 39"),
+            selectionBackground: getCssRgba(
+              rootStyles,
+              "--primary",
+              0.26,
+              "16 145 130",
+            ),
+          },
+          allowProposedApi: true,
+        });
+
+        const fitAddon = new FitAddon();
+        const webLinksAddon = new WebLinksAddon();
+
+        terminal.loadAddon(fitAddon);
+        terminal.loadAddon(webLinksAddon);
+        terminal.open(containerEl);
+
+        terminalInstanceRef.current = terminal;
+        fitAddonRef.current = fitAddon;
+
+        await new Promise<void>((resolve) => {
+          setTimeout(() => {
+            fitAddon.fit();
+            resolve();
+          }, 0);
+        });
+
+        for (let i = 0; i < terminal.rows - 1; i++) {
+          terminal.writeln("");
+        }
+        terminal.writeln("\x1b[33m* Connecting to sandbox...\x1b[0m");
+
+        await connectWebSocket(terminal, mounted);
+      } catch (err) {
+        if (mounted.current) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Failed to initialize terminal",
+          );
+        }
+      } finally {
+        if (mounted.current) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    initTerminal();
+
+    return () => {
+      mounted.current = false;
+      intentionalCloseRef.current = true;
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+      if (terminalInstanceRef.current) {
+        terminalInstanceRef.current.dispose();
+        terminalInstanceRef.current = null;
+      }
+    };
+  }, [isActive, sandboxId, typedSessionId, retryCount, connectWebSocket]);
+
+  useEffect(() => {
+    if (!terminalRef.current) {
+      return;
+    }
+    const el = terminalRef.current;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (
+        !entry ||
+        entry.contentRect.width === 0 ||
+        entry.contentRect.height === 0
+      ) {
+        return;
+      }
+      if (fitAddonRef.current && terminalInstanceRef.current) {
+        fitAddonRef.current.fit();
+        const { cols, rows } = terminalInstanceRef.current;
+        resizePtyRef
+          .current({ sessionId: typedSessionId, cols, rows })
+          .catch(() => {});
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [typedSessionId]);
+
+  if (!isActive || !sandboxId) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
+        <IconTerminal2 className="h-12 w-12 opacity-50" />
+        <p className="text-sm">
+          {!isActive
+            ? "Start the sandbox to use the terminal"
+            : "Waiting for sandbox..."}
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
+        <p className="text-sm text-destructive">{error}</p>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => setRetryCount((c) => c + 1)}
+        >
+          <IconRefresh className="h-4 w-4" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-full flex-col bg-card">
+      {isLoading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-card">
+          <Spinner size="lg" />
+        </div>
+      )}
+      <div ref={terminalRef} className="min-h-0 flex-1" />
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/WebPreviewPanel.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/WebPreviewPanel.tsx
@@ -1,0 +1,125 @@
+import { useRef } from "react";
+import {
+  Spinner,
+  Button,
+  WebPreview,
+  WebPreviewNavigation,
+  WebPreviewBody,
+  useWebPreview,
+} from "@conductor/ui";
+import { IconRefresh, IconWorld } from "@tabler/icons-react";
+import { PreviewNavBar } from "@/lib/components/PreviewNavBar";
+
+interface PreviewInfo {
+  url: string;
+  port: number;
+}
+
+interface WebPreviewPanelProps {
+  isActive: boolean;
+  sandboxId: string | undefined;
+  previewInfo: PreviewInfo | null;
+  isLoading: boolean;
+  error: string | null;
+  iframeKey: number;
+  onRefresh: () => void;
+  port: number;
+  onPortChange: (port: number) => void;
+}
+
+function NavigationBar({
+  previewInfo,
+  isLoading,
+  onRefresh,
+  containerRef,
+  port,
+  onPortChange,
+}: {
+  previewInfo: PreviewInfo | null;
+  isLoading: boolean;
+  onRefresh: () => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  port: number;
+  onPortChange: (port: number) => void;
+}) {
+  const { iframeRef } = useWebPreview();
+
+  return (
+    <WebPreviewNavigation>
+      <PreviewNavBar
+        previewUrl={previewInfo?.url ?? null}
+        iframeRef={iframeRef}
+        containerRef={containerRef}
+        port={port}
+        onPortChange={onPortChange}
+        isLoading={isLoading}
+        onRefresh={onRefresh}
+      />
+    </WebPreviewNavigation>
+  );
+}
+
+export function WebPreviewPanel({
+  isActive,
+  sandboxId,
+  previewInfo,
+  isLoading,
+  error,
+  iframeKey,
+  onRefresh,
+  port,
+  onPortChange,
+}: WebPreviewPanelProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  if (!isActive || !sandboxId) {
+    return (
+      <div className="h-full flex flex-col">
+        <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground gap-3">
+          <IconWorld className="w-12 h-12 opacity-50" />
+          <p className="text-sm">
+            {!isActive
+              ? "Start the sandbox to preview your app"
+              : "Waiting for sandbox..."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <WebPreview
+      ref={containerRef}
+      defaultUrl={previewInfo?.url ?? ""}
+      className="h-full rounded-none border-0"
+    >
+      <NavigationBar
+        previewInfo={previewInfo}
+        isLoading={isLoading}
+        onRefresh={onRefresh}
+        containerRef={containerRef}
+        port={port}
+        onPortChange={onPortChange}
+      />
+      <WebPreviewBody
+        key={iframeKey}
+        src={previewInfo?.url}
+        loading={
+          isLoading && !previewInfo ? (
+            <div className="absolute inset-0 flex items-center justify-center bg-secondary z-10">
+              <Spinner size="lg" />
+            </div>
+          ) : error ? (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
+              <p className="text-sm text-destructive">{error}</p>
+              <Button size="sm" variant="secondary" onClick={onRefresh}>
+                <IconRefresh className="w-4 h-4" />
+                Retry
+              </Button>
+            </div>
+          ) : undefined
+        }
+      />
+    </WebPreview>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/_components/SandboxTabBar.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/_components/SandboxTabBar.tsx
@@ -1,0 +1,68 @@
+import {
+  IconWorld,
+  IconDeviceDesktop,
+  IconCode,
+  IconTerminal2,
+} from "@tabler/icons-react";
+import { Tabs, TabsList, TabsTrigger } from "@conductor/ui";
+
+type SandboxTab = "preview" | "desktop" | "editor" | "terminal";
+
+const SANDBOX_TABS: Set<string> = new Set([
+  "preview",
+  "desktop",
+  "editor",
+  "terminal",
+]);
+
+const tabs: Array<{
+  value: SandboxTab;
+  label: string;
+  icon: typeof IconWorld;
+}> = [
+  { value: "preview", label: "Preview", icon: IconWorld },
+  { value: "desktop", label: "Computer", icon: IconDeviceDesktop },
+  { value: "editor", label: "Editor", icon: IconCode },
+  { value: "terminal", label: "Terminal", icon: IconTerminal2 },
+];
+
+interface SandboxTabBarProps {
+  activeTab: SandboxTab;
+  onTabChange: (tab: SandboxTab) => void;
+}
+
+function isSandboxTab(value: string): value is SandboxTab {
+  return SANDBOX_TABS.has(value);
+}
+
+export function SandboxTabBar({ activeTab, onTabChange }: SandboxTabBarProps) {
+  return (
+    <div className="relative flex items-end px-2 pt-1.5 bg-secondary/50">
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => {
+          if (isSandboxTab(v)) {
+            onTabChange(v);
+          }
+        }}
+      >
+        <TabsList className="h-auto gap-0 rounded-none border-0 bg-transparent p-0 shadow-none">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                className="relative flex items-center gap-1.5 rounded-none rounded-t-md border border-b-0 px-4 py-1.5 text-sm font-medium data-[state=active]:bg-card data-[state=active]:border-border data-[state=active]:z-10 data-[state=active]:shadow-none data-[state=inactive]:bg-transparent data-[state=inactive]:border-transparent data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:text-foreground data-[state=inactive]:hover:bg-secondary"
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {tab.label}
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+      </Tabs>
+      <div className="absolute bottom-0 left-0 right-0 h-px bg-border" />
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/index.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/sessions/index.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IconTerminal2 } from "@tabler/icons-react";
+import { EmptyState } from "@/lib/components/ui/EmptyState";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/sessions/")({
+  component: SessionsPage,
+});
+
+function SessionsPage() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <EmptyState
+        icon={<IconTerminal2 size={24} className="text-muted-foreground" />}
+        title="Select a session to view the conversation"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Port sessions index (empty state) and session detail routes from Next.js to Vite + TanStack Router under `apps/web-v2/src/routes/_repo/$owner/$repo/sessions/`
- Port all session panel components: ChatPanel, SandboxPanel, TerminalPanel, EditorPanel, WebPreviewPanel, DesktopPanel, and SandboxTabBar
- Replace `next/link` with native `<a>` tags (PR links are external URLs), remove `"use client"` directives, replace `as SandboxTab` cast with type guard function

## Test plan
- [ ] Verify sessions index route renders empty state at `/:owner/:repo/sessions`
- [ ] Verify session detail route loads at `/:owner/:repo/sessions/:id`
- [ ] Verify all sandbox tabs (preview, editor, terminal, desktop) render correctly
- [ ] Verify chat panel send/receive works with sandbox active