### PR TITLE
feat(artifacts): host Cowork artifacts in eva with an in-app MCP bridge

### DIFF
--- a/apps/web/src/lib/components/Sidebar.tsx
+++ b/apps/web/src/lib/components/Sidebar.tsx
@@ -192,6 +192,7 @@ export function Sidebar() {
       "setup",
       "teams",
       "inbox",
+      "artifacts",
       "api",
       "settings",
       "testing",

--- a/apps/web/src/lib/components/artifacts/ArtifactCard.tsx
+++ b/apps/web/src/lib/components/artifacts/ArtifactCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Link } from "@tanstack/react-router";
+import { useMutation } from "convex/react";
+import { api } from "@conductor/backend";
+import type { FunctionReturnType } from "convex/server";
+import { IconLayoutDashboard, IconTrash } from "@tabler/icons-react";
+
+type ArtifactRow = FunctionReturnType<typeof api.artifacts.listAll>[number];
+
+/** A single artifact tile: opens the viewer on click; trash button deletes it. */
+export function ArtifactCard({ artifact }: { artifact: ArtifactRow }) {
+  const remove = useMutation(api.artifacts.remove);
+
+  const onDelete = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!window.confirm(`Delete "${artifact.name}"? This cannot be undone.`)) {
+      return;
+    }
+    await remove({ id: artifact._id });
+  };
+
+  return (
+    <Link
+      to="/artifacts/$artifactId"
+      params={{ artifactId: artifact._id }}
+      className="group relative flex flex-col gap-2 rounded-surface border border-border bg-card p-4 shadow-sm transition-colors hover:bg-muted"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <IconLayoutDashboard
+            size={18}
+            className="shrink-0 text-muted-foreground"
+          />
+          <span className="truncate font-medium text-foreground">
+            {artifact.name}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onDelete}
+          aria-label="Delete artifact"
+          className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+        >
+          <IconTrash size={15} />
+        </button>
+      </div>
+      {artifact.description ? (
+        <p className="line-clamp-2 text-sm text-muted-foreground">
+          {artifact.description}
+        </p>
+      ) : null}
+      <span className="mt-auto text-xs text-muted-foreground">
+        {new Date(artifact.createdAt).toLocaleDateString()}
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/src/lib/components/artifacts/ArtifactFrame.tsx
+++ b/apps/web/src/lib/components/artifacts/ArtifactFrame.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useRef } from "react";
+import { buildArtifactSrcDoc } from "./_shim";
+import { useArtifactBridge } from "./useArtifactBridge";
+
+/** Renders a hosted artifact in a sandboxed iframe with the cowork bridge wired up. */
+export function ArtifactFrame({
+  html,
+  title,
+}: {
+  html: string;
+  title: string;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  useArtifactBridge(iframeRef);
+  return (
+    <iframe
+      ref={iframeRef}
+      title={title}
+      srcDoc={buildArtifactSrcDoc(html)}
+      // allow-scripts WITHOUT allow-same-origin: the artifact runs in an opaque
+      // origin and cannot reach eva's cookies, storage, or DOM. CDN scripts and
+      // postMessage still work.
+      sandbox="allow-scripts"
+      className="h-full w-full border-0 bg-white"
+    />
+  );
+}

--- a/apps/web/src/lib/components/artifacts/ArtifactList.tsx
+++ b/apps/web/src/lib/components/artifacts/ArtifactList.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { FunctionReturnType } from "convex/server";
+import { api } from "@conductor/backend";
+import { IconLayoutDashboard } from "@tabler/icons-react";
+import { EmptyState } from "@/lib/components/ui/EmptyState";
+import { ArtifactCard } from "./ArtifactCard";
+
+type ArtifactRow = FunctionReturnType<typeof api.artifacts.listAll>[number];
+
+/** Responsive grid of artifact tiles, or an empty state. */
+export function ArtifactList({
+  artifacts,
+  emptyDescription,
+}: {
+  artifacts: ArtifactRow[];
+  emptyDescription: string;
+}) {
+  if (artifacts.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <IconLayoutDashboard size={24} className="text-muted-foreground" />
+        }
+        title="No artifacts yet"
+        description={emptyDescription}
+      />
+    );
+  }
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {artifacts.map((artifact) => (
+        <ArtifactCard key={artifact._id} artifact={artifact} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/artifacts/ArtifactUploadDialog.tsx
+++ b/apps/web/src/lib/components/artifacts/ArtifactUploadDialog.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { useMutation } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogTrigger,
+  Input,
+  Label,
+  Textarea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@conductor/ui";
+import { IconUpload } from "@tabler/icons-react";
+import { parseArtifactMeta, parseStorageId } from "./_meta";
+
+/**
+ * Upload a Cowork artifact HTML file and bind it to a team. Parses the
+ * cowork-artifact-meta manifest to pre-fill the name/description/tools. When
+ * `defaultTeamId` is given (the team tab) the team is fixed and the picker is
+ * hidden; otherwise the user chooses from their teams.
+ */
+export function ArtifactUploadDialog({
+  defaultTeamId,
+}: {
+  defaultTeamId?: Id<"teams">;
+}) {
+  const teams = useQuery(api.teams.list) ?? [];
+  const generateUploadUrl = useMutation(api.artifacts.generateUploadUrl);
+  const create = useMutation(api.artifacts.create);
+
+  const [open, setOpen] = useState(false);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [html, setHtml] = useState("");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [declaredTools, setDeclaredTools] = useState<string[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setFileName(null);
+    setHtml("");
+    setName("");
+    setDescription("");
+    setDeclaredTools([]);
+    setSelectedTeamId("");
+    setError(null);
+  };
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const meta = parseArtifactMeta(text, file.name.replace(/\.html?$/i, ""));
+    setFileName(file.name);
+    setHtml(text);
+    setName(meta.name);
+    setDescription(meta.description);
+    setDeclaredTools(meta.declaredTools);
+  };
+
+  const onSubmit = async () => {
+    setUploading(true);
+    setError(null);
+    try {
+      const teamId =
+        defaultTeamId ?? teams.find((t) => t._id === selectedTeamId)?._id;
+      if (!teamId) throw new Error("Choose a team.");
+      if (!html) throw new Error("Choose an artifact HTML file.");
+      if (!name.trim()) throw new Error("Give the artifact a name.");
+
+      const uploadUrl = await generateUploadUrl({});
+      const res = await fetch(uploadUrl, {
+        method: "POST",
+        headers: { "Content-Type": "text/html" },
+        body: html,
+      });
+      const storageId = parseStorageId(await res.text());
+      if (!res.ok || !storageId) throw new Error("Upload failed.");
+
+      await create({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        boundTeamId: teamId,
+        declaredTools,
+        htmlStorageId: storageId,
+      });
+      reset();
+      setOpen(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const bareTools = declaredTools
+    .map((t) => t.split("__").pop() ?? t)
+    .join(", ");
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <IconUpload size={16} />
+          Upload artifact
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upload artifact</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="artifact-file">Artifact HTML</Label>
+            <input
+              id="artifact-file"
+              type="file"
+              accept=".html,text/html"
+              onChange={onFileChange}
+              className="text-sm file:mr-3 file:rounded-surface file:border file:border-border file:bg-muted file:px-3 file:py-1.5 file:text-sm"
+            />
+            {fileName ? (
+              <span className="text-xs text-muted-foreground">{fileName}</span>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="artifact-name">Name</Label>
+            <Input
+              id="artifact-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Artifact name"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="artifact-description">Description</Label>
+            <Textarea
+              id="artifact-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder="What this artifact shows"
+            />
+          </div>
+
+          {defaultTeamId ? null : (
+            <div className="flex flex-col gap-1.5">
+              <Label>Team</Label>
+              <Select value={selectedTeamId} onValueChange={setSelectedTeamId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a team" />
+                </SelectTrigger>
+                <SelectContent>
+                  {teams.map((t) => (
+                    <SelectItem key={t._id} value={t._id}>
+                      {t.displayName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {bareTools ? (
+            <p className="text-xs text-muted-foreground">
+              Declares tools: {bareTools}
+            </p>
+          ) : null}
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={uploading}
+          >
+            Cancel
+          </Button>
+          <Button onClick={onSubmit} disabled={uploading || !html}>
+            {uploading ? "Uploading..." : "Upload"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/components/artifacts/ArtifactViewer.tsx
+++ b/apps/web/src/lib/components/artifacts/ArtifactViewer.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { api } from "@conductor/backend";
+import { Spinner } from "@conductor/ui";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { ArtifactFrame } from "./ArtifactFrame";
+
+/** Loads an artifact's stored HTML and renders it in the bridged sandbox iframe. */
+export function ArtifactViewer({ artifactId }: { artifactId: string }) {
+  const artifact = useQuery(api.artifacts.get, { id: artifactId });
+  const [html, setHtml] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const url = artifact?.url ?? null;
+  useEffect(() => {
+    if (!url) return;
+    let cancelled = false;
+    setHtml(null);
+    setError(null);
+    fetch(url)
+      .then((r) => {
+        if (!r.ok) {
+          throw new Error(`Failed to load artifact (status ${r.status})`);
+        }
+        return r.text();
+      })
+      .then((text) => {
+        if (!cancelled) setHtml(text);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (artifact === undefined) {
+    return <Centered>{<Spinner />}</Centered>;
+  }
+  if (artifact === null) {
+    return (
+      <Centered>
+        <p className="text-sm text-muted-foreground">
+          Artifact not found, or you do not have access.
+        </p>
+      </Centered>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <Link
+          to="/artifacts"
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <IconArrowLeft size={16} />
+          Artifacts
+        </Link>
+        <span className="text-muted-foreground">/</span>
+        <h1 className="truncate font-medium text-foreground">
+          {artifact.name}
+        </h1>
+      </div>
+      <div className="h-[80vh] w-full overflow-hidden rounded-surface border border-border bg-white shadow-sm">
+        {error ? (
+          <Centered>
+            <p className="text-sm text-destructive">{error}</p>
+          </Centered>
+        ) : html === null ? (
+          <Centered>{<Spinner />}</Centered>
+        ) : (
+          <ArtifactFrame html={html} title={artifact.name} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Centered({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full min-h-64 items-center justify-center">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/artifacts/_meta.ts
+++ b/apps/web/src/lib/components/artifacts/_meta.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import type { Id } from "@conductor/backend";
+
+// The cowork-artifact-meta manifest embedded in a Cowork artifact's HTML. Extra
+// keys (schemaVersion, mcpServerNames, …) are ignored by the non-strict schema.
+const metaSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  mcpTools: z.array(z.string()).optional(),
+});
+
+export interface ParsedArtifactMeta {
+  name: string;
+  description: string;
+  declaredTools: string[];
+}
+
+/** Reads the cowork-artifact-meta manifest from an artifact's HTML, with fallbacks. */
+export function parseArtifactMeta(
+  html: string,
+  fallbackName: string,
+): ParsedArtifactMeta {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const raw = doc.getElementById("cowork-artifact-meta")?.textContent?.trim();
+  if (!raw) {
+    return { name: fallbackName, description: "", declaredTools: [] };
+  }
+  try {
+    const meta = metaSchema.parse(JSON.parse(raw));
+    return {
+      name: meta.name ?? fallbackName,
+      description: meta.description ?? "",
+      declaredTools: meta.mcpTools ?? [],
+    };
+  } catch {
+    return { name: fallbackName, description: "", declaredTools: [] };
+  }
+}
+
+/**
+ * Extracts the storage ID from Convex's upload-URL response body. Mirrors the
+ * helper in SnapshotsClient: `response.storageId` is already the branded id, so
+ * returning it needs no `as` cast.
+ */
+export function parseStorageId(text: string): Id<"_storage"> | null {
+  try {
+    const response = JSON.parse(text);
+    return typeof response.storageId === "string" ? response.storageId : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/components/artifacts/_shim.ts
+++ b/apps/web/src/lib/components/artifacts/_shim.ts
@@ -1,0 +1,79 @@
+// The cowork bridge injected into every hosted artifact iframe before the
+// artifact's own scripts run. It recreates `window.cowork.callMcpTool` — the API
+// Claude's Cowork host normally injects — by posting each call to the parent
+// (eva), which runs it through eva's read-only MCP tools and posts the result
+// back, correlated by a per-call id. The artifact runs unmodified.
+//
+// Readiness handshake: the sandboxed iframe (opaque origin) and the parent's
+// message listener attach on independent schedules, so a call posted before the
+// parent is listening would be lost. The shim therefore queues calls and pings
+// the parent with "eva-bridge-hello" until it receives "eva-bridge-ready", then
+// flushes the queue. This makes delivery race-free without `allow-same-origin`.
+const COWORK_SHIM = `<script>
+(function () {
+  // In an opaque-origin sandbox (allow-scripts, no allow-same-origin) accessing
+  // localStorage/sessionStorage throws a SecurityError, which would abort any
+  // artifact that touches them at top level. Provide an in-memory polyfill so
+  // those artifacts run under the strict sandbox (per-session, not persisted).
+  function makeStore() {
+    var s = {};
+    return {
+      getItem: function (k) { return Object.prototype.hasOwnProperty.call(s, k) ? s[k] : null; },
+      setItem: function (k, v) { s[k] = String(v); },
+      removeItem: function (k) { delete s[k]; },
+      clear: function () { s = {}; },
+      key: function (i) { return Object.keys(s)[i] || null; },
+      get length() { return Object.keys(s).length; },
+    };
+  }
+  function ensureStore(name) {
+    try { var t = window[name]; if (t) { t.getItem("__probe"); return; } } catch (e) { /* blocked */ }
+    try { Object.defineProperty(window, name, { value: makeStore(), configurable: true }); } catch (e) { /* ignore */ }
+  }
+  ensureStore("localStorage");
+  ensureStore("sessionStorage");
+
+  var seq = 0, pending = {}, ready = false, queue = [];
+  function send(m) { parent.postMessage(m, "*"); }
+  function flush() { if (ready) return; ready = true; while (queue.length) send(queue.shift()); }
+  window.cowork = {
+    callMcpTool: function (name, args) {
+      return new Promise(function (resolve, reject) {
+        var id = ++seq;
+        pending[id] = { resolve: resolve, reject: reject };
+        var msg = { source: "eva-artifact", type: "eva-mcp-call", id: id, name: name, args: args };
+        if (ready) send(msg); else queue.push(msg);
+      });
+    },
+  };
+  window.addEventListener("message", function (e) {
+    var d = e.data;
+    if (!d || typeof d !== "object") return;
+    if (d.type === "eva-bridge-ready") { flush(); return; }
+    if (d.type !== "eva-mcp-result") return;
+    var entry = pending[d.id];
+    if (!entry) return;
+    delete pending[d.id];
+    if (d.error) entry.reject(new Error(d.error));
+    else entry.resolve(d.result);
+  });
+  var tries = 0;
+  (function hello() {
+    if (ready || tries++ > 40) return;
+    send({ source: "eva-artifact", type: "eva-bridge-hello" });
+    setTimeout(hello, 50);
+  })();
+})();
+</script>`;
+
+/**
+ * Returns the artifact HTML with the cowork bridge injected so it is defined
+ * before the artifact's scripts. Injects right after <head> (keeping the
+ * doctype first, avoiding quirks mode); falls back to prepending.
+ */
+export function buildArtifactSrcDoc(html: string): string {
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(/(<head[^>]*>)/i, `$1${COWORK_SHIM}`);
+  }
+  return COWORK_SHIM + html;
+}

--- a/apps/web/src/lib/components/artifacts/useArtifactBridge.ts
+++ b/apps/web/src/lib/components/artifacts/useArtifactBridge.ts
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+import type { RefObject } from "react";
+import { useAction } from "convex/react";
+import { api } from "@conductor/backend";
+
+/**
+ * Parent-side half of the artifact bridge. Listens for messages from the
+ * sandboxed artifact iframe:
+ *  - "eva-bridge-hello": the shim announcing it is ready; we reply
+ *    "eva-bridge-ready" so it flushes any queued calls (race-free handshake).
+ *  - "eva-mcp-call": a tool call, which we run through eva's read-only MCP tools
+ *    as the signed-in user (api.artifacts.callTool) and reply to, by id.
+ * Messages are accepted only from this iframe's own contentWindow (the sandboxed
+ * frame is an opaque origin, so we match by source, not origin).
+ */
+export function useArtifactBridge(
+  iframeRef: RefObject<HTMLIFrameElement | null>,
+): void {
+  const callTool = useAction(api.artifacts.callTool);
+
+  useEffect(() => {
+    async function handle(event: MessageEvent) {
+      const iframe = iframeRef.current;
+      if (!iframe || event.source !== iframe.contentWindow) return;
+      const data = event.data;
+      if (typeof data !== "object" || data === null || !("type" in data))
+        return;
+
+      if (data.type === "eva-bridge-hello") {
+        iframe.contentWindow?.postMessage({ type: "eva-bridge-ready" }, "*");
+        return;
+      }
+      if (data.type !== "eva-mcp-call") return;
+
+      const id = data.id;
+      const reply = (payload: Record<string, unknown>) =>
+        iframe.contentWindow?.postMessage(
+          { type: "eva-mcp-result", id, ...payload },
+          "*",
+        );
+      try {
+        const result = await callTool({
+          toolName: String(data.name),
+          args: JSON.stringify(data.args ?? {}),
+        });
+        reply({ result });
+      } catch (err) {
+        reply({ error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    function listener(event: MessageEvent) {
+      void handle(event);
+    }
+    window.addEventListener("message", listener);
+    return () => window.removeEventListener("message", listener);
+  }, [callTool, iframeRef]);
+}

--- a/apps/web/src/lib/components/sidebar/RootSidebarContent.tsx
+++ b/apps/web/src/lib/components/sidebar/RootSidebarContent.tsx
@@ -5,6 +5,7 @@ import {
   IconBell,
   IconHome,
   IconInbox,
+  IconLayoutDashboard,
   IconPalette,
   IconServerBolt,
   IconTestPipe,
@@ -21,6 +22,7 @@ import {
 const ROOT_NAV_ITEMS = [
   { name: "Home", href: "/home", icon: IconHome },
   { name: "Teams", href: "/teams", icon: IconUsers },
+  { name: "Artifacts", href: "/artifacts", icon: IconLayoutDashboard },
   { name: "Inbox", href: "/inbox", icon: IconInbox },
   { name: "Theme", href: "/settings/theme", icon: IconPalette },
   { name: "Notifications", href: "/settings/notifications", icon: IconBell },

--- a/apps/web/src/lib/search-params.ts
+++ b/apps/web/src/lib/search-params.ts
@@ -182,7 +182,7 @@ export function isEnvVarScope(s: string): s is EnvVarScope {
   return (envVarScopes as readonly string[]).includes(s);
 }
 
-const teamDetailTabs = ["members", "repos", "env"] as const;
+const teamDetailTabs = ["members", "repos", "env", "artifacts"] as const;
 export type TeamDetailTab = (typeof teamDetailTabs)[number];
 
 export function isTeamDetailTab(s: string): s is TeamDetailTab {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as GlobalTestingRouteImport } from './routes/_global/testing'
 import { Route as GlobalInboxRouteImport } from './routes/_global/inbox'
 import { Route as GlobalHomeRouteImport } from './routes/_global/home'
 import { Route as GlobalTeamsIndexRouteImport } from './routes/_global/teams/index'
+import { Route as GlobalArtifactsIndexRouteImport } from './routes/_global/artifacts/index'
 import { Route as McpOauthAuthorizeRouteImport } from './routes/mcp/oauth/authorize'
 import { Route as RepoOwnerRepoRouteImport } from './routes/_repo/$owner/$repo'
 import { Route as GlobalSetupIdRouteImport } from './routes/_global/setup/$id'
@@ -26,6 +27,7 @@ import { Route as GlobalSettingsSyncRouteImport } from './routes/_global/setting
 import { Route as GlobalSettingsSandboxesRouteImport } from './routes/_global/settings/sandboxes'
 import { Route as GlobalSettingsPersonalisationRouteImport } from './routes/_global/settings/personalisation'
 import { Route as GlobalSettingsNotificationsRouteImport } from './routes/_global/settings/notifications'
+import { Route as GlobalArtifactsArtifactIdRouteImport } from './routes/_global/artifacts/$artifactId'
 import { Route as GlobalTeamsTeamIdRouteRouteImport } from './routes/_global/teams/$teamId/route'
 import { Route as RepoOwnerRepoIndexRouteImport } from './routes/_repo/$owner/$repo/index'
 import { Route as GlobalTeamsTeamIdIndexRouteImport } from './routes/_global/teams/$teamId/index'
@@ -123,6 +125,11 @@ const GlobalTeamsIndexRoute = GlobalTeamsIndexRouteImport.update({
   path: '/teams/',
   getParentRoute: () => GlobalRoute,
 } as any)
+const GlobalArtifactsIndexRoute = GlobalArtifactsIndexRouteImport.update({
+  id: '/artifacts/',
+  path: '/artifacts/',
+  getParentRoute: () => GlobalRoute,
+} as any)
 const McpOauthAuthorizeRoute = McpOauthAuthorizeRouteImport.update({
   id: '/mcp/oauth/authorize',
   path: '/mcp/oauth/authorize',
@@ -163,6 +170,12 @@ const GlobalSettingsNotificationsRoute =
   GlobalSettingsNotificationsRouteImport.update({
     id: '/settings/notifications',
     path: '/settings/notifications',
+    getParentRoute: () => GlobalRoute,
+  } as any)
+const GlobalArtifactsArtifactIdRoute =
+  GlobalArtifactsArtifactIdRouteImport.update({
+    id: '/artifacts/$artifactId',
+    path: '/artifacts/$artifactId',
     getParentRoute: () => GlobalRoute,
   } as any)
 const GlobalTeamsTeamIdRouteRoute = GlobalTeamsTeamIdRouteRouteImport.update({
@@ -485,6 +498,7 @@ export interface FileRoutesByFullPath {
   '/inbox': typeof GlobalInboxRoute
   '/testing': typeof GlobalTestingRoute
   '/teams/$teamId': typeof GlobalTeamsTeamIdRouteRouteWithChildren
+  '/artifacts/$artifactId': typeof GlobalArtifactsArtifactIdRoute
   '/settings/notifications': typeof GlobalSettingsNotificationsRoute
   '/settings/personalisation': typeof GlobalSettingsPersonalisationRoute
   '/settings/sandboxes': typeof GlobalSettingsSandboxesRoute
@@ -493,6 +507,7 @@ export interface FileRoutesByFullPath {
   '/setup/$id': typeof GlobalSetupIdRoute
   '/$owner/$repo': typeof RepoOwnerRepoRouteWithChildren
   '/mcp/oauth/authorize': typeof McpOauthAuthorizeRoute
+  '/artifacts/': typeof GlobalArtifactsIndexRoute
   '/teams/': typeof GlobalTeamsIndexRoute
   '/$owner/$repo/quick-tasks': typeof RepoOwnerRepoQuickTasksRouteRouteWithChildren
   '/teams/$teamId/$teamTab': typeof GlobalTeamsTeamIdTeamTabRoute
@@ -554,6 +569,7 @@ export interface FileRoutesByTo {
   '/home': typeof GlobalHomeRoute
   '/inbox': typeof GlobalInboxRoute
   '/testing': typeof GlobalTestingRoute
+  '/artifacts/$artifactId': typeof GlobalArtifactsArtifactIdRoute
   '/settings/notifications': typeof GlobalSettingsNotificationsRoute
   '/settings/personalisation': typeof GlobalSettingsPersonalisationRoute
   '/settings/sandboxes': typeof GlobalSettingsSandboxesRoute
@@ -561,6 +577,7 @@ export interface FileRoutesByTo {
   '/settings/theme': typeof GlobalSettingsThemeRoute
   '/setup/$id': typeof GlobalSetupIdRoute
   '/mcp/oauth/authorize': typeof McpOauthAuthorizeRoute
+  '/artifacts': typeof GlobalArtifactsIndexRoute
   '/teams': typeof GlobalTeamsIndexRoute
   '/teams/$teamId/$teamTab': typeof GlobalTeamsTeamIdTeamTabRoute
   '/$owner/$repo/inbox': typeof RepoOwnerRepoInboxRoute
@@ -617,6 +634,7 @@ export interface FileRoutesById {
   '/_global/inbox': typeof GlobalInboxRoute
   '/_global/testing': typeof GlobalTestingRoute
   '/_global/teams/$teamId': typeof GlobalTeamsTeamIdRouteRouteWithChildren
+  '/_global/artifacts/$artifactId': typeof GlobalArtifactsArtifactIdRoute
   '/_global/settings/notifications': typeof GlobalSettingsNotificationsRoute
   '/_global/settings/personalisation': typeof GlobalSettingsPersonalisationRoute
   '/_global/settings/sandboxes': typeof GlobalSettingsSandboxesRoute
@@ -625,6 +643,7 @@ export interface FileRoutesById {
   '/_global/setup/$id': typeof GlobalSetupIdRoute
   '/_repo/$owner/$repo': typeof RepoOwnerRepoRouteWithChildren
   '/mcp/oauth/authorize': typeof McpOauthAuthorizeRoute
+  '/_global/artifacts/': typeof GlobalArtifactsIndexRoute
   '/_global/teams/': typeof GlobalTeamsIndexRoute
   '/_repo/$owner/$repo/quick-tasks': typeof RepoOwnerRepoQuickTasksRouteRouteWithChildren
   '/_global/teams/$teamId/$teamTab': typeof GlobalTeamsTeamIdTeamTabRoute
@@ -689,6 +708,7 @@ export interface FileRouteTypes {
     | '/inbox'
     | '/testing'
     | '/teams/$teamId'
+    | '/artifacts/$artifactId'
     | '/settings/notifications'
     | '/settings/personalisation'
     | '/settings/sandboxes'
@@ -697,6 +717,7 @@ export interface FileRouteTypes {
     | '/setup/$id'
     | '/$owner/$repo'
     | '/mcp/oauth/authorize'
+    | '/artifacts/'
     | '/teams/'
     | '/$owner/$repo/quick-tasks'
     | '/teams/$teamId/$teamTab'
@@ -758,6 +779,7 @@ export interface FileRouteTypes {
     | '/home'
     | '/inbox'
     | '/testing'
+    | '/artifacts/$artifactId'
     | '/settings/notifications'
     | '/settings/personalisation'
     | '/settings/sandboxes'
@@ -765,6 +787,7 @@ export interface FileRouteTypes {
     | '/settings/theme'
     | '/setup/$id'
     | '/mcp/oauth/authorize'
+    | '/artifacts'
     | '/teams'
     | '/teams/$teamId/$teamTab'
     | '/$owner/$repo/inbox'
@@ -820,6 +843,7 @@ export interface FileRouteTypes {
     | '/_global/inbox'
     | '/_global/testing'
     | '/_global/teams/$teamId'
+    | '/_global/artifacts/$artifactId'
     | '/_global/settings/notifications'
     | '/_global/settings/personalisation'
     | '/_global/settings/sandboxes'
@@ -828,6 +852,7 @@ export interface FileRouteTypes {
     | '/_global/setup/$id'
     | '/_repo/$owner/$repo'
     | '/mcp/oauth/authorize'
+    | '/_global/artifacts/'
     | '/_global/teams/'
     | '/_repo/$owner/$repo/quick-tasks'
     | '/_global/teams/$teamId/$teamTab'
@@ -957,6 +982,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GlobalTeamsIndexRouteImport
       parentRoute: typeof GlobalRoute
     }
+    '/_global/artifacts/': {
+      id: '/_global/artifacts/'
+      path: '/artifacts'
+      fullPath: '/artifacts/'
+      preLoaderRoute: typeof GlobalArtifactsIndexRouteImport
+      parentRoute: typeof GlobalRoute
+    }
     '/mcp/oauth/authorize': {
       id: '/mcp/oauth/authorize'
       path: '/mcp/oauth/authorize'
@@ -1011,6 +1043,13 @@ declare module '@tanstack/react-router' {
       path: '/settings/notifications'
       fullPath: '/settings/notifications'
       preLoaderRoute: typeof GlobalSettingsNotificationsRouteImport
+      parentRoute: typeof GlobalRoute
+    }
+    '/_global/artifacts/$artifactId': {
+      id: '/_global/artifacts/$artifactId'
+      path: '/artifacts/$artifactId'
+      fullPath: '/artifacts/$artifactId'
+      preLoaderRoute: typeof GlobalArtifactsArtifactIdRouteImport
       parentRoute: typeof GlobalRoute
     }
     '/_global/teams/$teamId': {
@@ -1408,12 +1447,14 @@ interface GlobalRouteChildren {
   GlobalInboxRoute: typeof GlobalInboxRoute
   GlobalTestingRoute: typeof GlobalTestingRoute
   GlobalTeamsTeamIdRouteRoute: typeof GlobalTeamsTeamIdRouteRouteWithChildren
+  GlobalArtifactsArtifactIdRoute: typeof GlobalArtifactsArtifactIdRoute
   GlobalSettingsNotificationsRoute: typeof GlobalSettingsNotificationsRoute
   GlobalSettingsPersonalisationRoute: typeof GlobalSettingsPersonalisationRoute
   GlobalSettingsSandboxesRoute: typeof GlobalSettingsSandboxesRoute
   GlobalSettingsSyncRoute: typeof GlobalSettingsSyncRoute
   GlobalSettingsThemeRoute: typeof GlobalSettingsThemeRoute
   GlobalSetupIdRoute: typeof GlobalSetupIdRoute
+  GlobalArtifactsIndexRoute: typeof GlobalArtifactsIndexRoute
   GlobalTeamsIndexRoute: typeof GlobalTeamsIndexRoute
 }
 
@@ -1422,12 +1463,14 @@ const GlobalRouteChildren: GlobalRouteChildren = {
   GlobalInboxRoute: GlobalInboxRoute,
   GlobalTestingRoute: GlobalTestingRoute,
   GlobalTeamsTeamIdRouteRoute: GlobalTeamsTeamIdRouteRouteWithChildren,
+  GlobalArtifactsArtifactIdRoute: GlobalArtifactsArtifactIdRoute,
   GlobalSettingsNotificationsRoute: GlobalSettingsNotificationsRoute,
   GlobalSettingsPersonalisationRoute: GlobalSettingsPersonalisationRoute,
   GlobalSettingsSandboxesRoute: GlobalSettingsSandboxesRoute,
   GlobalSettingsSyncRoute: GlobalSettingsSyncRoute,
   GlobalSettingsThemeRoute: GlobalSettingsThemeRoute,
   GlobalSetupIdRoute: GlobalSetupIdRoute,
+  GlobalArtifactsIndexRoute: GlobalArtifactsIndexRoute,
   GlobalTeamsIndexRoute: GlobalTeamsIndexRoute,
 }
 

--- a/apps/web/src/routes/_global/artifacts/$artifactId.tsx
+++ b/apps/web/src/routes/_global/artifacts/$artifactId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ArtifactViewer } from "@/lib/components/artifacts/ArtifactViewer";
+
+export const Route = createFileRoute("/_global/artifacts/$artifactId")({
+  component: ArtifactRoute,
+});
+
+function ArtifactRoute() {
+  const { artifactId } = Route.useParams();
+  return <ArtifactViewer artifactId={artifactId} />;
+}

--- a/apps/web/src/routes/_global/artifacts/ArtifactsGlobalClient.tsx
+++ b/apps/web/src/routes/_global/artifacts/ArtifactsGlobalClient.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { api } from "@conductor/backend";
+import { Spinner } from "@conductor/ui";
+import { PageWrapper } from "@/lib/components/PageWrapper";
+import { ArtifactList } from "@/lib/components/artifacts/ArtifactList";
+import { ArtifactUploadDialog } from "@/lib/components/artifacts/ArtifactUploadDialog";
+
+/** Global Artifacts page: every artifact across the teams the user belongs to. */
+export function ArtifactsGlobalClient() {
+  const artifacts = useQuery(api.artifacts.listAll);
+
+  if (artifacts === undefined) {
+    return (
+      <div className="flex h-full flex-1 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <PageWrapper title="Artifacts" comfortable>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          Hosted dashboards that read live data through the Eva connector.
+        </p>
+        <ArtifactUploadDialog />
+      </div>
+      <ArtifactList
+        artifacts={artifacts}
+        emptyDescription="Upload a Cowork artifact HTML file to host it here. It runs live against the Eva MCP read-only tools."
+      />
+    </PageWrapper>
+  );
+}

--- a/apps/web/src/routes/_global/artifacts/index.tsx
+++ b/apps/web/src/routes/_global/artifacts/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ArtifactsGlobalClient } from "./ArtifactsGlobalClient";
+
+export const Route = createFileRoute("/_global/artifacts/")({
+  component: ArtifactsGlobalClient,
+});

--- a/apps/web/src/routes/_global/teams/TeamDetailClient.tsx
+++ b/apps/web/src/routes/_global/teams/TeamDetailClient.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@conductor/ui";
 import { TeamMembersTab } from "./_components/TeamMembersTab";
 import { TeamReposTab } from "./_components/TeamReposTab";
 import { TeamEnvVarsTab } from "./_components/TeamEnvVarsTab";
+import { TeamArtifactsTab } from "./_components/TeamArtifactsTab";
 import { useNavigate } from "@tanstack/react-router";
 
 export function TeamDetailClient({
@@ -48,7 +49,12 @@ export function TeamDetailClient({
       <Tabs
         value={tab}
         onValueChange={(v) => {
-          if (v === "members" || v === "repos" || v === "env") {
+          if (
+            v === "members" ||
+            v === "repos" ||
+            v === "env" ||
+            v === "artifacts"
+          ) {
             navigate({
               to: `/teams/${teamId}/${v}`,
             });
@@ -59,6 +65,7 @@ export function TeamDetailClient({
           <TabsTrigger value="members">Members</TabsTrigger>
           <TabsTrigger value="repos">Codebases</TabsTrigger>
           <TabsTrigger value="env">Environment Variables</TabsTrigger>
+          <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
         </TabsList>
 
         <TabsContent value="members">
@@ -80,6 +87,10 @@ export function TeamDetailClient({
 
         <TabsContent value="env">
           <TeamEnvVarsTab teamId={team._id} teamEnvVars={teamEnvVars} />
+        </TabsContent>
+
+        <TabsContent value="artifacts">
+          <TeamArtifactsTab teamId={team._id} />
         </TabsContent>
       </Tabs>
     </PageWrapper>

--- a/apps/web/src/routes/_global/teams/_components/TeamArtifactsTab.tsx
+++ b/apps/web/src/routes/_global/teams/_components/TeamArtifactsTab.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { ArtifactList } from "@/lib/components/artifacts/ArtifactList";
+import { ArtifactUploadDialog } from "@/lib/components/artifacts/ArtifactUploadDialog";
+
+/** Team detail "Artifacts" tab: artifacts bound to this team, with team-scoped upload. */
+export function TeamArtifactsTab({ teamId }: { teamId: Id<"teams"> }) {
+  const artifacts = useQuery(api.artifacts.listForTeam, { teamId }) ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          Artifacts bound to this team. Anyone in the team can open or delete
+          them.
+        </p>
+        <ArtifactUploadDialog defaultTeamId={teamId} />
+      </div>
+      <ArtifactList
+        artifacts={artifacts}
+        emptyDescription="Upload a Cowork artifact HTML file to host it for this team."
+      />
+    </div>
+  );
+}

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Host Cowork artifacts in eva - 2026-06-17
+
+- Upload Claude "Cowork" artifacts (self-contained HTML dashboards) into eva and open them in-app, so live dashboards can be deployed and shared internally instead of living only in the Cowork host.
+- Each artifact runs in a sandboxed, isolated iframe; an injected bridge resolves its `window.cowork.callMcpTool` calls against eva's read-only MCP tools using the viewer's signed-in session — no OAuth, and the artifact runs unmodified.
+- Tool calls are restricted to the read-only MCP tools (postgres_query, query_table, run_query, get_document, count_table, list_repos) and enforce per-call repo access, so an artifact can only read data the viewer already has access to.
+- Artifacts are reachable from a global Artifacts section and a per-team Artifacts tab; they bind to a team for visibility and can be opened or deleted by any member of that team.
+
 ## Testing Arena: public release - 2026-06-17
 
 - Testing Arena is now visible to all users — removed the dev-only gate on its sidebar nav item.

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -131,6 +131,7 @@ import type * as agentTaskChatWorkflow from "../agentTaskChatWorkflow.js";
 import type * as agentTasks from "../agentTasks.js";
 import type * as analytics from "../analytics.js";
 import type * as annotations from "../annotations.js";
+import type * as artifacts from "../artifacts.js";
 import type * as auditCategories from "../auditCategories.js";
 import type * as audits from "../audits.js";
 import type * as auth from "../auth.js";
@@ -368,6 +369,7 @@ declare const fullApi: ApiFromModules<{
   agentTasks: typeof agentTasks;
   analytics: typeof analytics;
   annotations: typeof annotations;
+  artifacts: typeof artifacts;
   auditCategories: typeof auditCategories;
   audits: typeof audits;
   auth: typeof auth;

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -519,3 +519,19 @@ export const draftTarget = v.union(
     designSessionId: v.id("designSessions"),
   }),
 );
+
+// A hosted Claude "Cowork" artifact: a self-contained HTML page uploaded to eva
+// that calls the Eva MCP read-only tools via an in-app bridge. boundTeamId scopes
+// listing/visibility only — tool calls target any repo the signed-in user can
+// access (enforced per call). declaredTools is advisory metadata parsed from the
+// artifact's cowork-artifact-meta header; the runtime read-only whitelist is the
+// real gate. New row per upload; manual delete.
+export const artifactFields = {
+  name: v.string(),
+  description: v.optional(v.string()),
+  boundTeamId: v.id("teams"),
+  declaredTools: v.array(v.string()),
+  htmlStorageId: v.id("_storage"),
+  uploadedBy: v.id("users"),
+  createdAt: v.number(),
+};

--- a/packages/backend/convex/artifacts.ts
+++ b/packages/backend/convex/artifacts.ts
@@ -1,0 +1,403 @@
+import { v } from "convex/values";
+import { z } from "zod";
+import { internal } from "./_generated/api";
+import type { ActionCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import {
+  authQuery,
+  authMutation,
+  authAction,
+  hasTeamAccess,
+} from "./functions";
+import { artifactFields } from "./validators";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Return validators (composed from the single-source-of-truth artifactFields)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const artifactDoc = v.object({
+  _id: v.id("artifacts"),
+  _creationTime: v.number(),
+  ...artifactFields,
+});
+
+// get() resolves the stored HTML to a (time-limited, signed) storage URL.
+const artifactWithUrl = v.object({
+  _id: v.id("artifacts"),
+  _creationTime: v.number(),
+  ...artifactFields,
+  url: v.union(v.string(), v.null()),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MCP CallToolResult envelope
+//
+// Mirrors `textResult`/`errorResult` in mcp/tools.ts. Re-declared here (rather
+// than imported) because mcp/tools.ts pulls in the MCP SDK and only runs in the
+// "use node" runtime; this module runs in the default isolate. The shape is kept
+// byte-identical so hosted artifacts (which parse `content[].text`) work
+// unchanged.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+function errorResult(message: string): ToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+function textResult(
+  data: Record<string, unknown> | Array<unknown>,
+): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CRUD
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Temporary upload URL for the artifact HTML (client POSTs the file, then calls create). */
+export const generateUploadUrl = authMutation({
+  args: {},
+  returns: v.string(),
+  handler: async (ctx) => ctx.storage.generateUploadUrl(),
+});
+
+// Tools a hosted artifact is allowed to invoke through the bridge. Read-only
+// only: no task creation or other write tools. This whitelist — not the
+// artifact's declared `mcpTools` — is the runtime gate.
+const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
+  "postgres_query",
+  "query_table",
+  "run_query",
+  "get_document",
+  "count_table",
+  "list_repos",
+]);
+
+/** Records an uploaded artifact against a team. Caller must be a member of that team. */
+export const create = authMutation({
+  args: {
+    name: v.string(),
+    description: v.optional(v.string()),
+    boundTeamId: v.id("teams"),
+    declaredTools: v.array(v.string()),
+    htmlStorageId: v.id("_storage"),
+  },
+  returns: v.id("artifacts"),
+  handler: async (ctx, args) => {
+    if (!(await hasTeamAccess(ctx.db, args.boundTeamId, ctx.userId))) {
+      throw new Error("Not authorized: you are not a member of this team.");
+    }
+    return ctx.db.insert("artifacts", {
+      ...args,
+      uploadedBy: ctx.userId,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+/** Fetches one artifact plus a signed URL for its HTML; null if missing or no team access. */
+export const get = authQuery({
+  // Accept a raw string (the route param) and normalise it, so callers never
+  // need an `as Id<...>` cast at the route boundary.
+  args: { id: v.string() },
+  returns: v.union(artifactWithUrl, v.null()),
+  handler: async (ctx, args) => {
+    const id = ctx.db.normalizeId("artifacts", args.id);
+    if (!id) return null;
+    const artifact = await ctx.db.get(id);
+    if (!artifact) return null;
+    if (!(await hasTeamAccess(ctx.db, artifact.boundTeamId, ctx.userId))) {
+      return null;
+    }
+    return {
+      ...artifact,
+      url: await ctx.storage.getUrl(artifact.htmlStorageId),
+    };
+  },
+});
+
+/** Lists a team's artifacts (newest first). Empty if the caller is not a member. */
+export const listForTeam = authQuery({
+  args: { teamId: v.id("teams") },
+  returns: v.array(artifactDoc),
+  handler: async (ctx, args) => {
+    if (!(await hasTeamAccess(ctx.db, args.teamId, ctx.userId))) return [];
+    return ctx.db
+      .query("artifacts")
+      .withIndex("by_team", (q) => q.eq("boundTeamId", args.teamId))
+      .order("desc")
+      .collect();
+  },
+});
+
+/** Lists every artifact across all teams the caller belongs to (newest first). */
+export const listAll = authQuery({
+  args: {},
+  returns: v.array(artifactDoc),
+  handler: async (ctx) => {
+    const memberships = await ctx.db
+      .query("teamMembers")
+      .withIndex("by_user", (q) => q.eq("userId", ctx.userId))
+      .collect();
+    const perTeam = await Promise.all(
+      memberships.map((m) =>
+        ctx.db
+          .query("artifacts")
+          .withIndex("by_team", (q) => q.eq("boundTeamId", m.teamId))
+          .collect(),
+      ),
+    );
+    return perTeam.flat().sort((a, b) => b.createdAt - a.createdAt);
+  },
+});
+
+/** Deletes an artifact and its stored HTML. Allowed for any member of the bound team. */
+export const remove = authMutation({
+  args: { id: v.id("artifacts") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const artifact = await ctx.db.get(args.id);
+    if (!artifact) throw new Error("Artifact not found");
+    if (!(await hasTeamAccess(ctx.db, artifact.boundTeamId, ctx.userId))) {
+      throw new Error("Not authorized: you are not a member of this team.");
+    }
+    await ctx.storage.delete(artifact.htmlStorageId);
+    await ctx.db.delete(args.id);
+    return null;
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The bridge: window.cowork.callMcpTool → here
+//
+// A hosted artifact (running in a sandboxed iframe) posts its callMcpTool
+// requests to the parent, which forwards them here. We re-dispatch eva's
+// existing read-only MCP tools as the SIGNED-IN user — no OAuth, no MCP wire
+// protocol — and return the identical envelope so the artifact runs unmodified.
+//
+// Access is enforced per call against the caller's own repo access
+// (checkRepoAccessForUser = repo owner OR team member). Team binding only scopes
+// where the artifact is listed; a call may target any repo the caller can reach.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Claude names MCP tools `mcp__<serverId>__<bareName>`. Strip through the last
+// "__" (serverIds can themselves contain "__", so lastIndexOf is correct).
+function bareToolName(toolName: string): string {
+  const idx = toolName.lastIndexOf("__");
+  return idx === -1 ? toolName : toolName.slice(idx + 2);
+}
+
+// Per-tool argument schemas, mirroring the zod shapes (and defaults) in
+// mcp/tools.ts. The action receives `args` as a JSON string; each tool parses it
+// with its schema, so the parsed value is precisely typed without `any`/`as`.
+const postgresQueryArgs = z.object({
+  sql: z.string(),
+  limit: z.number().max(1000).default(100),
+  repoId: z.string(),
+});
+const environmentArg = z.enum(["staging", "prod"]).default("prod");
+const queryTableArgs = z.object({
+  table: z.string(),
+  order: z.enum(["asc", "desc"]).default("desc"),
+  limit: z.number().max(1000).default(100),
+  cursor: z.string().optional(),
+  repoId: z.string(),
+  environment: environmentArg,
+});
+const runQueryArgs = z.object({
+  code: z.string(),
+  repoId: z.string(),
+  environment: environmentArg,
+});
+const getDocumentArgs = z.object({
+  id: z.string(),
+  repoId: z.string(),
+  environment: environmentArg,
+});
+const countTableArgs = z.object({
+  table: z.string(),
+  repoId: z.string(),
+  environment: environmentArg,
+});
+
+/** Throws unless the caller can access the repo (owner or team member). */
+async function assertRepoAccess(
+  ctx: ActionCtx,
+  repoId: string,
+  userId: Id<"users">,
+): Promise<void> {
+  const ok = await ctx.runQuery(internal.mcp.queries.checkRepoAccessForUser, {
+    repoId,
+    userId,
+  });
+  if (!ok) {
+    throw new Error("Access denied: you do not have access to this repo.");
+  }
+}
+
+/** Asserts access, then resolves the repo's Convex credentials for the environment. */
+async function resolveCreds(
+  ctx: ActionCtx,
+  repoId: string,
+  userId: Id<"users">,
+  environment: "staging" | "prod",
+): Promise<{ convexUrl: string; deployKey: string }> {
+  await assertRepoAccess(ctx, repoId, userId);
+  const creds = await ctx.runAction(
+    internal.mcp.nodeActions.getRepoConvexCredentials,
+    { repoId, userId, environment },
+  );
+  if (!creds) {
+    throw new Error(
+      `Repo ${repoId} has no Convex credentials configured for "${environment}". Add them in the repo's Environment Variables in Eva.`,
+    );
+  }
+  return creds;
+}
+
+export const callTool = authAction({
+  args: { toolName: v.string(), args: v.string() },
+  returns: v.object({
+    content: v.array(v.object({ type: v.literal("text"), text: v.string() })),
+    isError: v.optional(v.boolean()),
+  }),
+  handler: async (ctx, { toolName, args }): Promise<ToolResult> => {
+    const name = bareToolName(toolName);
+    if (!READ_ONLY_TOOLS.has(name)) {
+      return errorResult(
+        `Tool "${name}" is not available in hosted artifacts.`,
+      );
+    }
+    const userId = ctx.userId;
+
+    try {
+      switch (name) {
+        case "list_repos": {
+          const repos = await ctx.runAction(
+            internal.mcp.nodeActions.listUserRepos,
+            { userId },
+          );
+          const replicaIds = new Set(
+            await ctx.runQuery(internal.mcp.queries.reposWithPostgresReplica, {
+              repoIds: repos.map((r) => r.id),
+            }),
+          );
+          return textResult(
+            repos.map((r) => ({
+              id: r.id,
+              owner: r.owner,
+              name: r.name,
+              app: r.rootDirectory,
+              hasPostgresReplica: replicaIds.has(r.id),
+            })),
+          );
+        }
+
+        case "postgres_query": {
+          const a = postgresQueryArgs.parse(JSON.parse(args));
+          await assertRepoAccess(ctx, a.repoId, userId);
+          const result = await ctx.runAction(
+            internal.mcp.postgres.runPostgresQuery,
+            { repoId: a.repoId, sql: a.sql, maxRows: a.limit },
+          );
+          if (!result.ok) {
+            return errorResult(`Postgres query failed: ${result.error}`);
+          }
+          return textResult({
+            columns: result.columns,
+            rows: result.rows,
+            rowCount: result.rowCount,
+            truncated: result.truncated,
+          });
+        }
+
+        case "query_table": {
+          const a = queryTableArgs.parse(JSON.parse(args));
+          const t = await resolveCreds(ctx, a.repoId, userId, a.environment);
+          const result = await ctx.runAction(
+            internal.mcp.nodeActions.queryTable,
+            {
+              convexUrl: t.convexUrl,
+              deployKey: t.deployKey,
+              table: a.table,
+              order: a.order,
+              numItems: a.limit,
+              cursor: a.cursor ?? null,
+            },
+          );
+          return textResult({
+            page: result.page,
+            isDone: result.isDone,
+            continueCursor: result.continueCursor,
+            count: result.page.length,
+          });
+        }
+
+        case "run_query": {
+          const a = runQueryArgs.parse(JSON.parse(args));
+          const t = await resolveCreds(ctx, a.repoId, userId, a.environment);
+          const result = await ctx.runAction(
+            internal.mcp.nodeActions.runTestQuery,
+            { convexUrl: t.convexUrl, deployKey: t.deployKey, code: a.code },
+          );
+          return textResult(
+            result.logLines.length > 0
+              ? { result: result.value, logLines: result.logLines }
+              : { result: result.value },
+          );
+        }
+
+        case "get_document": {
+          const a = getDocumentArgs.parse(JSON.parse(args));
+          if (!/^[a-zA-Z0-9_]+$/.test(a.id)) {
+            return errorResult("Invalid document ID format.");
+          }
+          const t = await resolveCreds(ctx, a.repoId, userId, a.environment);
+          const result = await ctx.runAction(
+            internal.mcp.nodeActions.runTestQuery,
+            {
+              convexUrl: t.convexUrl,
+              deployKey: t.deployKey,
+              code: `return await ctx.db.get(${JSON.stringify(a.id)});`,
+            },
+          );
+          return textResult(
+            result.logLines.length > 0
+              ? { document: result.value, logLines: result.logLines }
+              : { document: result.value },
+          );
+        }
+
+        case "count_table": {
+          const a = countTableArgs.parse(JSON.parse(args));
+          if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(a.table)) {
+            return errorResult("Invalid table name.");
+          }
+          const t = await resolveCreds(ctx, a.repoId, userId, a.environment);
+          const result = await ctx.runAction(
+            internal.mcp.nodeActions.runTestQuery,
+            {
+              convexUrl: t.convexUrl,
+              deployKey: t.deployKey,
+              code: `const docs = await ctx.db.query(${JSON.stringify(a.table)}).collect(); return docs.length;`,
+            },
+          );
+          return textResult({ table: a.table, count: result.value });
+        }
+
+        default:
+          return errorResult(
+            `Tool "${name}" is not available in hosted artifacts.`,
+          );
+      }
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err));
+    }
+  },
+});

--- a/packages/backend/convex/functions.ts
+++ b/packages/backend/convex/functions.ts
@@ -43,6 +43,21 @@ export async function hasRepoAccess(
   return membership !== null;
 }
 
+/** Checks if a user has access to a team — i.e. is a member of it. */
+export async function hasTeamAccess(
+  db: GenericDatabaseReader<DataModel>,
+  teamId: Id<"teams">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  const membership = await db
+    .query("teamMembers")
+    .withIndex("by_team_and_user", (q) =>
+      q.eq("teamId", teamId).eq("userId", userId),
+    )
+    .first();
+  return membership !== null;
+}
+
 /** Checks if a user can access a task by verifying access to its parent repo or project. */
 export async function hasTaskAccess(
   db: GenericDatabaseReader<DataModel>,

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -40,12 +40,17 @@ import {
   docVersionDraftFields,
   draftFields,
   evaluationReportFields,
+  artifactFields,
 } from "./validators";
 
 const schema = defineSchema({
   users: defineTable(userFields)
     .index("by_clerk_id", ["clerkId"])
     .index("by_email", ["email"]),
+
+  artifacts: defineTable(artifactFields)
+    .index("by_team", ["boundTeamId"])
+    .index("by_uploader", ["uploadedBy"]),
 
   projects: defineTable(projectFields)
     .index("by_repo", ["repoId"])


### PR DESCRIPTION
Lets teams upload Claude Cowork dashboards and open them inside eva instead of depending on the Cowork host.

- Each artifact runs in a sandboxed, isolated iframe; an injected bridge resolves its `window.cowork.callMcpTool` calls against eva's read-only MCP tools using the viewer's signed-in session — no OAuth, artifact runs unmodified.
- Calls are restricted to read-only tools (postgres_query, query_table, run_query, get_document, count_table, list_repos) and re-check repo access per call, so a hosted page can only read what the viewer already can.
- Reachable from a global Artifacts section and a per-team Artifacts tab; artifacts bind to a team for visibility and any team member can open or delete them.

Verified live end-to-end with agent-browser (upload → open → bridge → callTool → postgres_query → access check → result back to the artifact).