### PR TITLE
feat(web-v2): add all settings routes

### DIFF
--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/AuditsClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/AuditsClient.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@conductor/backend";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import { Checkbox } from "@conductor/ui";
+import { IconTrash } from "@tabler/icons-react";
+import type { FunctionReturnType } from "convex/server";
+import { AddCategoryForm } from "./audits/_components/AddCategoryForm";
+
+type Category = FunctionReturnType<
+  typeof api.auditCategories.listByRepo
+>[number];
+
+export function AuditsClient() {
+  const { repo, repoId } = useRepo();
+  const categories = useQuery(api.auditCategories.listByRepo, { repoId });
+  const toggleEnabled = useMutation(api.auditCategories.toggleEnabled);
+  const removeCategory = useMutation(api.auditCategories.remove);
+
+  if (!categories) return null;
+
+  const repoCategories = categories.filter((c) => c.appId === undefined);
+  const isApp = repo.parentRepoId !== undefined;
+  const appCategories = isApp
+    ? categories.filter((c) => c.appId === repoId)
+    : [];
+
+  return (
+    <PageWrapper title="Audits">
+      <div className="space-y-6">
+        <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+          <div>
+            <h3 className="text-sm font-medium">Repo-level Audits</h3>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              {isApp
+                ? "These audits are managed at the repo level and apply to all apps."
+                : "These audits run for all tasks across the repo and all apps."}
+            </p>
+          </div>
+
+          {repoCategories.length > 0 && (
+            <div className="grid gap-2">
+              {repoCategories.map((category) =>
+                isApp ? (
+                  <ReadOnlyCategoryRow key={category._id} category={category} />
+                ) : (
+                  <CategoryRow
+                    key={category._id}
+                    category={category}
+                    onToggle={(enabled) =>
+                      toggleEnabled({ id: category._id, enabled })
+                    }
+                    onRemove={() => removeCategory({ id: category._id })}
+                  />
+                ),
+              )}
+            </div>
+          )}
+
+          {repoCategories.length === 0 && (
+            <p className="text-xs text-muted-foreground text-center py-6">
+              No audit categories configured yet.
+            </p>
+          )}
+
+          {!isApp && <AddCategoryForm repoId={repo.parentRepoId ?? repoId} />}
+        </div>
+
+        {isApp && (
+          <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+            <div>
+              <h3 className="text-sm font-medium">App-specific Audits</h3>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Audits that only run for this app.
+              </p>
+            </div>
+
+            {appCategories.length > 0 && (
+              <div className="grid gap-2">
+                {appCategories.map((category) => (
+                  <CategoryRow
+                    key={category._id}
+                    category={category}
+                    onToggle={(enabled) =>
+                      toggleEnabled({ id: category._id, enabled })
+                    }
+                    onRemove={() => removeCategory({ id: category._id })}
+                  />
+                ))}
+              </div>
+            )}
+
+            <AddCategoryForm repoId={repoId} appId={repoId} />
+          </div>
+        )}
+      </div>
+    </PageWrapper>
+  );
+}
+
+function ReadOnlyCategoryRow({ category }: { category: Category }) {
+  return (
+    <div className="flex items-start gap-3 rounded-md bg-muted/40 p-3 opacity-60">
+      <Checkbox checked={category.enabled} disabled className="mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-xs font-medium">{category.name}</p>
+        <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
+          {category.description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CategoryRow({
+  category,
+  onToggle,
+  onRemove,
+}: {
+  category: Category;
+  onToggle: (enabled: boolean) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-md bg-muted/40 p-3">
+      <Checkbox
+        checked={category.enabled}
+        onCheckedChange={(value) => onToggle(value === true)}
+        className="mt-0.5"
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-xs font-medium">{category.name}</p>
+        <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
+          {category.description}
+        </p>
+      </div>
+      <button
+        onClick={onRemove}
+        className="text-muted-foreground hover:text-destructive transition-colors p-1"
+      >
+        <IconTrash size={14} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/ConfigClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/ConfigClient.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "convex/react";
+import { api, CLAUDE_MODELS } from "@conductor/backend";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
+  Button,
+} from "@conductor/ui";
+import { BranchSelect } from "@/lib/components/BranchSelect";
+import { IconPlus, IconX } from "@tabler/icons-react";
+
+export function ConfigClient() {
+  const { repo, repoId } = useRepo();
+  const updateConfig = useMutation(api.githubRepos.updateConfig);
+
+  return (
+    <PageWrapper title="Config">
+      <div className="space-y-4">
+        <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+          <h3 className="text-sm font-medium">Repository Configuration</h3>
+
+          <div className="grid gap-4">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Default Base Branch
+              </label>
+              <BranchSelect
+                value={repo.defaultBaseBranch ?? "main"}
+                onValueChange={(val) =>
+                  updateConfig({ repoId, defaultBaseBranch: val || undefined })
+                }
+                className="h-8 text-xs"
+                placeholder="Select a branch"
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                The default branch used when creating quick tasks. Defaults to{" "}
+                <code>main</code> if not set.
+              </p>
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Default Model
+              </label>
+              <Select
+                value={repo.defaultModel ?? "sonnet"}
+                onValueChange={(val) => {
+                  const model = CLAUDE_MODELS.find((m) => m === val);
+                  if (model) updateConfig({ repoId, defaultModel: model });
+                }}
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CLAUDE_MODELS.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {m.charAt(0).toUpperCase() + m.slice(1)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                The default model used when creating new tasks. Defaults to{" "}
+                <code>Sonnet</code> if not set.
+              </p>
+            </div>
+
+            {repo.parentRepoId && (
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                  Deployment Project Name
+                </label>
+                <Input
+                  className="h-8 text-xs"
+                  placeholder="e.g. my-vercel-project"
+                  defaultValue={repo.deploymentProjectName ?? ""}
+                  onBlur={(e) => {
+                    const val = e.target.value.trim();
+                    if (val !== (repo.deploymentProjectName ?? "")) {
+                      updateConfig({
+                        repoId,
+                        deploymentProjectName: val || undefined,
+                      });
+                    }
+                  }}
+                />
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  Vercel or Netlify project name for this app. Used to match the
+                  correct preview deployment in monorepos.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DomainsSection />
+      </div>
+    </PageWrapper>
+  );
+}
+
+function extractHostname(raw: string): string {
+  try {
+    const url = new URL(raw.includes("://") ? raw : `https://${raw}`);
+    return url.hostname;
+  } catch {
+    return raw;
+  }
+}
+
+function DomainsSection() {
+  const { repo, repoId } = useRepo();
+  const updateConfig = useMutation(api.githubRepos.updateConfig);
+  const [newDomain, setNewDomain] = useState("");
+
+  const domains = repo.domains ?? [];
+
+  const addDomain = () => {
+    const raw = newDomain.trim().toLowerCase();
+    if (!raw) return;
+    const hostname = extractHostname(raw);
+    if (domains.includes(hostname)) return;
+    updateConfig({ repoId, domains: [...domains, hostname] });
+    setNewDomain("");
+  };
+
+  const removeDomain = (domain: string) => {
+    updateConfig({ repoId, domains: domains.filter((d) => d !== domain) });
+  };
+
+  return (
+    <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+      <div>
+        <h3 className="text-sm font-medium">Domains</h3>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Hostnames where this app is deployed. The Chrome extension will
+          auto-select this repo when browsing these domains.
+        </p>
+      </div>
+
+      {domains.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {domains.map((domain) => (
+            <span
+              key={domain}
+              className="inline-flex items-center gap-1 rounded-md bg-muted/50 px-2 py-1 text-xs"
+            >
+              {domain}
+              <button
+                type="button"
+                onClick={() => removeDomain(domain)}
+                className="ml-0.5 rounded hover:bg-muted-foreground/20 p-0.5"
+              >
+                <IconX size={12} />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Input
+          className="h-8 text-xs flex-1"
+          placeholder="e.g. myapp.com or localhost:3000"
+          value={newDomain}
+          onChange={(e) => setNewDomain(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") addDomain();
+          }}
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8"
+          onClick={addDomain}
+          disabled={!newDomain.trim()}
+        >
+          <IconPlus size={14} />
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/EnvVariablesClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/EnvVariablesClient.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useQuery, useMutation, useAction } from "convex/react";
+import { api } from "@conductor/backend";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { EnvVarsTable } from "@/lib/components/EnvVarsTable";
+
+export function EnvVariablesClient() {
+  const { repoId } = useRepo();
+  const vars = useQuery(api.repoEnvVars.list, { repoId });
+  const upsertVar = useAction(api.repoEnvVarsActions.upsertVar);
+  const revealValue = useAction(api.repoEnvVarsActions.revealValue);
+  const removeVar = useMutation(api.repoEnvVars.removeVar);
+  const toggleSandboxExclude = useMutation(
+    api.repoEnvVars.toggleSandboxExclude,
+  );
+
+  return (
+    <EnvVarsTable
+      vars={vars}
+      onUpsert={async (key, value, sandboxExclude) => {
+        await upsertVar({ repoId, key, value, sandboxExclude });
+      }}
+      onReveal={(key) => revealValue({ repoId, key })}
+      onRemove={async (key) => {
+        await removeVar({ repoId, key });
+      }}
+      onToggleSandboxExclude={async (key, sandboxExclude) => {
+        await toggleSandboxExclude({ repoId, key, sandboxExclude });
+      }}
+      description="Repo-specific variables injected into sandboxes for this repository."
+    />
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/EnvVariablesPageClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/EnvVariablesPageClient.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQueryState } from "nuqs";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import { Tabs, TabsList, TabsTrigger } from "@conductor/ui";
+import { envVarTabParser } from "@/lib/search-params";
+import { EnvVariablesClient } from "./EnvVariablesClient";
+import { TeamEnvVarsClient } from "./TeamEnvVarsClient";
+
+export function EnvVariablesPageClient() {
+  const [tab, setTab] = useQueryState("tab", envVarTabParser);
+
+  return (
+    <PageWrapper title="Environment Variables">
+      <Tabs
+        value={tab}
+        onValueChange={(value) => {
+          if (value === "repo" || value === "team") {
+            setTab(value);
+          }
+        }}
+      >
+        <TabsList className="mb-4">
+          <TabsTrigger value="repo">Repo</TabsTrigger>
+          <TabsTrigger value="team">Team</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      {tab === "repo" && <EnvVariablesClient />}
+      {tab === "team" && <TeamEnvVarsClient />}
+    </PageWrapper>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/LogsClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/LogsClient.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMemo, useCallback } from "react";
+import { useQueryState, useQueryStates } from "nuqs";
+import { useQuery } from "convex/react";
+import { api } from "@conductor/backend";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import { timeRangeParser, logEntityTypesParser } from "@/lib/search-params";
+import { getStartTime } from "@/lib/components/analytics/TimeRangeFilter";
+import { Spinner } from "@conductor/ui";
+import { IconFileOff } from "@tabler/icons-react";
+import { parseResultEvent } from "./logs/_utils";
+import { LogsSummaryGrid } from "./logs/_components/LogsSummaryGrid";
+import { LogsHeader } from "./logs/_components/LogsHeader";
+import { LogEntryGroup } from "./logs/_components/LogEntryGroup";
+
+export function LogsClient() {
+  const { repo } = useRepo();
+  const [timeRange, setTimeRange] = useQueryState("range", timeRangeParser);
+  const [{ entityTypes }, setEntityParams] = useQueryStates({
+    entityTypes: logEntityTypesParser,
+  });
+
+  const visibleTypes = useMemo(() => new Set(entityTypes), [entityTypes]);
+
+  const handleTypeToggle = useCallback(
+    (type: string, allTypes: string[]) => {
+      const next = new Set(visibleTypes.size === 0 ? allTypes : visibleTypes);
+      if (next.has(type)) {
+        if (next.size === 1) return;
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      const isAll = allTypes.every((t) => next.has(t));
+      void setEntityParams({ entityTypes: isAll ? [] : [...next] });
+    },
+    [visibleTypes, setEntityParams],
+  );
+
+  const startTime = useMemo(() => getStartTime(timeRange), [timeRange]);
+
+  const logs = useQuery(api.logs.listByRepo, {
+    repoId: repo._id,
+    startTime: startTime ?? undefined,
+    entityTypes: entityTypes.length > 0 ? entityTypes : undefined,
+  });
+
+  const {
+    totalCost,
+    totalInput,
+    totalOutput,
+    totalDuration,
+    grouped,
+    availableTypes,
+  } = useMemo(() => {
+    if (!logs)
+      return {
+        totalCost: 0,
+        totalInput: 0,
+        totalOutput: 0,
+        totalDuration: 0,
+        grouped: [],
+        availableTypes: [],
+      };
+
+    let cost = 0;
+    let input = 0;
+    let output = 0;
+    let duration = 0;
+    const groups = new Map<string, { logs: typeof logs; total: number }>();
+
+    for (const log of logs) {
+      const parsed = parseResultEvent(log.rawResultEvent);
+      cost += parsed.costUsd;
+      input += parsed.inputTokens;
+      output += parsed.outputTokens;
+      duration += parsed.durationMs;
+      const existing = groups.get(log.entityType);
+      if (existing) {
+        existing.logs.push(log);
+        existing.total += parsed.costUsd;
+      } else {
+        groups.set(log.entityType, {
+          logs: [log],
+          total: parsed.costUsd,
+        });
+      }
+    }
+
+    const sorted = Array.from(groups.entries())
+      .sort((a, b) => b[1].total - a[1].total)
+      .map(([type, data]) => ({ type, ...data }));
+
+    return {
+      totalCost: cost,
+      totalInput: input,
+      totalOutput: output,
+      totalDuration: duration,
+      grouped: sorted,
+      availableTypes: sorted.map((g) => g.type),
+    };
+  }, [logs]);
+
+  return (
+    <PageWrapper
+      title={
+        logs !== undefined && logs.length > 0 ? `Logs (${logs.length})` : "Logs"
+      }
+      headerRight={
+        <LogsHeader
+          visibleTypes={visibleTypes}
+          availableTypes={availableTypes}
+          onTypeToggle={handleTypeToggle}
+          timeRange={timeRange}
+          onTimeRangeChange={setTimeRange}
+        />
+      }
+    >
+      {logs === undefined ? (
+        <div className="flex items-center justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      ) : logs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+          <div className="rounded-xl bg-secondary p-3">
+            <IconFileOff size={24} />
+          </div>
+          <p className="text-sm">No logs found for this time range</p>
+        </div>
+      ) : (
+        <div className="space-y-5">
+          <LogsSummaryGrid
+            totalCost={totalCost}
+            totalDuration={totalDuration}
+            totalInput={totalInput}
+            totalOutput={totalOutput}
+          />
+          <div className="space-y-1">
+            {grouped.map((group) => (
+              <LogEntryGroup
+                key={group.type}
+                type={group.type}
+                logs={group.logs}
+                total={group.total}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </PageWrapper>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/McpConfigClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/McpConfigClient.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@conductor/backend";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import {
+  Textarea,
+  Button,
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+  DialogFooter,
+} from "@conductor/ui";
+import { IconPencil } from "@tabler/icons-react";
+
+export function McpConfigClient() {
+  const { repo, repoId } = useRepo();
+  const updateMcpRootPrompt = useMutation(api.githubRepos.updateMcpRootPrompt);
+
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const prompt = repo.mcpRootPrompt ?? "";
+
+  const handleOpen = useCallback(() => {
+    setDraft(prompt);
+    setOpen(true);
+  }, [prompt]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      await updateMcpRootPrompt({
+        repoId,
+        mcpRootPrompt: draft.trim() || undefined,
+      });
+      setOpen(false);
+    } finally {
+      setSaving(false);
+    }
+  }, [updateMcpRootPrompt, repoId, draft]);
+
+  const isDirty = draft !== prompt;
+
+  return (
+    <PageWrapper title="MCP Config">
+      <div className="space-y-4">
+        <div className="rounded-lg bg-muted/40 p-3 space-y-3 sm:p-4">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h3 className="text-sm font-medium">Root Prompt</h3>
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Freeform instructions injected into MCP server context to guide
+                the AI on your data topology. Shared across all apps in a
+                monorepo.
+              </p>
+            </div>
+
+            <Dialog open={open} onOpenChange={setOpen}>
+              <DialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 shrink-0"
+                  onClick={handleOpen}
+                >
+                  <IconPencil size={14} />
+                  Edit
+                </Button>
+              </DialogTrigger>
+
+              <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle>Edit Root Prompt</DialogTitle>
+                  <DialogDescription>
+                    Instructions injected into MCP server context. Shared across
+                    all apps in a monorepo.
+                  </DialogDescription>
+                </DialogHeader>
+
+                <DialogBody>
+                  <Textarea
+                    className="min-h-[280px] text-xs font-mono"
+                    placeholder="Describe your repo's data topology, table relationships, or any context the MCP server should know..."
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                  />
+                </DialogBody>
+
+                <DialogFooter>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleSave}
+                    disabled={!isDirty || saving}
+                  >
+                    {saving ? "Saving..." : "Save"}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
+
+          {prompt ? (
+            <pre className="whitespace-pre-wrap text-xs font-mono text-foreground/80 leading-relaxed">
+              {prompt}
+            </pre>
+          ) : (
+            <p className="text-xs text-muted-foreground italic">
+              No root prompt configured.
+            </p>
+          )}
+        </div>
+      </div>
+    </PageWrapper>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/MonorepoClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/MonorepoClient.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useAction, useMutation, useQuery } from "convex/react";
+import { api } from "@conductor/backend";
+import type { FunctionReturnType } from "convex/server";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import {
+  Card,
+  CardContent,
+  Button,
+  Input,
+  Spinner,
+  Badge,
+} from "@conductor/ui";
+import {
+  IconFolders,
+  IconPlus,
+  IconCheck,
+  IconTerminal2,
+  IconAlertCircle,
+  IconRefresh,
+  IconEye,
+  IconEyeOff,
+} from "@tabler/icons-react";
+
+type DetectedApp = FunctionReturnType<
+  typeof api.github.detectMonorepoApps
+>[number];
+
+export function MonorepoClient() {
+  const { repo } = useRepo();
+  const detectApps = useAction(api.github.detectMonorepoApps);
+  const createRepo = useMutation(api.githubRepos.create);
+  const toggleHidden = useMutation(api.githubRepos.toggleHidden);
+  const allRepos = useQuery(api.githubRepos.list, { includeHidden: true });
+
+  const [detected, setDetected] = useState<ReadonlyArray<DetectedApp>>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [addingPath, setAddingPath] = useState<string | null>(null);
+  const [customPath, setCustomPath] = useState("");
+
+  const connectedApps = (allRepos ?? []).filter(
+    (r) => r.owner === repo.owner && r.name === repo.name && r.rootDirectory,
+  );
+
+  const connectedPaths = new Set(connectedApps.map((r) => r.rootDirectory));
+
+  const runDetection = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const apps = await detectApps({
+        installationId: repo.installationId,
+        owner: repo.owner,
+        name: repo.name,
+      });
+      setDetected(apps.filter((a) => a.path.startsWith("apps/")));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Detection failed");
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    void runDetection();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repo.owner, repo.name, repo.installationId]);
+
+  const handleAdd = async (path: string) => {
+    setAddingPath(path);
+    try {
+      await createRepo({
+        owner: repo.owner,
+        name: repo.name,
+        installationId: repo.installationId,
+        githubId: repo.githubId,
+        rootDirectory: path,
+        teamId: repo.teamId,
+      });
+    } catch (err) {
+      console.error("Failed to add app:", err);
+    }
+    setAddingPath(null);
+  };
+
+  const handleAddCustom = async () => {
+    const trimmed = customPath.trim().replace(/^\/+|\/+$/g, "");
+    if (!trimmed) return;
+    await handleAdd(trimmed);
+    setCustomPath("");
+  };
+
+  return (
+    <PageWrapper
+      title="Monorepo Apps"
+      headerRight={
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={loading}
+          onClick={() => void runDetection()}
+          className="motion-press border-border text-muted-foreground"
+        >
+          <IconRefresh size={16} className={loading ? "animate-spin" : ""} />
+          <span className="hidden sm:inline">Re-detect</span>
+        </Button>
+      }
+    >
+      {connectedApps.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium text-foreground">
+            Connected Apps
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Toggle visibility to hide apps from the sidebar and home page
+            without removing them.
+          </p>
+          <div className="space-y-2">
+            {connectedApps.map((app) => (
+              <Card key={app._id} className="ui-surface-strong">
+                <CardContent className="flex items-center gap-2 p-2.5 sm:gap-3 sm:p-3">
+                  <IconFolders size={18} className="text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-foreground">
+                      {app.rootDirectory?.split("/").pop()}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {app.rootDirectory}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant={app.hidden ? "outline" : "ghost"}
+                    onClick={() =>
+                      toggleHidden({
+                        repoId: app._id,
+                        hidden: app.hidden !== true,
+                      })
+                    }
+                    className={
+                      app.hidden
+                        ? "motion-press gap-1.5 border-border text-muted-foreground"
+                        : "motion-press gap-1.5 text-muted-foreground hover:text-foreground"
+                    }
+                  >
+                    {app.hidden ? (
+                      <>
+                        <IconEyeOff size={14} />
+                        Hidden
+                      </>
+                    ) : (
+                      <>
+                        <IconEye size={14} />
+                        Visible
+                      </>
+                    )}
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium text-foreground">Detect Apps</h3>
+        <p className="text-xs text-muted-foreground">
+          Scan{" "}
+          <span className="font-medium text-foreground">
+            {repo.owner}/{repo.name}
+          </span>{" "}
+          for workspace apps and add them as separate repositories.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="flex flex-col items-center gap-3">
+            <Spinner size="md" />
+            <p className="text-sm text-muted-foreground">
+              Scanning workspace configuration...
+            </p>
+          </div>
+        </div>
+      ) : error ? (
+        <Card className="border-destructive/30">
+          <CardContent className="flex items-center gap-3 p-4">
+            <IconAlertCircle size={20} className="text-destructive" />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                Detection failed
+              </p>
+              <p className="text-xs text-muted-foreground">{error}</p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : detected.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 p-8 text-center">
+            <IconFolders size={28} className="text-muted-foreground/50" />
+            <p className="text-sm font-medium text-foreground">
+              No workspace apps detected
+            </p>
+            <p className="text-xs text-muted-foreground">
+              This repository doesn't appear to have a monorepo workspace
+              configuration (package.json workspaces or pnpm-workspace.yaml).
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {detected.map((app) => {
+            const isConnected = connectedPaths.has(app.path);
+            const isAdding = addingPath === app.path;
+
+            return (
+              <Card key={app.path} className="ui-surface-strong">
+                <CardContent className="flex items-center gap-2 p-2.5 sm:gap-3 sm:p-3">
+                  <IconFolders size={18} className="text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {app.name}
+                      </p>
+                      {app.hasDevScript && (
+                        <Badge
+                          variant="secondary"
+                          className="gap-1 text-[10px]"
+                        >
+                          <IconTerminal2 size={10} />
+                          dev
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">{app.path}</p>
+                  </div>
+                  {isConnected ? (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 border-primary/30 text-primary"
+                    >
+                      <IconCheck size={12} />
+                      Added
+                    </Badge>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={isAdding}
+                      onClick={() => void handleAdd(app.path)}
+                      className="motion-press"
+                    >
+                      {isAdding ? (
+                        <Spinner size="sm" />
+                      ) : (
+                        <IconPlus size={14} />
+                      )}
+                      Add
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <Card className="mt-2">
+        <CardContent className="p-3">
+          <p className="mb-2 text-xs font-medium text-muted-foreground">
+            Custom root directory
+          </p>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleAddCustom();
+            }}
+            className="flex items-center gap-2"
+          >
+            <Input
+              placeholder="e.g. apps/api"
+              value={customPath}
+              onChange={(e) => setCustomPath(e.target.value)}
+              className="flex-1"
+            />
+            <Button
+              type="submit"
+              size="sm"
+              disabled={
+                !customPath.trim() ||
+                addingPath === customPath.trim().replace(/^\/+|\/+$/g, "")
+              }
+              className="motion-press"
+            >
+              <IconPlus size={14} />
+              Add
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </PageWrapper>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import {
+  Button,
+  Spinner,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@conductor/ui";
+import { BranchSelect } from "@/lib/components/BranchSelect";
+import {
+  CronScheduleCard,
+  describeCron,
+} from "@/lib/components/CronScheduleCard";
+import {
+  IconCamera,
+  IconPlayerPlay,
+  IconTrash,
+  IconChevronDown,
+  IconChevronRight,
+  IconCheck,
+  IconX,
+  IconClock,
+  IconExternalLink,
+} from "@tabler/icons-react";
+import { formatDurationMs } from "@/lib/utils/formatDuration";
+
+export function SnapshotsClient() {
+  const { repoId, owner, name: repoName } = useRepo();
+  const snapshot = useQuery(api.repoSnapshots.getRepoSnapshot, { repoId });
+  const builds = useQuery(
+    api.repoSnapshots.listBuilds,
+    snapshot ? { repoSnapshotId: snapshot._id } : "skip",
+  );
+  const saveRepoSnapshot = useMutation(api.repoSnapshots.saveRepoSnapshot);
+  const deleteRepoSnapshot = useMutation(api.repoSnapshots.deleteRepoSnapshot);
+  const startBuild = useMutation(api.repoSnapshots.startBuild);
+
+  const [schedule, setSchedule] = useState("manual");
+  const [workflowRef, setWorkflowRef] = useState("main");
+  const [saving, setSaving] = useState(false);
+  const [building, setBuilding] = useState(false);
+  const [expandedBuild, setExpandedBuild] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (snapshot === undefined) return;
+
+    if (snapshot) {
+      setSchedule(snapshot.schedule);
+      setWorkflowRef(snapshot.workflowRef ?? "main");
+      return;
+    }
+
+    setSchedule("manual");
+    setWorkflowRef("main");
+  }, [snapshot?._id, snapshot?.updatedAt, snapshot === null]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await saveRepoSnapshot({
+        repoId,
+        schedule,
+        workflowRef: workflowRef.trim() || undefined,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!snapshot) return;
+    await deleteRepoSnapshot({ repoSnapshotId: snapshot._id });
+    setSchedule("manual");
+    setWorkflowRef("main");
+  };
+
+  const handleRebuild = async () => {
+    if (!snapshot) return;
+    setBuilding(true);
+    try {
+      await startBuild({ repoSnapshotId: snapshot._id });
+    } catch {
+      // Error already shown in UI via build status
+    } finally {
+      setBuilding(false);
+    }
+  };
+
+  const isRunning =
+    builds && builds.length > 0 && builds[0].status === "running";
+  const lastBuild = builds && builds.length > 0 ? builds[0] : null;
+
+  if (snapshot === undefined) {
+    return (
+      <PageWrapper title="Snapshots">
+        <div className="flex items-center justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      </PageWrapper>
+    );
+  }
+
+  return (
+    <PageWrapper title="Snapshots">
+      <Tabs defaultValue="configuration" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="configuration">Configuration</TabsTrigger>
+          <TabsTrigger value="status">Status</TabsTrigger>
+          <TabsTrigger value="builds">Builds</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="configuration" className="space-y-4">
+          {snapshot && (
+            <div className="flex justify-end">
+              <Button size="sm" variant="destructive" onClick={handleDelete}>
+                <IconTrash size={14} className="mr-1.5" />
+                Delete Config
+              </Button>
+            </div>
+          )}
+
+          <CronScheduleCard
+            value={schedule}
+            onChange={setSchedule}
+            allowManual
+          />
+
+          <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+            <h3 className="text-sm font-medium">Workflow Branch</h3>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Branch
+              </label>
+              <BranchSelect
+                value={workflowRef}
+                onValueChange={setWorkflowRef}
+                className="h-8 text-xs"
+                placeholder="Select a branch"
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Branch where <code>rebuild-snapshot.yml</code> exists. Defaults
+                to <code>main</code> if empty.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-[11px] text-muted-foreground">
+              Requires <code className="font-mono">rebuild-snapshot.yml</code>{" "}
+              workflow on target branch and{" "}
+              <code className="font-mono">DAYTONA_API_KEY</code> secret in the
+              repo.
+            </p>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={saving}
+              className="shrink-0"
+            >
+              {saving ? <Spinner size="sm" className="mr-1.5" /> : null}
+              Save
+            </Button>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="status" className="space-y-6">
+          {snapshot ? (
+            <div className="rounded-lg bg-muted/40 p-4 space-y-3">
+              <h3 className="text-sm font-medium">Current Status</h3>
+              <div className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2 sm:gap-4">
+                <div>
+                  <span className="text-muted-foreground">Snapshot Name</span>
+                  <p className="font-mono mt-0.5">{snapshot.snapshotName}</p>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Schedule</span>
+                  <p className="mt-0.5">
+                    {snapshot.schedule === "manual"
+                      ? "Manual"
+                      : (() => {
+                          const result = describeCron(snapshot.schedule);
+                          return result.valid
+                            ? `${result.text} (UTC)`
+                            : snapshot.schedule;
+                        })()}
+                  </p>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Workflow Branch</span>
+                  <p className="font-mono mt-0.5">
+                    {snapshot.workflowRef ?? "main"}
+                  </p>
+                </div>
+                {lastBuild && (
+                  <>
+                    <div>
+                      <span className="text-muted-foreground">Last Build</span>
+                      <p className="mt-0.5">
+                        {new Date(lastBuild.startedAt).toLocaleDateString(
+                          "en-GB",
+                          {
+                            day: "numeric",
+                            month: "short",
+                            year: "numeric",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          },
+                        )}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Status</span>
+                      <p className="mt-0.5">
+                        <BuildStatusBadge status={lastBuild.status} />
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Warmup</span>
+                      <p className="mt-0.5">
+                        <WarmupStatusBadge status={lastBuild.warmupStatus} />
+                      </p>
+                    </div>
+                  </>
+                )}
+              </div>
+              <Button
+                size="sm"
+                onClick={handleRebuild}
+                disabled={building || isRunning}
+              >
+                {isRunning ? (
+                  <Spinner size="sm" className="mr-1.5" />
+                ) : (
+                  <IconPlayerPlay size={14} className="mr-1.5" />
+                )}
+                {isRunning ? "Building..." : "Rebuild Now"}
+              </Button>
+            </div>
+          ) : (
+            <div className="rounded-lg bg-muted/40 p-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                No snapshot configured yet. Configure one in the Configuration
+                tab.
+              </p>
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="builds" className="space-y-6">
+          {snapshot && builds && builds.length > 0 ? (
+            <div className="rounded-lg bg-muted/40 overflow-hidden">
+              <div className="px-4 py-3">
+                <h3 className="text-sm font-medium">Build History</h3>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs min-w-[320px] sm:min-w-[420px]">
+                  <thead>
+                    <tr className="text-left text-muted-foreground">
+                      <th className="px-2 py-2 font-medium w-8 sm:px-4" />
+                      <th className="px-2 py-2 font-medium sm:px-4">Date</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">
+                        Duration
+                      </th>
+                      <th className="px-2 py-2 font-medium sm:px-4">Trigger</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">Status</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">Warmup</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {builds.map((build) => {
+                      const isExpanded = expandedBuild === build._id;
+                      const duration = build.completedAt
+                        ? formatDurationMs(build.completedAt - build.startedAt)
+                        : build.status === "running"
+                          ? "Running..."
+                          : "-";
+                      return (
+                        <BuildRow
+                          key={build._id}
+                          build={build}
+                          isExpanded={isExpanded}
+                          duration={duration}
+                          repoFullName={`${owner}/${repoName}`}
+                          onToggle={() =>
+                            setExpandedBuild(isExpanded ? null : build._id)
+                          }
+                        />
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : snapshot && builds && builds.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+              <IconCamera size={48} className="mb-3 opacity-40" />
+              <p className="text-sm">
+                No builds yet. Click "Rebuild Now" to start.
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-lg bg-muted/40 p-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                No snapshot configured yet. Configure one in the Configuration
+                tab.
+              </p>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </PageWrapper>
+  );
+}
+
+function BuildRow({
+  build,
+  isExpanded,
+  duration,
+  repoFullName,
+  onToggle,
+}: {
+  build: {
+    _id: Id<"snapshotBuilds">;
+    status: "running" | "success" | "error";
+    triggeredBy: "cron" | "manual";
+    logs: string;
+    error?: string;
+    workflowRunId?: number;
+    startedAt: number;
+    completedAt?: number;
+    warmupStatus?: "pending" | "success" | "error";
+    warmupError?: string;
+  };
+  isExpanded: boolean;
+  duration: string;
+  repoFullName: string;
+  onToggle: () => void;
+}) {
+  const runUrl = build.workflowRunId
+    ? `https://github.com/${repoFullName}/actions/runs/${build.workflowRunId}`
+    : null;
+
+  return (
+    <>
+      <tr className="cursor-pointer hover:bg-muted/30" onClick={onToggle}>
+        <td className="px-2 py-2 sm:px-4">
+          {isExpanded ? (
+            <IconChevronDown size={14} />
+          ) : (
+            <IconChevronRight size={14} />
+          )}
+        </td>
+        <td className="px-2 py-2 sm:px-4">
+          {new Date(build.startedAt).toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </td>
+        <td className="px-2 py-2 sm:px-4">{duration}</td>
+        <td className="px-2 py-2 capitalize sm:px-4">{build.triggeredBy}</td>
+        <td className="px-2 py-2 sm:px-4">
+          <BuildStatusBadge status={build.status} />
+        </td>
+        <td className="px-2 py-2 sm:px-4">
+          <WarmupStatusBadge status={build.warmupStatus} />
+        </td>
+      </tr>
+      {isExpanded && (
+        <tr>
+          <td colSpan={6} className="px-4 py-3">
+            {build.error && (
+              <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                {build.error}
+              </div>
+            )}
+            {build.warmupError && (
+              <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                Warmup failed: {build.warmupError}
+              </div>
+            )}
+            {runUrl && (
+              <a
+                href={runUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mb-2 inline-flex items-center gap-1 text-xs text-blue-500 hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <IconExternalLink size={12} />
+                View GitHub Actions Run
+              </a>
+            )}
+            {build.logs ? (
+              <pre className="max-h-64 overflow-auto rounded bg-muted/50 p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap sm:p-3 sm:text-[11px]">
+                {build.logs}
+              </pre>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No logs available.
+              </p>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function BuildStatusBadge({
+  status,
+}: {
+  status: "running" | "success" | "error";
+}) {
+  if (status === "running") {
+    return (
+      <span className="inline-flex items-center gap-1 text-blue-500">
+        <IconClock size={12} />
+        Running
+      </span>
+    );
+  }
+  if (status === "success") {
+    return (
+      <span className="inline-flex items-center gap-1 text-green-500">
+        <IconCheck size={12} />
+        Success
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-destructive">
+      <IconX size={12} />
+      Error
+    </span>
+  );
+}
+
+function WarmupStatusBadge({
+  status,
+}: {
+  status?: "pending" | "success" | "error";
+}) {
+  if (!status) {
+    return <span className="text-muted-foreground">&mdash;</span>;
+  }
+  if (status === "pending") {
+    return (
+      <span className="inline-flex items-center gap-1 text-blue-500">
+        <IconClock size={12} />
+        Pending
+      </span>
+    );
+  }
+  if (status === "success") {
+    return (
+      <span className="inline-flex items-center gap-1 text-green-500">
+        <IconCheck size={12} />
+        Warmed
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-destructive">
+      <IconX size={12} />
+      Failed
+    </span>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/TeamEnvVarsClient.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/TeamEnvVarsClient.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useQuery, useMutation, useAction } from "convex/react";
+import { api } from "@conductor/backend";
+import { Card, CardContent } from "@conductor/ui";
+import { Link } from "@tanstack/react-router";
+import { IconUsers } from "@tabler/icons-react";
+import { useRepo } from "@/lib/contexts/RepoContext";
+import { EnvVarsTable } from "@/lib/components/EnvVarsTable";
+
+export function TeamEnvVarsClient() {
+  const { repo } = useRepo();
+
+  const team = useQuery(
+    api.teams.get,
+    repo.teamId ? { id: repo.teamId } : "skip",
+  );
+
+  const teamEnvVars = useQuery(
+    api.teamEnvVars.list,
+    repo.teamId ? { teamId: repo.teamId } : "skip",
+  );
+
+  const upsertTeamVar = useAction(api.teamEnvVarsActions.upsertVar);
+  const revealTeamValue = useAction(api.teamEnvVarsActions.revealValue);
+  const removeTeamVar = useMutation(api.teamEnvVars.removeVar);
+  const toggleSandboxExclude = useMutation(
+    api.teamEnvVars.toggleSandboxExclude,
+  );
+
+  if (!repo.teamId || !team) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center py-12">
+          <IconUsers size={48} className="mb-4 text-muted-foreground/50" />
+          <p className="mb-2 text-sm font-medium">No team configured</p>
+          <p className="text-xs text-muted-foreground">
+            This repository is not part of any team yet
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <EnvVarsTable
+        vars={teamEnvVars}
+        description="Team-level variables inherited by all repositories in this team."
+        onUpsert={async (key, value, sandboxExclude) => {
+          if (!repo.teamId) return;
+          await upsertTeamVar({
+            teamId: repo.teamId,
+            key,
+            value,
+            sandboxExclude,
+          });
+        }}
+        onReveal={async (key) => {
+          if (!repo.teamId) return null;
+          return await revealTeamValue({ teamId: repo.teamId, key });
+        }}
+        onRemove={async (key) => {
+          if (!repo.teamId) return;
+          await removeTeamVar({ teamId: repo.teamId, key });
+        }}
+        onToggleSandboxExclude={async (key, sandboxExclude) => {
+          if (!repo.teamId) return;
+          await toggleSandboxExclude({
+            teamId: repo.teamId,
+            key,
+            sandboxExclude,
+          });
+        }}
+      />
+      <div className="flex items-center gap-2">
+        <IconUsers size={16} className="text-muted-foreground" />
+        <p className="text-sm">
+          Team: <span className="font-medium">{team.name}</span>
+        </p>
+        <span className="text-muted-foreground">•</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId: team._id }}
+          target="_blank"
+          className="text-sm text-primary hover:underline"
+        >
+          Manage team variables →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/audits.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/audits.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AuditsClient } from "./AuditsClient";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/settings/audits")({
+  component: AuditsClient,
+});

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/audits/_components/AddCategoryForm.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/audits/_components/AddCategoryForm.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { api } from "@conductor/backend";
+import { Button, Input, Textarea } from "@conductor/ui";
+import { IconPlus } from "@tabler/icons-react";
+import type { Id } from "@conductor/backend";
+import { useCallback, useState } from "react";
+
+export function AddCategoryForm(props: {
+  repoId: Id<"githubRepos">;
+  appId?: Id<"githubRepos">;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const createCategory = useMutation(api.auditCategories.create);
+
+  const handleSubmit = useCallback(async () => {
+    if (!name.trim() || !description.trim()) return;
+    await createCategory({
+      repoId: props.repoId,
+      name: name.trim(),
+      description: description.trim(),
+      appId: props.appId,
+    });
+    setName("");
+    setDescription("");
+  }, [name, description, createCategory, props.repoId, props.appId]);
+
+  return (
+    <div className="grid gap-3">
+      <div>
+        <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+          Name
+        </label>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Performance"
+          className="h-8 text-xs"
+        />
+      </div>
+      <div>
+        <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+          Description
+        </label>
+        <Textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe what this audit should check for..."
+          className="text-xs min-h-[60px] resize-none"
+        />
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          This description is sent to the AI as instructions for what to audit.
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleSubmit}
+        disabled={!name.trim() || !description.trim()}
+        className="w-fit"
+      >
+        <IconPlus size={14} />
+        Add Category
+      </Button>
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/config.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/config.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ConfigClient } from "./ConfigClient";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/settings/config")({
+  component: ConfigClient,
+});

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/env-variables.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/env-variables.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { EnvVariablesPageClient } from "./EnvVariablesPageClient";
+
+export const Route = createFileRoute(
+  "/_repo/$owner/$repo/settings/env-variables",
+)({
+  component: EnvVariablesPageClient,
+});

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/index.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/index.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/settings/")({
+  component: SettingsRedirect,
+});
+
+function SettingsRedirect() {
+  const navigate = useNavigate();
+  const { owner, repo } = Route.useParams();
+  useEffect(() => {
+    navigate({
+      to: "/_repo/$owner/$repo/settings/config",
+      params: { owner, repo },
+      replace: true,
+    });
+  }, [navigate, owner, repo]);
+  return null;
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LogsClient } from "./LogsClient";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/settings/logs")({
+  component: LogsClient,
+});

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_components/LogEntryGroup.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_components/LogEntryGroup.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import type { FunctionReturnType } from "convex/server";
+import type { api } from "@conductor/backend";
+import {
+  Badge,
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@conductor/ui";
+import { IconChevronRight, IconCode } from "@tabler/icons-react";
+import dayjs from "@conductor/shared/dates";
+import { formatDurationMsShort } from "@/lib/utils/formatDuration";
+import {
+  parseResultEvent,
+  formatCost,
+  formatTokens,
+  labelFor,
+} from "../_utils";
+
+type LogEntry = FunctionReturnType<typeof api.logs.listByRepo>[number];
+
+interface LogEntryGroupProps {
+  type: string;
+  logs: LogEntry[];
+  total: number;
+}
+
+function RawEventViewer({ raw }: { raw: string | undefined }) {
+  const [open, setOpen] = useState(false);
+  if (!raw) return null;
+
+  let formatted = raw;
+  try {
+    formatted = JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {}
+
+  return (
+    <div className="mt-2">
+      <button
+        onClick={() => setOpen((p) => !p)}
+        className="motion-base flex items-center gap-1.5 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-secondary hover:text-foreground"
+      >
+        <IconCode size={12} />
+        {open ? "Hide raw" : "View raw"}
+      </button>
+      {open && (
+        <pre className="mt-2 max-h-48 overflow-auto rounded-lg bg-muted/50 p-3 font-mono text-xs leading-relaxed text-muted-foreground">
+          {formatted}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function LogEntryGroup({ type, logs, total }: LogEntryGroupProps) {
+  return (
+    <Collapsible defaultOpen>
+      <CollapsibleTrigger className="motion-base flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium hover:bg-muted/60 sm:gap-2.5 sm:px-4 [&[data-state=open]>svg:first-child]:rotate-90">
+        <IconChevronRight
+          size={14}
+          className="shrink-0 text-muted-foreground transition-transform"
+        />
+        <span className="tracking-[-0.01em]">{labelFor(type)}</span>
+        <Badge variant="secondary" className="ml-1 tabular-nums">
+          {logs.length}
+        </Badge>
+        <span className="ml-auto font-mono text-xs text-muted-foreground">
+          {formatCost(total)}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="ml-2 pl-3 sm:ml-4 sm:pl-4">
+          {logs.map((log) => {
+            const evt = parseResultEvent(log.rawResultEvent);
+            return (
+              <div
+                key={log._id}
+                className="motion-base rounded-lg px-3 py-2.5 transition-colors hover:bg-accent/25"
+              >
+                <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-3">
+                  <span className="min-w-0 flex-1 truncate text-sm">
+                    {log.entityTitle}
+                  </span>
+                  <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
+                    <Badge variant="outline" className="font-mono text-[11px]">
+                      {evt.model}
+                    </Badge>
+                    <span className="text-xs tabular-nums text-muted-foreground">
+                      {formatTokens(evt.inputTokens)} in /{" "}
+                      {formatTokens(evt.outputTokens)} out
+                    </span>
+                    {evt.durationMs > 0 && (
+                      <span className="text-xs tabular-nums text-muted-foreground">
+                        {formatDurationMsShort(evt.durationMs)}
+                      </span>
+                    )}
+                    <span className="font-mono text-xs font-medium tabular-nums">
+                      {formatCost(evt.costUsd)}
+                    </span>
+                    <span className="text-xs text-muted-foreground/70">
+                      {dayjs(log.createdAt).format("MMM D, HH:mm")}
+                    </span>
+                  </div>
+                </div>
+                <RawEventViewer raw={log.rawResultEvent} />
+              </div>
+            );
+          })}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_components/LogsHeader.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_components/LogsHeader.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  Badge,
+  Button,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+} from "@conductor/ui";
+import { IconFilter } from "@tabler/icons-react";
+import {
+  TimeRangeFilter,
+  type TimeRange,
+} from "@/lib/components/analytics/TimeRangeFilter";
+import { labelFor } from "../_utils";
+
+interface LogsHeaderProps {
+  visibleTypes: Set<string>;
+  availableTypes: string[];
+  onTypeToggle: (type: string, allTypes: string[]) => void;
+  timeRange: TimeRange;
+  onTimeRangeChange: (value: TimeRange) => void;
+}
+
+export function LogsHeader({
+  visibleTypes,
+  availableTypes,
+  onTypeToggle,
+  timeRange,
+  onTimeRangeChange,
+}: LogsHeaderProps) {
+  const filterActive = visibleTypes.size > 0;
+
+  return (
+    <div className="flex items-center gap-1.5 sm:gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="secondary" size="sm" className="motion-press">
+            <IconFilter size={14} />
+            <span className="hidden sm:inline">
+              {filterActive
+                ? `${visibleTypes.size} of ${availableTypes.length} Types`
+                : "All Types"}
+            </span>
+            <span className="sm:hidden">
+              {filterActive
+                ? `${visibleTypes.size}/${availableTypes.length}`
+                : "All"}
+            </span>
+            {filterActive && (
+              <Badge
+                variant="default"
+                className="ml-0.5 h-4 min-w-4 px-1 text-[10px]"
+              >
+                {visibleTypes.size}
+              </Badge>
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {availableTypes.map((type) => (
+            <DropdownMenuCheckboxItem
+              key={type}
+              checked={visibleTypes.size === 0 || visibleTypes.has(type)}
+              onCheckedChange={() => onTypeToggle(type, availableTypes)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              {labelFor(type)}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <TimeRangeFilter value={timeRange} onChange={onTimeRangeChange} />
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_components/LogsSummaryGrid.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_components/LogsSummaryGrid.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Card, CardContent } from "@conductor/ui";
+import {
+  IconCurrencyPound,
+  IconClock,
+  IconArrowDown,
+  IconArrowUp,
+} from "@tabler/icons-react";
+import { formatCost, formatTokens, GBP_TO_USD } from "../_utils";
+import { formatDurationMs } from "@/lib/utils/formatDuration";
+
+interface LogsSummaryGridProps {
+  totalCost: number;
+  totalDuration: number;
+  totalInput: number;
+  totalOutput: number;
+}
+
+export function LogsSummaryGrid({
+  totalCost,
+  totalDuration,
+  totalInput,
+  totalOutput,
+}: LogsSummaryGridProps) {
+  const stats = [
+    {
+      icon: IconCurrencyPound,
+      label: "Total Cost",
+      value: formatCost(totalCost),
+      subtitle: `$${formatCost(totalCost * GBP_TO_USD).slice(1)}`,
+    },
+    {
+      icon: IconClock,
+      label: "Ran For",
+      value: formatDurationMs(totalDuration),
+      subtitle: undefined,
+    },
+    {
+      icon: IconArrowDown,
+      label: "Input Tokens",
+      value: formatTokens(totalInput),
+      subtitle: undefined,
+    },
+    {
+      icon: IconArrowUp,
+      label: "Output Tokens",
+      value: formatTokens(totalOutput),
+      subtitle: undefined,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-4">
+      {stats.map((stat) => (
+        <Card
+          key={stat.label}
+          className="motion-emphasized bg-muted/40 transition-[transform,background-color] duration-200 hover:-translate-y-0.5 hover:bg-muted/60"
+        >
+          <CardContent className="flex flex-row items-center gap-2.5 p-3 sm:gap-3 sm:p-4">
+            <div className="motion-base rounded-lg bg-secondary p-1.5 text-muted-foreground sm:p-2">
+              <stat.icon size={18} className="sm:h-5 sm:w-5" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-lg font-bold text-foreground sm:text-2xl">
+                {stat.value}
+              </p>
+              <div className="flex items-baseline gap-1.5">
+                <p className="text-xs text-muted-foreground sm:text-sm">
+                  {stat.label}
+                </p>
+                {stat.subtitle && (
+                  <span className="text-xs text-muted-foreground/60">
+                    {stat.subtitle}
+                  </span>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_utils.ts
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/logs/_utils.ts
@@ -1,0 +1,92 @@
+const ENTITY_TYPE_LABELS: Record<string, string> = {
+  quickTask: "Quick Tasks",
+  session: "Sessions",
+  designSession: "Design Sessions",
+  researchQuery: "Research Queries",
+  project: "Projects",
+  doc: "Docs",
+  evaluation: "Evaluations",
+  sessionAudit: "Session Audits",
+  taskAudit: "Task Audits",
+  summarize: "Summaries",
+  testGen: "Test Generation",
+  automation: "Automations",
+};
+
+export function labelFor(entityType: string): string {
+  return ENTITY_TYPE_LABELS[entityType] ?? entityType;
+}
+
+export function formatCost(cost: number): string {
+  return `£${(cost * USD_TO_GBP).toFixed(2)}`;
+}
+
+export function formatTokens(count: number): string {
+  if (count === 0) return "0";
+  if (count >= 1e12) return `${(count / 1e12).toFixed(1)}T`;
+  if (count >= 1e9) return `${(count / 1e9).toFixed(1)}B`;
+  if (count >= 1e6) return `${(count / 1e6).toFixed(1)}M`;
+  if (count >= 1e3) return `${(count / 1e3).toFixed(1)}k`;
+  return String(count);
+}
+
+export const USD_TO_GBP = 0.74;
+export const GBP_TO_USD = 1.34;
+
+export interface ParsedResultEvent {
+  costUsd: number;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  durationMs: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+const EMPTY_PARSED: ParsedResultEvent = {
+  costUsd: 0,
+  model: "-",
+  inputTokens: 0,
+  outputTokens: 0,
+  durationMs: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+};
+
+export function parseResultEvent(raw: string | undefined): ParsedResultEvent {
+  if (!raw) return EMPTY_PARSED;
+  try {
+    const parsed = JSON.parse(raw);
+    const usage = parsed.usage ?? {};
+    const modelUsage = parsed.modelUsage ?? {};
+    const modelKeys = Object.keys(modelUsage);
+    const inputTokens =
+      (typeof usage.input_tokens === "number" ? usage.input_tokens : 0) +
+      (typeof usage.cache_read_input_tokens === "number"
+        ? usage.cache_read_input_tokens
+        : 0) +
+      (typeof usage.cache_creation_input_tokens === "number"
+        ? usage.cache_creation_input_tokens
+        : 0);
+    return {
+      costUsd:
+        typeof parsed.total_cost_usd === "number" ? parsed.total_cost_usd : 0,
+      model: modelKeys.length > 0 ? modelKeys[0] : "-",
+      inputTokens,
+      outputTokens:
+        typeof usage.output_tokens === "number" ? usage.output_tokens : 0,
+      durationMs:
+        typeof parsed.duration_ms === "number" ? parsed.duration_ms : 0,
+      cacheReadTokens:
+        typeof usage.cache_read_input_tokens === "number"
+          ? usage.cache_read_input_tokens
+          : 0,
+      cacheCreationTokens:
+        typeof usage.cache_creation_input_tokens === "number"
+          ? usage.cache_creation_input_tokens
+          : 0,
+    };
+  } catch {
+    return EMPTY_PARSED;
+  }
+}

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/mcp-config.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/mcp-config.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { McpConfigClient } from "./McpConfigClient";
+
+export const Route = createFileRoute(
+  "/_repo/$owner/$repo/settings/mcp-config",
+)({
+  component: McpConfigClient,
+});

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/monorepo.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/monorepo.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { MonorepoClient } from "./MonorepoClient";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/settings/monorepo")({
+  component: MonorepoClient,
+});

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/snapshots.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/snapshots.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SnapshotsClient } from "./SnapshotsClient";
+
+export const Route = createFileRoute(
+  "/_repo/$owner/$repo/settings/snapshots",
+)({
+  component: SnapshotsClient,
+});

--- a/apps/web-v2/src/routes/_repo/$owner/$repo/settings/theme.tsx
+++ b/apps/web-v2/src/routes/_repo/$owner/$repo/settings/theme.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ThemeSettingsClient } from "@/lib/components/theme/ThemeSettingsClient";
+
+export const Route = createFileRoute("/_repo/$owner/$repo/settings/theme")({
+  component: ThemeSettingsClient,
+});


### PR DESCRIPTION
## Summary
- Port all 8 settings sub-routes + index redirect from Next.js to TanStack Router (Migration Unit 10)
- Routes: config, audits, env-variables, logs, mcp-config, monorepo, snapshots, theme
- Applied all required replacements: `next/link` -> TanStack `Link`, removed `@clerk/nextjs`, `use(params)` -> `Route.useParams()`
- Includes co-located `_components/` and `_utils.ts` for audits and logs routes

## Test plan
- [ ] Verify each route file has correct `createFileRoute` path string
- [ ] Verify settings index redirects to config
- [ ] Verify no `next/link`, `@clerk/nextjs`, `useRouter`, or `use(params)` remain in copied files
- [ ] Verify `TeamEnvVarsClient` uses TanStack `Link` instead of `next/link`