### PR TITLE
Staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ openssl ec -in private.pem -pubout -out public.pem
 ```env
 VITE_CONVEX_URL=https://your-deployment.convex.cloud
 VITE_CLERK_PUBLISHABLE_KEY=pk_test_...
-VITE_ENV=development
 ```
 
 #### Convex (`npx convex env set VAR value`)
@@ -190,15 +189,14 @@ VITE_ENV=development
 
 **Optional:**
 
-| Variable                  | Purpose                                        |
-| ------------------------- | ---------------------------------------------- |
-| `ENVIRONMENT`             | Set to `production` to disable public sign-ups |
-| `SANDBOX_JWT_PRIVATE_KEY` | ES256 JWK for sandbox auth (JSON)              |
-| `SANDBOX_JWT_JWKS`        | Public JWKS for sandbox auth (JSON)            |
-| `MCP_BOOTSTRAP_SECRET`    | Secret for MCP bootstrap API                   |
-| `MCP_JWT_SECRET`          | Secret for MCP JWT signing                     |
-| `CLERK_SECRET_KEY`        | Clerk secret key (for MCP server)              |
-| `CLERK_PUBLISHABLE_KEY`   | Clerk publishable key (for MCP server)         |
+| Variable                  | Purpose                                |
+| ------------------------- | -------------------------------------- |
+| `SANDBOX_JWT_PRIVATE_KEY` | ES256 JWK for sandbox auth (JSON)      |
+| `SANDBOX_JWT_JWKS`        | Public JWKS for sandbox auth (JSON)    |
+| `MCP_BOOTSTRAP_SECRET`    | Secret for MCP bootstrap API           |
+| `MCP_JWT_SECRET`          | Secret for MCP JWT signing             |
+| `CLERK_SECRET_KEY`        | Clerk secret key (for MCP server)      |
+| `CLERK_PUBLISHABLE_KEY`   | Clerk publishable key (for MCP server) |
 
 ### Step 7: Add Daytona API Key
 

--- a/apps/web/src/env/client.ts
+++ b/apps/web/src/env/client.ts
@@ -6,7 +6,6 @@ export const clientEnv = createEnv({
   client: {
     VITE_CONVEX_URL: z.string().min(1),
     VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
-    VITE_ENV: z.enum(["development", "staging", "production"]),
   },
   runtimeEnv: import.meta.env,
 });

--- a/apps/web/src/lib/components/Sidebar.tsx
+++ b/apps/web/src/lib/components/Sidebar.tsx
@@ -30,7 +30,6 @@ import {
   IconTool,
   IconX,
 } from "@tabler/icons-react";
