### PR TITLE
feat: docs edit/save button

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SessionPrdPlanEditor.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SessionPrdPlanEditor.tsx
@@ -4,9 +4,7 @@ import { useEditor, EditorContent } from "@tiptap/react";
 import type { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown } from "@tiptap/markdown";
-import { useCallback } from "react";
-import { Button } from "@conductor/ui";
-import { IconCheck, IconX } from "@tabler/icons-react";
+import { forwardRef, useImperativeHandle } from "react";
 
 const prdExtensions = [
   StarterKit.configure({
@@ -23,19 +21,18 @@ function getMarkdownFromEditor(editor: Editor): string {
   return editor.getMarkdown();
 }
 
-interface SessionPrdPlanEditorProps {
-  initialMarkdown: string;
-  onSave: (markdown: string) => void | Promise<void>;
-  onCancel: () => void;
-  isSaving: boolean;
+export interface SessionPrdPlanEditorHandle {
+  getMarkdown: () => string | null;
 }
 
-export function SessionPrdPlanEditor({
-  initialMarkdown,
-  onSave,
-  onCancel,
-  isSaving,
-}: SessionPrdPlanEditorProps) {
+interface SessionPrdPlanEditorProps {
+  initialMarkdown: string;
+}
+
+export const SessionPrdPlanEditor = forwardRef<
+  SessionPrdPlanEditorHandle,
+  SessionPrdPlanEditorProps
+>(function SessionPrdPlanEditor({ initialMarkdown }, ref) {
   const editor = useEditor({
     extensions: prdExtensions,
     content: initialMarkdown,
@@ -49,41 +46,18 @@ export function SessionPrdPlanEditor({
     },
   });
 
-  const handleSave = useCallback(() => {
-    if (!editor) return;
-    const md = getMarkdownFromEditor(editor);
-    void onSave(md);
-  }, [editor, onSave]);
+  useImperativeHandle(ref, () => ({
+    getMarkdown: () => (editor ? getMarkdownFromEditor(editor) : null),
+  }));
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
+    <div className="flex min-h-0 flex-1 flex-col">
       <div className="min-h-0 flex-1 overflow-y-auto rounded-md bg-muted/40">
         <EditorContent
           editor={editor}
           className="[&_.tiptap]:min-h-[12rem] [&_.tiptap]:outline-none"
         />
       </div>
-      <div className="flex shrink-0 justify-end gap-2">
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          disabled={isSaving}
-          onClick={onCancel}
-        >
-          <IconX className="h-3.5 w-3.5" />
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          disabled={isSaving || !editor}
-          onClick={handleSave}
-        >
-          <IconCheck className="h-3.5 w-3.5" />
-          Save
-        </Button>
-      </div>
     </div>
   );
-}
+});

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SessionPrdPlanView.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SessionPrdPlanView.tsx
@@ -14,10 +14,19 @@ import {
   PlanTrigger,
   MessageResponse,
 } from "@conductor/ui";
-import { IconCheck, IconCode, IconCopy, IconPencil } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconCode,
+  IconCopy,
+  IconPencil,
+  IconX,
+} from "@tabler/icons-react";
 import type { Id } from "@conductor/backend";
 import { api } from "@conductor/backend";
-import { SessionPrdPlanEditor } from "./SessionPrdPlanEditor";
+import {
+  SessionPrdPlanEditor,
+  type SessionPrdPlanEditorHandle,
+} from "./SessionPrdPlanEditor";
 
 interface SessionPrdPlanViewProps {
   sessionId: Id<"sessions">;
@@ -41,6 +50,7 @@ export function SessionPrdPlanView({
   const [isSaving, setIsSaving] = useState(false);
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const editorRef = useRef<SessionPrdPlanEditorHandle>(null);
 
   const showEdit = !isArchived && editingSnapshot === null;
 
@@ -66,21 +76,20 @@ export function SessionPrdPlanView({
     setEditingSnapshot(null);
   }, []);
 
-  const handleSave = useCallback(
-    async (markdown: string) => {
-      setIsSaving(true);
-      try {
-        await updatePlanContent({
-          id: sessionId,
-          planContent: markdown,
-        });
-        setEditingSnapshot(null);
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [sessionId, updatePlanContent],
-  );
+  const handleSave = useCallback(async () => {
+    const markdown = editorRef.current?.getMarkdown();
+    if (markdown === null || markdown === undefined) return;
+    setIsSaving(true);
+    try {
+      await updatePlanContent({
+        id: sessionId,
+        planContent: markdown,
+      });
+      setEditingSnapshot(null);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [sessionId, updatePlanContent]);
 
   return (
     <Plan
@@ -120,10 +129,8 @@ export function SessionPrdPlanView({
         {editingSnapshot !== null ? (
           <SessionPrdPlanEditor
             key={editKey}
+            ref={editorRef}
             initialMarkdown={editingSnapshot}
-            onSave={handleSave}
-            onCancel={handleCancelEdit}
-            isSaving={isSaving}
           />
         ) : (
           <div
@@ -144,27 +151,51 @@ export function SessionPrdPlanView({
           isPanel && "shrink-0",
         )}
       >
-        {showEdit ? (
-          <Button
-            size="sm"
-            variant="secondary"
-            className="motion-press"
-            onClick={handleStartEdit}
-          >
-            <IconPencil className="w-3.5 h-3.5" />
-            Edit
-          </Button>
-        ) : null}
-        {editingSnapshot === null ? (
-          <Button
-            size="sm"
-            className="motion-press bg-success text-success-foreground hover:bg-success/90 hover:scale-[1.01] active:scale-[0.96]"
-            onClick={onApprovePlan}
-          >
-            <IconCode className="w-3.5 h-3.5" />
-            Approve Plan
-          </Button>
-        ) : null}
+        {editingSnapshot !== null ? (
+          <>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="motion-press"
+              disabled={isSaving}
+              onClick={handleCancelEdit}
+            >
+              <IconX className="w-3.5 h-3.5" />
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              className="motion-press"
+              disabled={isSaving}
+              onClick={handleSave}
+            >
+              <IconCheck className="w-3.5 h-3.5" />
+              Save
+            </Button>
+          </>
+        ) : (
+          <>
+            {showEdit ? (
+              <Button
+                size="sm"
+                variant="secondary"
+                className="motion-press"
+                onClick={handleStartEdit}
+              >
+                <IconPencil className="w-3.5 h-3.5" />
+                Edit
+              </Button>
+            ) : null}
+            <Button
+              size="sm"
+              className="motion-press bg-success text-success-foreground hover:bg-success/90 hover:scale-[1.01] active:scale-[0.96]"
+              onClick={onApprovePlan}
+            >
+              <IconCode className="w-3.5 h-3.5" />
+              Approve Plan
+            </Button>
+          </>
+        )}
       </PlanFooter>
     </Plan>
   );


### PR DESCRIPTION
Move Save/Cancel buttons from the PRD editor content area into the
PlanFooter so they occupy the same position as the Edit button.
This prevents cursor movement between editing and saving.