### PR TITLE
fix(task-comments): restrict comment deletion to the author

### DIFF
--- a/apps/web/src/lib/components/tasks/_components/CommentActivityItem.tsx
+++ b/apps/web/src/lib/components/tasks/_components/CommentActivityItem.tsx
@@ -210,13 +210,15 @@ export function CommentActivityItem({
                   Edit
                 </DropdownMenuItem>
               ) : null}
-              <DropdownMenuItem
-                className="text-destructive focus:text-destructive"
-                onClick={() => onDeleteRequest(comment._id)}
-              >
-                <IconTrash size={14} />
-                Delete
-              </DropdownMenuItem>
+              {isAuthor && !isDeleted ? (
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={() => onDeleteRequest(comment._id)}
+                >
+                  <IconTrash size={14} />
+                  Delete
+                </DropdownMenuItem>
+              ) : null}
             </DropdownMenuContent>
           </DropdownMenu>
           <RelativeDateTime

--- a/packages/backend/convex/taskComments.ts
+++ b/packages/backend/convex/taskComments.ts
@@ -193,6 +193,9 @@ export const remove = authMutation({
     if (!comment) {
       throw new Error("Comment not found");
     }
+    if (comment.authorId !== ctx.userId) {
+      throw new Error("Only the comment author can delete");
+    }
     const task = await ctx.db.get(comment.taskId);
     if (!task || !(await hasTaskAccess(ctx.db, task, ctx.userId))) {
       throw new Error("Comment not found");


### PR DESCRIPTION
## Problem

On quick-task activity, **any user with task access could delete anyone's comments** (including system-generated ones).

Two gaps, both fixed here:

1. **Backend** — `taskComments.remove` only checked task access, never that the caller authored the comment (unlike `taskComments.update`, which does).
2. **Frontend** — the **Delete** menu item in `CommentActivityItem` was shown to every user, while **Edit** was already gated behind `isAuthor`.

## Fix

- `remove` now throws unless `comment.authorId === ctx.userId`, mirroring the edit rule. This also blocks deleting system comments (which have no author).
- The Delete menu item is now gated behind `isAuthor && !isDeleted`, matching Edit. Non-authors still see **Reply**.

## Verification

- Backend: `convex codegen --typecheck enable` → exit 0.
- Web: `tsc -b` → exit 0.
