### PR TITLE
fix: stop caching signed preview urls in sessionstorage

### DIFF
--- a/apps/web/src/lib/components/PreviewNavBar.tsx
+++ b/apps/web/src/lib/components/PreviewNavBar.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback, type RefObject } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type RefObject,
+} from "react";
 import { Input, Spinner } from "@conductor/ui";
 import { WebPreviewNavigationButton } from "@conductor/ui";
 import {
@@ -20,11 +26,17 @@ function getPathFromUrl(fullUrl: string): string {
   }
 }
 
-function buildUrlWithPath(baseUrl: string, path: string): string {
+export function normalizePreviewPath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) return "/";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+export function buildUrlWithPath(baseUrl: string, path: string): string {
   try {
     const parsed = new URL(baseUrl);
     if (parsed.protocol === "http:") parsed.protocol = "https:";
-    const fullPath = path.startsWith("/") ? path : `/${path}`;
+    const fullPath = normalizePreviewPath(path);
     return `${parsed.origin}${fullPath}`;
   } catch {
     return baseUrl;
@@ -36,8 +48,10 @@ interface PreviewNavBarProps {
   iframeRef: RefObject<HTMLIFrameElement | null>;
   containerRef: RefObject<HTMLDivElement | null>;
   port: number;
+  path?: string;
   onPortChange?: (port: number) => void;
   defaultPath?: string;
+  onPathChange?: (path: string) => void;
   isLoading?: boolean;
   onRefresh?: () => void;
 }
@@ -51,34 +65,49 @@ export function PreviewNavBar({
   iframeRef,
   containerRef,
   port,
+  path,
   onPortChange,
   defaultPath = "/",
+  onPathChange,
   isLoading = false,
   onRefresh,
 }: PreviewNavBarProps) {
   const [portInput, setPortInput] = useState(String(port));
-  const [pathInput, setPathInput] = useState(defaultPath);
-  const [prevPreviewUrl, setPrevPreviewUrl] = useState(previewUrl);
+  const [pathInput, setPathInput] = useState(path ?? defaultPath);
+  // Tracks the last value emitted via onPathChange so the three event sources
+  // (input commit, iframe load, in-iframe postMessage) don't fire redundant
+  // notifications for the same path.
+  const lastNotifiedPathRef = useRef<string | null>(null);
 
   useEffect(() => {
     setPortInput(String(port));
   }, [port]);
 
-  if (previewUrl !== prevPreviewUrl) {
-    setPrevPreviewUrl(previewUrl);
-    setPathInput(getPathFromUrl(previewUrl ?? defaultPath));
-  }
+  useEffect(() => {
+    setPathInput(path ?? defaultPath);
+  }, [path, defaultPath]);
+
+  const notifyPathChange = useCallback(
+    (nextPath: string) => {
+      if (lastNotifiedPathRef.current === nextPath) return;
+      lastNotifiedPathRef.current = nextPath;
+      onPathChange?.(nextPath);
+    },
+    [onPathChange],
+  );
 
   const syncPathFromIframe = useCallback(() => {
     try {
       const href = iframeRef.current?.contentWindow?.location.href;
       if (href) {
-        setPathInput(getPathFromUrl(href));
+        const nextPath = getPathFromUrl(href);
+        setPathInput(nextPath);
+        notifyPathChange(nextPath);
       }
     } catch {
       // cross-origin — cannot read iframe location
     }
-  }, [iframeRef]);
+  }, [iframeRef, notifyPathChange]);
 
   function postHistoryCommand(type: PreviewHistoryCommand) {
     iframeRef.current?.contentWindow?.postMessage({ type }, "*");
@@ -99,7 +128,9 @@ export function PreviewNavBar({
         "url" in event.data &&
         typeof event.data.url === "string"
       ) {
-        setPathInput(getPathFromUrl(event.data.url));
+        const nextPath = getPathFromUrl(event.data.url);
+        setPathInput(nextPath);
+        notifyPathChange(nextPath);
       }
     }
 
@@ -108,7 +139,7 @@ export function PreviewNavBar({
       iframe.removeEventListener("load", syncPathFromIframe);
       window.removeEventListener("message", handleMessage);
     };
-  }, [iframeRef, syncPathFromIframe]);
+  }, [iframeRef, syncPathFromIframe, notifyPathChange]);
 
   function goBack() {
     let handled = false;
@@ -142,7 +173,10 @@ export function PreviewNavBar({
 
   function commitPath() {
     if (!iframeRef.current || !previewUrl) return;
-    iframeRef.current.src = buildUrlWithPath(previewUrl, pathInput);
+    const nextPath = normalizePreviewPath(pathInput);
+    setPathInput(nextPath);
+    notifyPathChange(nextPath);
+    iframeRef.current.src = buildUrlWithPath(previewUrl, nextPath);
   }
 
   function commitPort() {

--- a/apps/web/src/lib/components/projects/ProjectSandboxPanel.tsx
+++ b/apps/web/src/lib/components/projects/ProjectSandboxPanel.tsx
@@ -50,7 +50,6 @@ export function ProjectSandboxPanel({
     isActive,
     repoId,
     devPort,
-    cacheScope: `project-preview:${projectIdStr}`,
   });
 
   const panes = useSandboxPanes({

--- a/apps/web/src/lib/components/sandbox/SandboxPaneSlots.tsx
+++ b/apps/web/src/lib/components/sandbox/SandboxPaneSlots.tsx
@@ -91,6 +91,14 @@ export function SandboxPaneSlots({
                 onRefresh={preview.fetchPreview}
                 port={preview.effectivePort}
                 onPortChange={preview.setPort}
+                pathStorageKey={[
+                  "conductor",
+                  owner.kind,
+                  cacheKey,
+                  "preview-path",
+                  id,
+                  preview.effectivePort,
+                ].join(":")}
               />
             </div>
           ))}

--- a/apps/web/src/lib/components/sandbox/useSandboxPreview.ts
+++ b/apps/web/src/lib/components/sandbox/useSandboxPreview.ts
@@ -5,7 +5,6 @@ import { useAction } from "convex/react";
 import { api } from "@conductor/backend";
 import type { Id } from "@conductor/backend";
 import { useQueryState } from "nuqs";
-import { useSessionStorage } from "usehooks-ts";
 import { previewPortParser } from "@/lib/search-params";
 import { dismissDaytonaWarning } from "@/lib/utils/dismissDaytonaWarning";
 
@@ -29,45 +28,46 @@ interface UseSandboxPreviewArgs {
   isActive: boolean;
   repoId: Id<"githubRepos">;
   devPort?: number;
-  /**
-   * Full sessionStorage namespace for cached preview URLs — e.g.
-   * `preview:<sessionId>` or `task-preview:<taskId>`. Final keys include the
-   * sandbox ID, port, and preview-url behavior version.
-   */
-  cacheScope: string;
+}
+
+function clearLegacyPreviewUrlCache(): void {
+  const keys: string[] = [];
+  for (let i = 0; i < sessionStorage.length; i += 1) {
+    const key = sessionStorage.key(i);
+    if (key?.startsWith("conductor:") && key.includes(":nav-sync-")) {
+      keys.push(key);
+    }
+  }
+
+  for (const key of keys) {
+    sessionStorage.removeItem(key);
+  }
 }
 
 /**
- * Drives the WebPreview pane: resolves a sandbox+port to a live URL, polls
- * until the dev server is reachable, and caches the resolved URL in
- * sessionStorage (via `useSessionStorage`) so navigating back doesn't
- * re-fetch. Used by both the session and quick-task sandbox panels.
+ * Drives the WebPreview pane: resolves a sandbox+port to a live URL and polls
+ * until the dev server is reachable. Signed Daytona preview URLs are kept in
+ * memory only because persisting them can resurrect stale iframe targets.
  */
 export function useSandboxPreview({
   sandboxId,
   isActive,
   repoId,
   devPort,
-  cacheScope,
 }: UseSandboxPreviewArgs): SandboxPreviewApi {
+  const [previewInfo, setPreviewInfo] = useState<PreviewInfo | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [iframeKey, setIframeKey] = useState(0);
   const [port, setPort] = useQueryState("port", previewPortParser);
   const effectivePort = port ?? devPort ?? 3000;
 
-  // sessionStorage is both cache and live state — when port or sandboxId
-  // changes useSessionStorage re-reads the new key automatically. sandboxId is
-  // part of the key because Daytona signed preview URLs embed the sandbox ID
-  // in the subdomain; reusing a cached URL after the sandbox is destroyed and
-  // recreated would 400 with "Sandbox not found".
-  const [previewInfo, setPreviewInfo] = useSessionStorage<PreviewInfo | null>(
-    `conductor:${cacheScope}:nav-sync-v2:${sandboxId ?? "no-sandbox"}:${effectivePort}`,
-    null,
-  );
-
   const getPreviewUrl = useAction(api.daytona.getPreviewUrl);
   const pollingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    clearLegacyPreviewUrlCache();
+  }, []);
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -103,31 +103,18 @@ export function useSandboxPreview({
       setError(err instanceof Error ? err.message : "Failed to load preview");
       setIsLoading(false);
     }
-  }, [
-    sandboxId,
-    isActive,
-    getPreviewUrl,
-    stopPolling,
-    repoId,
-    effectivePort,
-    setPreviewInfo,
-  ]);
+  }, [sandboxId, isActive, getPreviewUrl, stopPolling, repoId, effectivePort]);
 
   useEffect(() => {
     if (isActive && sandboxId) {
-      // useSessionStorage already hydrated `previewInfo` from cache; only
-      // fetch if there isn't one yet for this port.
-      if (previewInfo) return;
+      setPreviewInfo(null);
       fetchPreview();
     }
     if (!isActive) {
       setPreviewInfo(null);
+      setIsLoading(false);
     }
     return stopPolling;
-    // We intentionally omit `previewInfo` from deps — re-running on every
-    // cache write would cause a fetch loop. The cached value is only checked
-    // on (isActive, sandboxId, port) transitions.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActive, sandboxId, effectivePort, fetchPreview, stopPolling]);
 
   return {

--- a/apps/web/src/lib/components/tasks/TaskSandboxPanel.tsx
+++ b/apps/web/src/lib/components/tasks/TaskSandboxPanel.tsx
@@ -53,7 +53,6 @@ export function TaskSandboxPanel({
     isActive,
     repoId,
     devPort,
-    cacheScope: `task-preview:${taskIdStr}`,
   });
 
   const panes = useSandboxPanes({

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/SandboxPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/SandboxPanel.tsx
@@ -43,7 +43,6 @@ export function SandboxPanel({
     isActive,
     repoId,
     devPort,
-    cacheScope: `preview:${sessionIdStr}`,
   });
 
   const panes = useSandboxPanes({

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/WebPreviewPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/WebPreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Spinner,
   Button,
@@ -13,7 +13,11 @@ import {
   IconWorld,
   IconX,
 } from "@tabler/icons-react";
-import { PreviewNavBar } from "@/lib/components/PreviewNavBar";
+import {
+  PreviewNavBar,
+  buildUrlWithPath,
+  normalizePreviewPath,
+} from "@/lib/components/PreviewNavBar";
 
 interface PreviewInfo {
   url: string;
@@ -30,6 +34,26 @@ interface WebPreviewPanelProps {
   onRefresh: () => void;
   port: number;
   onPortChange: (port: number) => void;
+  pathStorageKey: string;
+}
+
+function readPreviewPath(storageKey: string): string {
+  try {
+    const stored = sessionStorage.getItem(storageKey);
+    return stored ? normalizePreviewPath(stored) : "/";
+  } catch {
+    return "/";
+  }
+}
+
+function writePreviewPath(storageKey: string, path: string): string {
+  const normalized = normalizePreviewPath(path);
+  try {
+    sessionStorage.setItem(storageKey, normalized);
+  } catch {
+    // non-critical; the live preview path still updates in memory
+  }
+  return normalized;
 }
 
 function NavigationBar({
@@ -39,6 +63,8 @@ function NavigationBar({
   containerRef,
   port,
   onPortChange,
+  previewPath,
+  onPathChange,
 }: {
   previewInfo: PreviewInfo | null;
   isLoading: boolean;
@@ -46,6 +72,8 @@ function NavigationBar({
   containerRef: React.RefObject<HTMLDivElement | null>;
   port: number;
   onPortChange: (port: number) => void;
+  previewPath: string;
+  onPathChange: (path: string) => void;
 }) {
   const { iframeRef } = useWebPreview();
 
@@ -56,7 +84,9 @@ function NavigationBar({
         iframeRef={iframeRef}
         containerRef={containerRef}
         port={port}
+        path={previewPath}
         onPortChange={onPortChange}
+        onPathChange={onPathChange}
         isLoading={isLoading}
         onRefresh={onRefresh}
       />
@@ -74,9 +104,35 @@ export function WebPreviewPanel({
   onRefresh,
   port,
   onPortChange,
+  pathStorageKey,
 }: WebPreviewPanelProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [warningHintDismissed, setWarningHintDismissed] = useState(false);
+  const [previewPath, setPreviewPath] = useState(() =>
+    readPreviewPath(pathStorageKey),
+  );
+
+  useEffect(() => {
+    setPreviewPath(readPreviewPath(pathStorageKey));
+  }, [pathStorageKey]);
+
+  // iframeSrc is recomputed only at remount points (previewInfo change,
+  // storage-key change, or iframeKey bump from a refresh). Reading the path
+  // from sessionStorage here — instead of from previewPath state — keeps the
+  // src stable while the user navigates inside the iframe, so we don't fight
+  // the iframe with declarative src updates.
+  const iframeSrc = useMemo(() => {
+    if (!previewInfo) return undefined;
+    return buildUrlWithPath(previewInfo.url, readPreviewPath(pathStorageKey));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewInfo, pathStorageKey, iframeKey]);
+
+  const handlePathChange = useCallback(
+    (path: string) => {
+      setPreviewPath(writePreviewPath(pathStorageKey, path));
+    },
+    [pathStorageKey],
+  );
 
   if (!isActive || !sandboxId) {
     return (
@@ -96,7 +152,7 @@ export function WebPreviewPanel({
   return (
     <WebPreview
       ref={containerRef}
-      defaultUrl={previewInfo?.url ?? ""}
+      defaultUrl={iframeSrc ?? ""}
       className="h-full rounded-none border-0"
     >
       <NavigationBar
@@ -106,6 +162,8 @@ export function WebPreviewPanel({
         containerRef={containerRef}
         port={port}
         onPortChange={onPortChange}
+        previewPath={previewPath}
+        onPathChange={handlePathChange}
       />
       {!warningHintDismissed ? (
         <div className="flex items-start gap-2 bg-orange-500/10 px-3 py-2 text-xs text-orange-700 dark:text-orange-300">
@@ -126,7 +184,7 @@ export function WebPreviewPanel({
       ) : null}
       <WebPreviewBody
         key={iframeKey}
-        src={previewInfo?.url}
+        src={iframeSrc}
         loading={
           isLoading && !previewInfo ? (
             <div className="absolute inset-0 flex items-center justify-center bg-secondary z-10">

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/WebPreviewPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/WebPreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Spinner,
   Button,
@@ -7,6 +7,7 @@ import {
   WebPreviewBody,
   useWebPreview,
 } from "@conductor/ui";
+import { useSessionStorage } from "usehooks-ts";
 import {
   IconAlertTriangle,
   IconRefresh,
@@ -35,25 +36,6 @@ interface WebPreviewPanelProps {
   port: number;
   onPortChange: (port: number) => void;
   pathStorageKey: string;
-}
-
-function readPreviewPath(storageKey: string): string {
-  try {
-    const stored = sessionStorage.getItem(storageKey);
-    return stored ? normalizePreviewPath(stored) : "/";
-  } catch {
-    return "/";
-  }
-}
-
-function writePreviewPath(storageKey: string, path: string): string {
-  const normalized = normalizePreviewPath(path);
-  try {
-    sessionStorage.setItem(storageKey, normalized);
-  } catch {
-    // non-critical; the live preview path still updates in memory
-  }
-  return normalized;
 }
 
 function NavigationBar({
@@ -108,30 +90,27 @@ export function WebPreviewPanel({
 }: WebPreviewPanelProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [warningHintDismissed, setWarningHintDismissed] = useState(false);
-  const [previewPath, setPreviewPath] = useState(() =>
-    readPreviewPath(pathStorageKey),
-  );
-
-  useEffect(() => {
-    setPreviewPath(readPreviewPath(pathStorageKey));
-  }, [pathStorageKey]);
+  const [previewPath, setPreviewPath] = useSessionStorage(pathStorageKey, "/", {
+    serializer: (value) => value,
+    deserializer: (value) => normalizePreviewPath(value),
+  });
 
   // iframeSrc is recomputed only at remount points (previewInfo change,
-  // storage-key change, or iframeKey bump from a refresh). Reading the path
-  // from sessionStorage here — instead of from previewPath state — keeps the
-  // src stable while the user navigates inside the iframe, so we don't fight
-  // the iframe with declarative src updates.
+  // storage-key change, or iframeKey bump from a refresh). previewPath is
+  // intentionally excluded from deps so the src stays stable while the user
+  // navigates inside the iframe — otherwise we'd fight the iframe with
+  // declarative src updates.
   const iframeSrc = useMemo(() => {
     if (!previewInfo) return undefined;
-    return buildUrlWithPath(previewInfo.url, readPreviewPath(pathStorageKey));
+    return buildUrlWithPath(previewInfo.url, previewPath);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [previewInfo, pathStorageKey, iframeKey]);
 
   const handlePathChange = useCallback(
     (path: string) => {
-      setPreviewPath(writePreviewPath(pathStorageKey, path));
+      setPreviewPath(normalizePreviewPath(path));
     },
-    [pathStorageKey],
+    [setPreviewPath],
   );
 
   if (!isActive || !sandboxId) {

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -3,8 +3,8 @@
 ## Keep Daytona sandbox preview on the resolved dev port - 2026-05-06
 
 - **Why**: The preview pane could display port 3000 while hidden state still defaulted to 3001, and the navigation-sync proxy generated Daytona preview URLs for port 33000, outside Daytona's supported preview range.
-- **Change**: Removed the 3001 preview-port default, resolved preview ports as `URL override -> saved devPort -> 3000`, synchronized the port input from the resolved port prop, moved the navigation-sync proxy to available ports in the 9000-9999 range, and stopped caching signed preview URLs in sessionStorage.
-- **Reason**: Preview URL generation, the visible port control, and Daytona's supported preview-port contract now agree on the same target port. Signed preview URLs are time-bound capability URLs and should be resolved fresh instead of persisted.
+- **Change**: Removed the 3001 preview-port default, resolved preview ports as `URL override -> saved devPort -> 3000`, synchronized the port input from the resolved port prop, moved the navigation-sync proxy to available ports in the 9000-9999 range, stopped caching signed preview URLs in sessionStorage, and kept only per-pane preview paths cached.
+- **Reason**: Preview URL generation, the visible port control, and Daytona's supported preview-port contract now agree on the same target port. Signed preview URLs are time-bound capability URLs and should be resolved fresh, while simple app paths are safe to restore after refresh.
 
 ## Project-level sandbox preview - 2026-05-06
 

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -3,8 +3,8 @@
 ## Keep Daytona sandbox preview on the resolved dev port - 2026-05-06
 
 - **Why**: The preview pane could display port 3000 while hidden state still defaulted to 3001, and the navigation-sync proxy generated Daytona preview URLs for port 33000, outside Daytona's supported preview range.
-- **Change**: Removed the 3001 preview-port default, resolved preview ports as `URL override -> saved devPort -> 3000`, synchronized the port input from the resolved port prop, moved the navigation-sync proxy to available ports in the 9000-9999 range, and bumped the preview cache key so browsers discard cached 33000 URLs.
-- **Reason**: Preview URL generation, the visible port control, and Daytona's supported preview-port contract now agree on the same target port.
+- **Change**: Removed the 3001 preview-port default, resolved preview ports as `URL override -> saved devPort -> 3000`, synchronized the port input from the resolved port prop, moved the navigation-sync proxy to available ports in the 9000-9999 range, and stopped caching signed preview URLs in sessionStorage.
+- **Reason**: Preview URL generation, the visible port control, and Daytona's supported preview-port contract now agree on the same target port. Signed preview URLs are time-bound capability URLs and should be resolved fresh instead of persisted.
 
 ## Project-level sandbox preview - 2026-05-06
 


### PR DESCRIPTION
daytona preview URLs are time-bound capability tokens. persisting them in
sessionStorage can resurrect stale targets after token expiry. instead,
resolve fresh on each sandbox activation and clean up legacy cache entries.