### PR TITLE
fix: invalidate preview cache and increase snapshot build memory

### DIFF
--- a/apps/web/src/lib/components/sandbox/useSandboxPreview.ts
+++ b/apps/web/src/lib/components/sandbox/useSandboxPreview.ts
@@ -62,7 +62,7 @@ export function useSandboxPreview({
   // in the subdomain; reusing a cached URL after the sandbox is destroyed and
   // recreated would 400 with "Sandbox not found".
   const [previewInfo, setPreviewInfo] = useSessionStorage<PreviewInfo | null>(
-    `conductor:${cacheScope}:nav-sync-v1:${sandboxId ?? "no-sandbox"}:${effectivePort}`,
+    `conductor:${cacheScope}:nav-sync-v2:${sandboxId ?? "no-sandbox"}:${effectivePort}`,
     null,
   );
 

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -3,7 +3,7 @@
 ## Keep Daytona sandbox preview on the resolved dev port - 2026-05-06
 
 - **Why**: The preview pane could display port 3000 while hidden state still defaulted to 3001, and the navigation-sync proxy generated Daytona preview URLs for port 33000, outside Daytona's supported preview range.
-- **Change**: Removed the 3001 preview-port default, resolved preview ports as `URL override -> saved devPort -> 3000`, synchronized the port input from the resolved port prop, and moved the navigation-sync proxy to available ports in the 9000-9999 range.
+- **Change**: Removed the 3001 preview-port default, resolved preview ports as `URL override -> saved devPort -> 3000`, synchronized the port input from the resolved port prop, moved the navigation-sync proxy to available ports in the 9000-9999 range, and bumped the preview cache key so browsers discard cached 33000 URLs.
 - **Reason**: Preview URL generation, the visible port control, and Daytona's supported preview-port contract now agree on the same target port.
 
 ## Project-level sandbox preview - 2026-05-06

--- a/packages/backend/convex/snapshotActions.ts
+++ b/packages/backend/convex/snapshotActions.ts
@@ -297,7 +297,7 @@ export const kickOffSnapshotBuild = internalAction({
           contextHashes: [],
         },
         cpu: 4,
-        memory: 12,
+        memory: 16,
         disk: 10,
       }),
     });


### PR DESCRIPTION
bump the preview cache key from v1 to v2 to clear cached URLs pointing to the old 33000 proxy port, and increase snapshot build memory from 12 to 16gb for additional stability.