-import { clientEnv } from "@/env/client";
 import { api } from "@conductor/backend";
 import {
   Button,
@@ -183,7 +182,7 @@ export function Sidebar() {
     owner && repoName ? { owner, name: repoName, appName } : "skip",
   );
 
-  const isDev = clientEnv.VITE_ENV === "development";
+  const isDev = import.meta.env.DEV;
 
   const repoNavigation = useMemo(() => {
     if (!isRepoRoute || !repoBasePath) return [];

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { SignInButton, SignUpButton } from "@clerk/clerk-react";
 import { Button } from "@conductor/ui";
-import { clientEnv } from "@/env/client";
 import { z } from "zod";
 
-const isProduction = clientEnv.VITE_ENV === "production";
+const isDev = import.meta.env.DEV;
 
 const searchSchema = z.object({
   agent: z.boolean().optional(),
@@ -53,32 +52,19 @@ function LandingPage() {
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row">
-          {isProduction ? (
-            <>
-              <Button size="lg" variant="default" disabled>
-                Sign In
-              </Button>
-              <Button size="lg" variant="outline" disabled>
-                Sign Up
-              </Button>
-            </>
-          ) : (
-            <>
-              <SignInButton mode="modal">
-                <Button size="lg" variant="default">
-                  Sign In
-                </Button>
-              </SignInButton>
-              <SignUpButton mode="modal">
-                <Button size="lg" variant="outline">
-                  Sign Up
-                </Button>
-              </SignUpButton>
-            </>
-          )}
+          <SignInButton mode="modal">
+            <Button size="lg" variant="default">
+              Sign In
+            </Button>
+          </SignInButton>
+          <SignUpButton mode="modal">
+            <Button size="lg" variant="outline">
+              Sign Up
+            </Button>
+          </SignUpButton>
         </div>
 
-        {!isProduction && (
+        {isDev && (
           <div className="flex justify-center">
             <Button
               size="lg"
@@ -89,13 +75,6 @@ function LandingPage() {
             >
               Sign in as Eva
             </Button>
-          </div>
-        )}
-
-        {isProduction && (
-          <div className="max-w-sm rounded-lg bg-muted/40 px-4 py-3 text-center text-sm text-muted-foreground">
-            Eva is fully open source and self-hosted. Clone the repo, create
-            your own Convex and Clerk projects, and run it locally.
           </div>
         )}
       </div>

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Drop MCP_BASE_URL and skip self-referential token-mint HTTP roundtrip - 2026-05-05
+
+- **Why**: `MCP_BASE_URL` pointed at a Railway MCP deployment that has since been deleted; the MCP server now lives on the same Convex deployment, so the token-mint flow was making Convex call back into its own HTTP API for no reason.
+- **Change**: `mintSandboxMcpToken` now calls `internal.mcp.nodeActions.mintInternalToken` directly via `ctx.runAction` instead of fetching `${MCP_BASE_URL}/api/internal/mint-token`. The sandbox MCP config in `_daytona/helpers.ts` reads `CONVEX_SITE_URL` instead of `MCP_BASE_URL`. Removed the now-orphaned `mintInternalToken` httpAction in `mcp/native.ts`, the `/api/internal/mint-token` route in `http.ts`, and the redundant `bootstrapSecret` arg from the internal action (no longer crossing a trust boundary).
+- **Action required**: `MCP_BASE_URL` has been removed from both dev and prod Convex deployments; no further action needed.
+
 ## Keep quick-task sandbox stop spinner visible - 2026-05-05
 
 - **Why**: Quick-task detail controls could return to the start/view state immediately after requesting a sandbox stop, even though Daytona can take roughly 30 seconds to finish stopping the sandbox.

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Open public sign-ups and drop bespoke env-mode flag - 2026-05-05
+
+- **Why**: The `ENVIRONMENT=production` backend flag and parallel `VITE_ENV === "production"` frontend flag existed to lock down a "public hosted Eva" deployment to existing users only. We no longer need that gating, and the custom `VITE_ENV` env var duplicated information Vite already exposes natively.
+- **Change**: Removed the `ensureUserExists` sign-up throw in `auth.ts`, the disabled-buttons + self-host fallback message on the landing route, the `ENVIRONMENT` doc row, and `VITE_ENV` from the t3-env schema and env files. Remaining dev-only UI (the "Sign in as Eva" button and dev-only sidebar nav) now reads `import.meta.env.DEV` directly.
+- **Why `import.meta.env.DEV`**: Vite-native typed boolean, statically replaced at build time, mode-aware (`vite build --mode staging` evaluates to `false`), and removes the need for a custom env var in `.env.local` / Convex.
+
 ## Drop MCP_BASE_URL and skip self-referential token-mint HTTP roundtrip - 2026-05-05
 
 - **Why**: `MCP_BASE_URL` pointed at a Railway MCP deployment that has since been deleted; the MCP server now lives on the same Convex deployment, so the token-mint flow was making Convex call back into its own HTTP API for no reason.

--- a/packages/backend/convex/_daytona/helpers.ts
+++ b/packages/backend/convex/_daytona/helpers.ts
@@ -357,7 +357,7 @@ export async function signAndLaunchScript(
     mcpTokenPromise,
   ]);
 
-  const mcpBaseUrl = mcpToken ? (process.env.MCP_BASE_URL ?? "") : "";
+  const mcpBaseUrl = mcpToken ? (process.env.CONVEX_SITE_URL ?? "") : "";
 
   await launchScript(
     sandbox,

--- a/packages/backend/convex/auth.ts
+++ b/packages/backend/convex/auth.ts
@@ -146,12 +146,6 @@ export const ensureUserExists = mutation({
       };
     }
 
-    if (process.env.ENVIRONMENT === "production") {
-      throw new Error(
-        "Sign-ups are disabled on this deployment. Please self-host Eva to create your own instance.",
-      );
-    }
-
     const userId = await ctx.db.insert("users", {
       clerkId: clerkUserId,
       email: email || undefined,

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -546,7 +546,6 @@ import {
   authorizePost,
   token,
   mcpHandler,
-  mintInternalToken,
   health,
 } from "./mcp/native";
 
@@ -605,13 +604,6 @@ http.route({
   path: "/mcp",
   method: "DELETE",
   handler: mcpHandler,
-});
-
-// Internal token minting (for scoped repo access from Eva sandboxes)
-http.route({
-  path: "/api/internal/mint-token",
-  method: "POST",
-  handler: mintInternalToken,
 });
 
 // Health check

--- a/packages/backend/convex/mcp/native.ts
+++ b/packages/backend/convex/mcp/native.ts
@@ -516,52 +516,6 @@ export const mcpHandler = httpAction(async (ctx, request) => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Internal Token Minting (for scoped repo access)
-// ─────────────────────────────────────────────────────────────────────────────
-
-export const mintInternalToken = httpAction(async (ctx, request) => {
-  // Verify bootstrap secret
-  const auth = request.headers.get("Authorization");
-  if (!auth || !auth.startsWith("MCPBootstrap ")) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const bootstrapSecret = auth.slice("MCPBootstrap ".length);
-
-  const bodyRaw = await request.json();
-  if (typeof bodyRaw !== "object" || bodyRaw === null) {
-    return Response.json({ error: "Invalid request body" }, { status: 400 });
-  }
-
-  const body = bodyRaw as Record<string, unknown>;
-  const clerkUserId = body.clerkUserId;
-  const repoId = body.repoId;
-
-  if (typeof clerkUserId !== "string" || typeof repoId !== "string") {
-    return Response.json(
-      { error: "clerkUserId and repoId required" },
-      { status: 400 },
-    );
-  }
-
-  // Delegate to Node.js action (which has access to MCP_INTERNAL_SECRET)
-  const result = await ctx.runAction(
-    internal.mcp.nodeActions.mintInternalToken,
-    {
-      clerkUserId,
-      repoId,
-      bootstrapSecret,
-    },
-  );
-
-  if (!result) {
-    return Response.json({ error: "Invalid credentials" }, { status: 403 });
-  }
-
-  return Response.json(result);
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Health Check
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/packages/backend/convex/mcp/nodeActions.ts
+++ b/packages/backend/convex/mcp/nodeActions.ts
@@ -258,7 +258,6 @@ export const mintInternalToken = internalAction({
   args: {
     clerkUserId: v.string(),
     repoId: v.string(),
-    bootstrapSecret: v.string(),
   },
   returns: v.union(
     v.object({
@@ -267,11 +266,7 @@ export const mintInternalToken = internalAction({
     }),
     v.null(),
   ),
-  handler: async (_ctx, { clerkUserId, repoId, bootstrapSecret }) => {
-    // Verify bootstrap secret
-    const expectedSecret = process.env.MCP_BOOTSTRAP_SECRET;
-    if (!expectedSecret || bootstrapSecret !== expectedSecret) return null;
-
+  handler: async (_ctx, { clerkUserId, repoId }) => {
     const internalSecret = process.env.MCP_INTERNAL_SECRET;
     if (!internalSecret) return null;
 

--- a/packages/backend/convex/mcp/tokenMinter.ts
+++ b/packages/backend/convex/mcp/tokenMinter.ts
@@ -1,94 +1,34 @@
-"use node";
-
 import { v } from "convex/values";
 import { internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
 
-const RETRYABLE_MCP_STATUS_CODES = new Set([429, 502, 503, 504]);
-const MCP_MINT_MAX_ATTEMPTS = 3;
-
-/** Returns the MCP server base URL from environment variables. */
-function getMcpBaseUrl(): string {
-  const url = process.env.MCP_BASE_URL;
-  if (!url) throw new Error("MCP_BASE_URL environment variable is required");
-  return url.replace(/\/$/, "");
-}
-
-/** Returns the MCP bootstrap secret from environment variables. */
-function getMcpBootstrapSecret(): string {
-  const secret = process.env.MCP_BOOTSTRAP_SECRET;
-  if (!secret)
-    throw new Error("MCP_BOOTSTRAP_SECRET environment variable is required");
-  return secret;
-}
-
-/** Pauses execution for the specified number of milliseconds. */
-async function delay(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-/** Calculates a retry delay with linear backoff and jitter for the given attempt number. */
-function buildRetryDelayMs(attempt: number): number {
-  return attempt * 2000 + Math.floor(Math.random() * 500);
-}
-
-/** Mints an MCP authentication token for a sandbox user, with automatic retries on transient failures. */
+/**
+ * Mints an MCP authentication token for a sandbox user.
+ *
+ * The MCP server lives on the same Convex deployment, so we delegate to the
+ * JWT-signing internal action directly instead of going through an HTTP
+ * roundtrip back into our own deployment.
+ */
 export const mintSandboxMcpToken = internalAction({
   args: {
     userId: v.id("users"),
     repoId: v.id("githubRepos"),
   },
   returns: v.object({ token: v.string(), expiresIn: v.number() }),
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ token: string; expiresIn: number }> => {
     const user = await ctx.runQuery(internal.users.getInternal, {
       userId: args.userId,
     });
     if (!user) throw new Error("User not found");
 
-    for (let attempt = 1; attempt <= MCP_MINT_MAX_ATTEMPTS; attempt += 1) {
-      try {
-        const response = await fetch(
-          `${getMcpBaseUrl()}/api/internal/mint-token`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `MCPBootstrap ${getMcpBootstrapSecret()}`,
-            },
-            body: JSON.stringify({
-              clerkUserId: user.clerkId,
-              repoId: String(args.repoId),
-            }),
-          },
-        );
-
-        if (!response.ok) {
-          if (
-            attempt < MCP_MINT_MAX_ATTEMPTS &&
-            RETRYABLE_MCP_STATUS_CODES.has(response.status)
-          ) {
-            await delay(buildRetryDelayMs(attempt));
-            continue;
-          }
-          throw new Error(`Failed to mint MCP token: HTTP ${response.status}`);
-        }
-
-        const result: { token: string; expiresIn: number } =
-          await response.json();
-        return { token: result.token, expiresIn: result.expiresIn };
-      } catch (error) {
-        if (attempt >= MCP_MINT_MAX_ATTEMPTS) {
-          if (error instanceof Error) {
-            throw error;
-          }
-          throw new Error(`Failed to mint MCP token: ${String(error)}`);
-        }
-        await delay(buildRetryDelayMs(attempt));
-      }
-    }
-
-    throw new Error("Failed to mint MCP token");
+    const result = await ctx.runAction(
+      internal.mcp.nodeActions.mintInternalToken,
+      {
+        clerkUserId: user.clerkId,
+        repoId: String(args.repoId),
+      },
+    );
+    if (!result) throw new Error("Failed to mint MCP token");
+    return result;
   },
 });


### PR DESCRIPTION
MCP server now runs natively on Convex (not on deleted Railway deployment).
mintSandboxMcpToken now calls internal.mcp.nodeActions.mintInternalToken
directly via ctx.runAction instead of fetching back into its own HTTP API.
Removed dead HTTP wrapper, route, and redundant bootstrapSecret verification.
Updated sandbox MCP config to use CONVEX_SITE_URL instead of MCP_BASE_URL.