### PR TITLE
feat(notifications): instant debounced emails for high-signal activity

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -171,6 +171,7 @@ import type * as mcp_tools from "../mcp/tools.js";
 import type * as messages from "../messages.js";
 import type * as migrations from "../migrations.js";
 import type * as notificationDigest from "../notificationDigest.js";
+import type * as notificationEmail from "../notificationEmail.js";
 import type * as notifications from "../notifications.js";
 import type * as prBody from "../prBody.js";
 import type * as presence from "../presence.js";
@@ -392,6 +393,7 @@ declare const fullApi: ApiFromModules<{
   messages: typeof messages;
   migrations: typeof migrations;
   notificationDigest: typeof notificationDigest;
+  notificationEmail: typeof notificationEmail;
   notifications: typeof notifications;
   prBody: typeof prBody;
   presence: typeof presence;

--- a/packages/backend/convex/emailTemplates.ts
+++ b/packages/backend/convex/emailTemplates.ts
@@ -18,6 +18,11 @@ export interface DigestEmailOptions {
   /** Base URL of the web app, e.g. https://app.example.com (no trailing slash needed). */
   appUrl: string;
   notifications: DigestNotification[];
+  /**
+   * Overrides the default "You have N unread notifications" heading. Used by the
+   * instant single-notification email to lead with the activity itself.
+   */
+  heading?: string;
 }
 
 const BRAND = "#4f46e5";
@@ -148,7 +153,9 @@ export function buildNotificationDigestHtml(opts: DigestEmailOptions): string {
   const greeting = opts.recipientName
     ? `Hi ${escapeHtml(opts.recipientName)},`
     : "Hi,";
-  const heading = `You have ${count} unread notification${count === 1 ? "" : "s"}`;
+  const heading =
+    opts.heading ??
+    `You have ${count} unread notification${count === 1 ? "" : "s"}`;
   const rows = opts.notifications
     .map((n) => renderNotification(n, opts.appUrl))
     .join("");

--- a/packages/backend/convex/notificationEmail.ts
+++ b/packages/backend/convex/notificationEmail.ts
@@ -1,0 +1,65 @@
+"use node";
+
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { sendEmail } from "./email";
+import { buildNotificationDigestHtml } from "./emailTemplates";
+
+/** Reads a required environment variable, throwing a clear error when it is missing. */
+function getEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set in the Convex environment`);
+  }
+  return value;
+}
+
+/**
+ * Sends the instant notification email for a user, debounced via the scheduler
+ * delay in createNotification. It re-reads the user's unread, not-yet-emailed,
+ * high-signal notifications at send time, so anything read in-app during the
+ * delay is silently skipped and a burst collapses into a single email. A single
+ * item leads with its own title; multiple are summarised by count. Marking the
+ * items emailed keeps the daily digest from repeating them.
+ */
+export const sendUnreadForUser = internalAction({
+  args: { userId: v.id("users") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const data = await ctx.runQuery(
+      internal.notifications.getUnreadEmailableForUser,
+      { userId: args.userId },
+    );
+    if (!data) return null;
+
+    const appUrl = getEnv("WEB_APP_URL");
+    const count = data.notifications.length;
+    const [first] = data.notifications;
+
+    // A single item leads with its own title for immediacy; a burst is summarised
+    // by count. The `if` narrows `first` to defined for the single-item branch.
+    let subject: string;
+    let heading: string | undefined;
+    if (count === 1 && first !== undefined) {
+      subject = first.title;
+      heading = "New activity";
+    } else {
+      subject = `You have ${count} new notifications`;
+      heading = undefined;
+    }
+
+    const html = buildNotificationDigestHtml({
+      recipientName: data.name,
+      appUrl,
+      notifications: data.notifications,
+      heading,
+    });
+
+    await sendEmail({ to: data.email, subject, html });
+    await ctx.runMutation(internal.notifications.markEmailed, {
+      notificationIds: data.notifications.map((n) => n.id),
+    });
+    return null;
+  },
+});

--- a/packages/backend/convex/notifications.ts
+++ b/packages/backend/convex/notifications.ts
@@ -1,11 +1,35 @@
-import { MutationCtx, internalQuery } from "./_generated/server";
+import {
+  MutationCtx,
+  internalQuery,
+  internalMutation,
+} from "./_generated/server";
 import { v, Infer } from "convex/values";
 import type { Id } from "./_generated/dataModel";
+import { internal } from "./_generated/api";
 import { notificationTypeValidator } from "./validators";
 import { authQuery, authMutation } from "./functions";
 
 /** Max unread notifications shown per user in the daily digest email. */
 const DIGEST_NOTIFICATION_LIMIT = 50;
+
+/**
+ * Notification types worth an instant (debounced) email — high-signal, human-
+ * directed activity. Everything else waits for the daily digest. Lower-signal
+ * types (run/task completion, system) are intentionally absent.
+ */
+const EMAIL_NOTIFICATION_TYPES: ReadonlySet<string> = new Set([
+  "mention",
+  "comment_reply",
+  "comment_added",
+  "task_assigned",
+]);
+
+/**
+ * Delay before an instant notification email is sent. Acts as a debounce: a
+ * burst of activity within this window is swept into a single email, and the
+ * send is skipped entirely if the user reads the notification in-app first.
+ */
+const EMAIL_SEND_DELAY_MS = 5 * 60 * 1000;
 
 /**
  * How many unread notifications to scan per user before filtering. Larger than
@@ -60,9 +84,10 @@ export async function createNotification(
       }
     }
   }
+  const type = params.type ?? "system";
   await ctx.db.insert("notifications", {
     userId: params.userId,
-    type: params.type ?? "system",
+    type,
     title: params.title,
     message: params.message,
     href,
@@ -70,6 +95,16 @@ export async function createNotification(
     read: false,
     createdAt: Date.now(),
   });
+
+  // High-signal types get an instant email after a short debounce. The send is
+  // skipped if the user reads it in-app first (see notificationEmail.ts).
+  if (EMAIL_NOTIFICATION_TYPES.has(type)) {
+    await ctx.scheduler.runAfter(
+      EMAIL_SEND_DELAY_MS,
+      internal.notificationEmail.sendUnreadForUser,
+      { userId: params.userId },
+    );
+  }
 }
 
 const notificationValidator = v.object({
@@ -83,6 +118,7 @@ const notificationValidator = v.object({
   href: v.optional(v.string()),
   repoId: v.optional(v.id("githubRepos")),
   createdAt: v.number(),
+  emailedAt: v.optional(v.number()),
 });
 
 /** Lists the 100 most recent notifications for the current user. */
@@ -193,7 +229,10 @@ export const getDigestRecipients = internalQuery({
         .order("desc")
         .take(DIGEST_SCAN_LIMIT);
       const relevant = unread
-        .filter((n) => !DIGEST_EXCLUDED_TYPES.has(n.type))
+        .filter(
+          (n) =>
+            !DIGEST_EXCLUDED_TYPES.has(n.type) && n.emailedAt === undefined,
+        )
         .slice(0, DIGEST_NOTIFICATION_LIMIT);
       if (relevant.length === 0) continue;
       recipients.push({
@@ -209,5 +248,76 @@ export const getDigestRecipients = internalQuery({
       });
     }
     return recipients;
+  },
+});
+
+/**
+ * For an instant notification email: returns the user's unread, not-yet-emailed,
+ * high-signal notifications (or null if there is nothing to send — user opted
+ * out, has no email, or has already read/been emailed everything). Sweeping all
+ * pending items lets a burst within the debounce window collapse into one email.
+ * Internal use only (notificationEmail.sendUnreadForUser).
+ */
+export const getUnreadEmailableForUser = internalQuery({
+  args: { userId: v.id("users") },
+  returns: v.union(
+    v.object({
+      email: v.string(),
+      name: v.optional(v.string()),
+      notifications: v.array(
+        v.object({
+          id: v.id("notifications"),
+          title: v.string(),
+          message: v.optional(v.string()),
+          href: v.optional(v.string()),
+          type: notificationTypeValidator,
+          createdAt: v.number(),
+        }),
+      ),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const user = await ctx.db.get(args.userId);
+    if (!user || !user.email) return null;
+    if (user.emailNotificationsEnabled !== true) return null;
+
+    const unread = await ctx.db
+      .query("notifications")
+      .withIndex("by_user_and_read", (q) =>
+        q.eq("userId", args.userId).eq("read", false),
+      )
+      .order("desc")
+      .take(DIGEST_SCAN_LIMIT);
+    const relevant = unread.filter(
+      (n) => EMAIL_NOTIFICATION_TYPES.has(n.type) && n.emailedAt === undefined,
+    );
+    if (relevant.length === 0) return null;
+
+    return {
+      email: user.email,
+      name: user.firstName ?? user.fullName,
+      notifications: relevant.map((n) => ({
+        id: n._id,
+        title: n.title,
+        message: n.message,
+        href: n.href,
+        type: n.type,
+        createdAt: n.createdAt,
+      })),
+    };
+  },
+});
+
+/** Stamps emailedAt on the given notifications so they are not emailed again. */
+export const markEmailed = internalMutation({
+  args: { notificationIds: v.array(v.id("notifications")) },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    for (const id of args.notificationIds) {
+      await ctx.db.patch(id, { emailedAt: now });
+    }
+    return null;
   },
 });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -244,6 +244,9 @@ const schema = defineSchema({
     href: v.optional(v.string()),
     repoId: v.optional(v.id("githubRepos")),
     createdAt: v.number(),
+    // Set once this notification has been included in an email (instant send or
+    // daily digest), so neither path emails the same notification twice.
+    emailedAt: v.optional(v.number()),
   })
     .index("by_user", ["userId"])
     .index("by_user_and_read", ["userId", "read"])


### PR DESCRIPTION
@
## Summary

Users only received a once-daily notification digest, so time-sensitive activity (mentions, replies, comments, task assignments) could sit unseen for hours. This adds **instant, debounced emails** for high-signal notifications, modelled on how Linear handles inbox email.

## How it works

- When a high-signal notification is created (`mention`, `comment_reply`, `comment_added`, `task_assigned`), an email is scheduled **5 minutes later** via the Convex scheduler.
- At send time the action re-reads the user`s unread, not-yet-emailed notifications — **anything already read in-app is skipped**, so email is a fallback for when you are away, not a duplicate of every in-app ping.
- A burst of activity within the window **collapses into one email** (first scheduled send sweeps all pending items; later sends find nothing).
- Sent items are stamped with `emailedAt`, so the **daily digest never repeats** an instant email.
- A single item leads with its own title for immediacy; multiple are summarised by count.
- Gated by the existing `emailNotificationsEnabled` opt-in. The daily digest stays as the low-signal catch-all.

## Changes

- `schema.ts` — add `emailedAt` to `notifications`.
- `notifications.ts` — schedule the send in `createNotification`; add `getUnreadEmailableForUser` + `markEmailed`; exclude already-emailed items from the digest.
- `notificationEmail.ts` (new) — `sendUnreadForUser` node action.
- `emailTemplates.ts` — optional `heading` override for the single-item email.

## Note

Type checking is being run separately against a deployment-configured checkout (the worktree had no `CONVEX_DEPLOYMENT`, so codegen for the new module could not run there).
@