### PR TITLE
feat(docs): Eva visual blocks and MCP feedback pull

### DIFF
--- a/apps/web/src/lib/components/docs/_blocks/EvaBlock.ts
+++ b/apps/web/src/lib/components/docs/_blocks/EvaBlock.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { Node, mergeAttributes } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { suggestChangesKey } from "@handlewithcare/prosemirror-suggest-changes";
+import { nanoid } from "nanoid";
+import { EvaBlockView, type EvaBlockOptions } from "./EvaBlockView";
+import { defaultBlockData, isEvaBlockType } from "./blockData";
+import type { EvaBlockType } from "./types";
+
+function createDefaultBlockData(blockType: EvaBlockType): object {
+  switch (blockType) {
+    case "callout":
+      return defaultBlockData("callout");
+    case "diff":
+      return defaultBlockData("diff");
+    case "file-tree":
+      return defaultBlockData("file-tree");
+    case "diagram":
+      return defaultBlockData("diagram");
+    case "wireframe":
+      return defaultBlockData("wireframe");
+    case "image":
+      return defaultBlockData("image");
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export const EvaBlock = Node.create<EvaBlockOptions>({
+  name: "evaBlock",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addOptions() {
+    return { docId: undefined };
+  },
+
+  addAttributes() {
+    return {
+      blockId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-block-id"),
+        renderHTML: (attributes) =>
+          attributes.blockId ? { "data-block-id": attributes.blockId } : {},
+      },
+      blockType: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-block-type"),
+        renderHTML: (attributes) =>
+          attributes.blockType
+            ? { "data-block-type": attributes.blockType }
+            : {},
+      },
+      data: {
+        default: {},
+        parseHTML: (element) => {
+          const raw = element.getAttribute("data-block-data");
+          if (!raw) return {};
+          try {
+            const parsed: unknown = JSON.parse(raw);
+            return isRecord(parsed) ? parsed : {};
+          } catch {
+            return {};
+          }
+        },
+        renderHTML: (attributes) => {
+          const data = isRecord(attributes.data) ? attributes.data : {};
+          return { "data-block-data": JSON.stringify(data) };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-eva-block]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-eva-block": "" })];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(EvaBlockView);
+  },
+
+  addCommands() {
+    return {
+      insertEvaBlock:
+        (blockType: EvaBlockType) =>
+        ({ commands, chain }) => {
+          if (!isEvaBlockType(blockType)) return false;
+          const inserted = commands.insertContent({
+            type: this.name,
+            attrs: {
+              blockId: nanoid(),
+              blockType,
+              data: createDefaultBlockData(blockType),
+            },
+          });
+          if (!inserted) return false;
+          return chain()
+            .command(({ tr }) => {
+              tr.setMeta(suggestChangesKey, { skip: true });
+              return true;
+            })
+            .run();
+        },
+    };
+  },
+});
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    evaBlock: {
+      insertEvaBlock: (blockType: EvaBlockType) => ReturnType;
+    };
+  }
+}

--- a/apps/web/src/lib/components/docs/_blocks/EvaBlockView.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/EvaBlockView.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
+import type { Id } from "@conductor/backend";
+import { renderEvaBlock } from "./registry";
+
+export function EvaBlockView({
+  node,
+  updateAttributes,
+  editor,
+  extension,
+}: ReactNodeViewProps) {
+  const blockId =
+    typeof node.attrs.blockId === "string" ? node.attrs.blockId : "";
+  const blockType =
+    typeof node.attrs.blockType === "string" ? node.attrs.blockType : "";
+  const readOnly = !editor.isEditable;
+  const docId = extension.options.docId;
+
+  return (
+    <NodeViewWrapper className="my-3" data-eva-block-wrapper>
+      {renderEvaBlock({
+        blockType,
+        blockId,
+        data: node.attrs.data,
+        readOnly,
+        docId,
+        onChange: (data) => {
+          updateAttributes({ data });
+        },
+      })}
+    </NodeViewWrapper>
+  );
+}
+
+export type EvaBlockOptions = {
+  docId?: Id<"docs">;
+};

--- a/apps/web/src/lib/components/docs/_blocks/blockData.ts
+++ b/apps/web/src/lib/components/docs/_blocks/blockData.ts
@@ -1,0 +1,261 @@
+import type {
+  CalloutBlockData,
+  CalloutTone,
+  DiagramBlockData,
+  DiagramKind,
+  DiffBlockData,
+  DiffMode,
+  EvaBlockDataByType,
+  EvaBlockType,
+  FileTreeBlockData,
+  FileTreeChange,
+  FileTreeEntry,
+  ImageBlockData,
+  WireframeBlockData,
+  WireframeSurface,
+} from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value : "";
+}
+
+function readOptionalString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  return typeof value === "number" ? value : 0;
+}
+
+function readOptionalNumber(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function readBoolean(
+  record: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function isCalloutTone(value: string): value is CalloutTone {
+  return value === "info" || value === "warn" || value === "decision";
+}
+
+function isDiffMode(value: string): value is DiffMode {
+  return value === "split" || value === "unified";
+}
+
+function isFileTreeChange(value: string): value is FileTreeChange {
+  return (
+    value === "added" ||
+    value === "modified" ||
+    value === "removed" ||
+    value === "renamed"
+  );
+}
+
+function isDiagramKind(value: string): value is DiagramKind {
+  return value === "mermaid" || value === "html";
+}
+
+function isWireframeSurface(value: string): value is WireframeSurface {
+  return (
+    value === "browser" ||
+    value === "desktop" ||
+    value === "mobile" ||
+    value === "popover" ||
+    value === "panel"
+  );
+}
+
+function parseFileTreeEntry(value: unknown): FileTreeEntry | null {
+  if (!isRecord(value)) return null;
+  const path = readString(value, "path");
+  const change = readString(value, "change");
+  if (!path || !isFileTreeChange(change)) return null;
+  const note = readOptionalString(value, "note");
+  return note ? { path, change, note } : { path, change };
+}
+
+export function defaultBlockData(blockType: "callout"): CalloutBlockData;
+export function defaultBlockData(blockType: "diff"): DiffBlockData;
+export function defaultBlockData(blockType: "file-tree"): FileTreeBlockData;
+export function defaultBlockData(blockType: "diagram"): DiagramBlockData;
+export function defaultBlockData(blockType: "wireframe"): WireframeBlockData;
+export function defaultBlockData(blockType: "image"): ImageBlockData;
+export function defaultBlockData(
+  blockType: EvaBlockType,
+): EvaBlockDataByType[EvaBlockType] {
+  switch (blockType) {
+    case "callout":
+      return { tone: "info", markdown: "" };
+    case "diff":
+      return {
+        filename: "example.ts",
+        language: "typescript",
+        before: "",
+        after: "",
+        mode: "split",
+      };
+    case "file-tree":
+      return { entries: [] };
+    case "diagram":
+      return { kind: "mermaid", source: "flowchart LR\n  A --> B" };
+    case "wireframe":
+      return {
+        surface: "browser",
+        html: "<div class='wf-card'><p class='wf-muted'>Wireframe</p></div>",
+      };
+    case "image":
+      return { alt: "" };
+  }
+}
+
+export function parseBlockData(
+  blockType: "callout",
+  raw: unknown,
+): CalloutBlockData;
+export function parseBlockData(blockType: "diff", raw: unknown): DiffBlockData;
+export function parseBlockData(
+  blockType: "file-tree",
+  raw: unknown,
+): FileTreeBlockData;
+export function parseBlockData(
+  blockType: "diagram",
+  raw: unknown,
+): DiagramBlockData;
+export function parseBlockData(
+  blockType: "wireframe",
+  raw: unknown,
+): WireframeBlockData;
+export function parseBlockData(
+  blockType: "image",
+  raw: unknown,
+): ImageBlockData;
+export function parseBlockData(
+  blockType: EvaBlockType,
+  raw: unknown,
+): EvaBlockDataByType[EvaBlockType] {
+  if (!isRecord(raw)) {
+    switch (blockType) {
+      case "callout":
+        return defaultBlockData("callout");
+      case "diff":
+        return defaultBlockData("diff");
+      case "file-tree":
+        return defaultBlockData("file-tree");
+      case "diagram":
+        return defaultBlockData("diagram");
+      case "wireframe":
+        return defaultBlockData("wireframe");
+      case "image":
+        return defaultBlockData("image");
+    }
+  }
+
+  switch (blockType) {
+    case "callout": {
+      const toneRaw = readString(raw, "tone");
+      const tone = isCalloutTone(toneRaw) ? toneRaw : "info";
+      return { tone, markdown: readString(raw, "markdown") };
+    }
+    case "diff": {
+      const modeRaw = readString(raw, "mode");
+      const mode = isDiffMode(modeRaw) ? modeRaw : "split";
+      const annotationsRaw = raw.annotations;
+      const annotations = Array.isArray(annotationsRaw)
+        ? annotationsRaw
+            .map((item) => {
+              if (!isRecord(item)) return null;
+              const lines = readString(item, "lines");
+              const note = readString(item, "note");
+              if (!lines || !note) return null;
+              return { lines, note };
+            })
+            .filter(
+              (item): item is { lines: string; note: string } => item !== null,
+            )
+        : undefined;
+      const summary = readOptionalString(raw, "summary");
+      const data: DiffBlockData = {
+        filename: readString(raw, "filename"),
+        language: readString(raw, "language"),
+        before: readString(raw, "before"),
+        after: readString(raw, "after"),
+        mode,
+      };
+      if (summary) data.summary = summary;
+      if (annotations && annotations.length > 0) data.annotations = annotations;
+      return data;
+    }
+    case "file-tree": {
+      const entriesRaw = raw.entries;
+      const entries = Array.isArray(entriesRaw)
+        ? entriesRaw
+            .map(parseFileTreeEntry)
+            .filter((entry): entry is FileTreeEntry => entry !== null)
+        : [];
+      return { entries };
+    }
+    case "diagram": {
+      const kindRaw = readString(raw, "kind");
+      const kind = isDiagramKind(kindRaw) ? kindRaw : "mermaid";
+      const data: DiagramBlockData = { kind };
+      const source = readOptionalString(raw, "source");
+      const html = readOptionalString(raw, "html");
+      const css = readOptionalString(raw, "css");
+      if (source) data.source = source;
+      if (html) data.html = html;
+      if (css) data.css = css;
+      return data;
+    }
+    case "wireframe": {
+      const surfaceRaw = readString(raw, "surface");
+      const surface = isWireframeSurface(surfaceRaw) ? surfaceRaw : "browser";
+      const skeleton = readBoolean(raw, "skeleton");
+      const data: WireframeBlockData = {
+        surface,
+        html: readString(raw, "html"),
+      };
+      if (skeleton !== undefined) data.skeleton = skeleton;
+      return data;
+    }
+    case "image": {
+      const storageId = readOptionalString(raw, "storageId");
+      const alt = readOptionalString(raw, "alt");
+      const width = readOptionalNumber(raw, "width");
+      const data: ImageBlockData = {};
+      if (storageId) data.storageId = storageId;
+      if (alt) data.alt = alt;
+      if (width !== undefined) data.width = width;
+      return data;
+    }
+  }
+}
+
+export function isEvaBlockType(value: string): value is EvaBlockType {
+  return (
+    value === "callout" ||
+    value === "diff" ||
+    value === "file-tree" ||
+    value === "diagram" ||
+    value === "wireframe" ||
+    value === "image"
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/evaBlockMarkdown.ts
+++ b/apps/web/src/lib/components/docs/_blocks/evaBlockMarkdown.ts
@@ -1,0 +1,8 @@
+export function evaBlockToMarkdown(
+  blockType: string,
+  data: Record<string, unknown>,
+): string {
+  return (
+    "```eva:" + blockType + "\n" + JSON.stringify(data, null, 2) + "\n```\n\n"
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/pmJsonToMarkdown.ts
+++ b/apps/web/src/lib/components/docs/_blocks/pmJsonToMarkdown.ts
@@ -1,0 +1,96 @@
+interface PMNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: PMNode[];
+  text?: string;
+  marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readBlockData(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+/** Mirrors the server mirror walker so client version snapshots match docs.content. */
+export function pmJsonToMarkdown(node: PMNode, depth?: number): string {
+  const d = depth ?? 0;
+  if (node.type === "text") {
+    let text = node.text ?? "";
+    if (node.marks) {
+      for (const mark of node.marks) {
+        if (mark.type === "bold" || mark.type === "strong") {
+          text = `**${text}**`;
+        } else if (mark.type === "italic" || mark.type === "em") {
+          text = `*${text}*`;
+        } else if (mark.type === "code") {
+          text = `\`${text}\``;
+        } else if (mark.type === "link") {
+          text = `[${text}](${String(mark.attrs?.href ?? "")})`;
+        } else if (mark.type === "deletion") {
+          return "";
+        }
+      }
+    }
+    return text;
+  }
+
+  const children = (node.content ?? [])
+    .map((child) => pmJsonToMarkdown(child, d))
+    .join("");
+
+  switch (node.type) {
+    case "doc":
+      return children;
+    case "paragraph":
+      return children + "\n\n";
+    case "heading": {
+      const level = Number(node.attrs?.level ?? 1);
+      return "#".repeat(level) + " " + children + "\n\n";
+    }
+    case "bulletList":
+      return (node.content ?? [])
+        .map((li) => "- " + pmJsonToMarkdown(li, d + 1).trimStart())
+        .join("");
+    case "orderedList":
+      return (node.content ?? [])
+        .map((li, i) => `${i + 1}. ` + pmJsonToMarkdown(li, d + 1).trimStart())
+        .join("");
+    case "listItem":
+      return children;
+    case "codeBlock": {
+      const lang = String(node.attrs?.language ?? "");
+      return "```" + lang + "\n" + children + "```\n\n";
+    }
+    case "evaBlock": {
+      const blockType = String(node.attrs?.blockType ?? "callout");
+      const data = readBlockData(node.attrs?.data);
+      return (
+        "```eva:" +
+        blockType +
+        "\n" +
+        JSON.stringify(data, null, 2) +
+        "\n```\n\n"
+      );
+    }
+    case "blockquote":
+      return (
+        children
+          .split("\n")
+          .map((line) => "> " + line)
+          .join("\n") + "\n"
+      );
+    case "horizontalRule":
+      return "---\n\n";
+    case "hardBreak":
+      return "\n";
+    default:
+      return children;
+  }
+}
+
+export function editorDocToMarkdown(docJson: PMNode): string {
+  return pmJsonToMarkdown(docJson).trim();
+}

--- a/apps/web/src/lib/components/docs/_blocks/registry.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/registry.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import type { ComponentType } from "react";
+import type { Id } from "@conductor/backend";
+import type { BlockProps, EvaBlockDataByType, EvaBlockType } from "./types";
+import { parseBlockData } from "./blockData";
+import { CalloutBlock } from "./renderers/CalloutBlock";
+import { DiffBlock } from "./renderers/DiffBlock";
+import { FileTreeBlock } from "./renderers/FileTreeBlock";
+import { DiagramBlock } from "./renderers/DiagramBlock";
+import { WireframeBlock } from "./renderers/WireframeBlock";
+import { ImageBlock } from "./renderers/ImageBlock";
+
+type RendererComponent<T extends EvaBlockType> = ComponentType<
+  BlockProps<T> & (T extends "image" ? { docId: Id<"docs"> } : object)
+>;
+
+type EvaBlockRendererEntry<T extends EvaBlockType> = {
+  Read: RendererComponent<T>;
+  Edit?: RendererComponent<T>;
+};
+
+export const EVA_BLOCK_RENDERERS: {
+  [K in EvaBlockType]: EvaBlockRendererEntry<K>;
+} = {
+  callout: { Read: CalloutBlock, Edit: CalloutBlock },
+  diff: { Read: DiffBlock, Edit: DiffBlock },
+  "file-tree": { Read: FileTreeBlock, Edit: FileTreeBlock },
+  diagram: { Read: DiagramBlock, Edit: DiagramBlock },
+  wireframe: { Read: WireframeBlock, Edit: WireframeBlock },
+  image: { Read: ImageBlock, Edit: ImageBlock },
+};
+
+export function renderEvaBlock({
+  blockType,
+  blockId,
+  data,
+  readOnly,
+  onChange,
+  docId,
+}: {
+  blockType: string;
+  blockId: string;
+  data: unknown;
+  readOnly: boolean;
+  onChange: (data: object) => void;
+  docId?: Id<"docs">;
+}) {
+  if (blockType === "callout") {
+    const parsed = parseBlockData("callout", data);
+    const Component = readOnly
+      ? EVA_BLOCK_RENDERERS.callout.Read
+      : (EVA_BLOCK_RENDERERS.callout.Edit ?? EVA_BLOCK_RENDERERS.callout.Read);
+    return (
+      <Component
+        blockId={blockId}
+        data={parsed}
+        readOnly={readOnly}
+        onChange={(next) => onChange(next)}
+      />
+    );
+  }
+  if (blockType === "diff") {
+    const parsed = parseBlockData("diff", data);
+    const Component = readOnly
+      ? EVA_BLOCK_RENDERERS.diff.Read
+      : (EVA_BLOCK_RENDERERS.diff.Edit ?? EVA_BLOCK_RENDERERS.diff.Read);
+    return (
+      <Component
+        blockId={blockId}
+        data={parsed}
+        readOnly={readOnly}
+        onChange={(next) => onChange(next)}
+      />
+    );
+  }
+  if (blockType === "file-tree") {
+    const parsed = parseBlockData("file-tree", data);
+    const Component = readOnly
+      ? EVA_BLOCK_RENDERERS["file-tree"].Read
+      : (EVA_BLOCK_RENDERERS["file-tree"].Edit ??
+        EVA_BLOCK_RENDERERS["file-tree"].Read);
+    return (
+      <Component
+        blockId={blockId}
+        data={parsed}
+        readOnly={readOnly}
+        onChange={(next) => onChange(next)}
+      />
+    );
+  }
+  if (blockType === "diagram") {
+    const parsed = parseBlockData("diagram", data);
+    const Component = readOnly
+      ? EVA_BLOCK_RENDERERS.diagram.Read
+      : (EVA_BLOCK_RENDERERS.diagram.Edit ?? EVA_BLOCK_RENDERERS.diagram.Read);
+    return (
+      <Component
+        blockId={blockId}
+        data={parsed}
+        readOnly={readOnly}
+        onChange={(next) => onChange(next)}
+      />
+    );
+  }
+  if (blockType === "wireframe") {
+    const parsed = parseBlockData("wireframe", data);
+    const Component = readOnly
+      ? EVA_BLOCK_RENDERERS.wireframe.Read
+      : (EVA_BLOCK_RENDERERS.wireframe.Edit ??
+        EVA_BLOCK_RENDERERS.wireframe.Read);
+    return (
+      <Component
+        blockId={blockId}
+        data={parsed}
+        readOnly={readOnly}
+        onChange={(next) => onChange(next)}
+      />
+    );
+  }
+  if (blockType === "image") {
+    const parsed = parseBlockData("image", data);
+    const Component = readOnly
+      ? EVA_BLOCK_RENDERERS.image.Read
+      : (EVA_BLOCK_RENDERERS.image.Edit ?? EVA_BLOCK_RENDERERS.image.Read);
+    if (!docId) {
+      return (
+        <div className="rounded-surface border border-border p-3 text-sm text-muted-foreground">
+          Image block requires a document context.
+        </div>
+      );
+    }
+    return (
+      <Component
+        blockId={blockId}
+        data={parsed}
+        readOnly={readOnly}
+        onChange={(next) => onChange(next)}
+        docId={docId}
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-surface border border-border p-3 text-sm text-muted-foreground">
+      Unknown block type: {blockType}
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/renderers/CalloutBlock.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/renderers/CalloutBlock.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Streamdown } from "streamdown";
+import { cjk } from "@streamdown/cjk";
+import { math } from "@streamdown/math";
+import type { BlockProps } from "../types";
+
+const plugins = { cjk, math };
+
+export function CalloutBlock({
+  data,
+  readOnly,
+  onChange,
+}: BlockProps<"callout">) {
+  const toneClass =
+    data.tone === "warn"
+      ? "border-amber-500/40 bg-amber-500/5"
+      : data.tone === "decision"
+        ? "border-primary/40 bg-primary/5"
+        : "border-border bg-muted/30";
+
+  if (readOnly) {
+    return (
+      <div className={`rounded-surface border p-3 ${toneClass}`}>
+        <div className="prose prose-sm dark:prose-invert max-w-none">
+          <Streamdown plugins={plugins}>
+            {data.markdown || "_Empty callout_"}
+          </Streamdown>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`rounded-surface border p-3 ${toneClass}`}>
+      <div className="mb-2 flex items-center gap-2">
+        <label className="text-xs text-muted-foreground" htmlFor="callout-tone">
+          Tone
+        </label>
+        <select
+          id="callout-tone"
+          className="rounded-surface border border-border bg-background px-2 py-1 text-xs"
+          value={data.tone}
+          onChange={(event) => {
+            const value = event.target.value;
+            if (value === "info" || value === "warn" || value === "decision") {
+              onChange({ ...data, tone: value });
+            }
+          }}
+        >
+          <option value="info">Info</option>
+          <option value="warn">Warn</option>
+          <option value="decision">Decision</option>
+        </select>
+      </div>
+      <textarea
+        className="min-h-24 w-full rounded-surface border border-border bg-background px-3 py-2 text-sm"
+        value={data.markdown}
+        onChange={(event) =>
+          onChange({ ...data, markdown: event.target.value })
+        }
+        placeholder="Callout markdown…"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/renderers/DiagramBlock.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/renderers/DiagramBlock.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useId, useRef } from "react";
+import { Streamdown } from "streamdown";
+import { cjk } from "@streamdown/cjk";
+import { math } from "@streamdown/math";
+import { mermaid } from "@streamdown/mermaid";
+import type { BlockProps } from "../types";
+import { sanitizeWireframeHtml } from "../sanitizeWireframeHtml";
+
+const plugins = { cjk, math, mermaid };
+
+export function DiagramBlock({
+  data,
+  readOnly,
+  onChange,
+}: BlockProps<"diagram">) {
+  if (data.kind === "mermaid") {
+    return (
+      <MermaidDiagram
+        source={data.source ?? ""}
+        readOnly={readOnly}
+        onChange={(source) => onChange({ ...data, kind: "mermaid", source })}
+      />
+    );
+  }
+
+  return (
+    <HtmlDiagram
+      html={data.html ?? ""}
+      css={data.css}
+      readOnly={readOnly}
+      onChange={(html) => onChange({ ...data, kind: "html", html })}
+    />
+  );
+}
+
+function MermaidDiagram({
+  source,
+  readOnly,
+  onChange,
+}: {
+  source: string;
+  readOnly: boolean;
+  onChange: (source: string) => void;
+}) {
+  if (readOnly) {
+    return (
+      <div className="rounded-surface border border-border p-3">
+        <Streamdown
+          plugins={plugins}
+        >{`\`\`\`mermaid\n${source}\n\`\`\``}</Streamdown>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-surface border border-border p-3">
+      <label className="text-xs text-muted-foreground">
+        Mermaid source
+        <textarea
+          className="mt-1 min-h-32 w-full rounded-surface border border-border bg-background px-2 py-1 font-mono text-xs"
+          value={source}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </label>
+    </div>
+  );
+}
+
+function HtmlDiagram({
+  html,
+  css,
+  readOnly,
+  onChange,
+}: {
+  html: string;
+  css?: string;
+  readOnly: boolean;
+  onChange: (html: string) => void;
+}) {
+  const styleId = useId().replace(/:/g, "");
+  const styleRef = useRef<HTMLStyleElement | null>(null);
+
+  useEffect(() => {
+    if (!css) return;
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = css;
+    document.head.appendChild(style);
+    styleRef.current = style;
+    return () => {
+      style.remove();
+      styleRef.current = null;
+    };
+  }, [css, styleId]);
+
+  if (readOnly) {
+    return (
+      <div
+        className="eva-wireframe rounded-surface border border-border p-3"
+        dangerouslySetInnerHTML={{ __html: sanitizeWireframeHtml(html) }}
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-surface border border-border p-3">
+      <label className="text-xs text-muted-foreground">
+        HTML
+        <textarea
+          className="mt-1 min-h-32 w-full rounded-surface border border-border bg-background px-2 py-1 font-mono text-xs"
+          value={html}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </label>
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/renderers/DiffBlock.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/renderers/DiffBlock.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { diffLines } from "diff";
+import type { BlockProps } from "../types";
+
+export function DiffBlock({ data, readOnly, onChange }: BlockProps<"diff">) {
+  if (readOnly) {
+    return (
+      <div className="overflow-hidden rounded-surface border border-border">
+        <div className="border-b border-border bg-muted/40 px-3 py-2 text-xs font-medium">
+          {data.filename}
+          {data.summary ? (
+            <span className="ml-2 font-normal text-muted-foreground">
+              {data.summary}
+            </span>
+          ) : null}
+        </div>
+        {data.mode === "unified" ? (
+          <UnifiedDiff before={data.before} after={data.after} />
+        ) : (
+          <SplitDiff before={data.before} after={data.after} />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-surface border border-border p-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="text-xs text-muted-foreground">
+          Filename
+          <input
+            className="mt-1 w-full rounded-surface border border-border bg-background px-2 py-1 text-sm"
+            value={data.filename}
+            onChange={(event) =>
+              onChange({ ...data, filename: event.target.value })
+            }
+          />
+        </label>
+        <label className="text-xs text-muted-foreground">
+          Language
+          <input
+            className="mt-1 w-full rounded-surface border border-border bg-background px-2 py-1 text-sm"
+            value={data.language}
+            onChange={(event) =>
+              onChange({ ...data, language: event.target.value })
+            }
+          />
+        </label>
+      </div>
+      <label className="text-xs text-muted-foreground">
+        Mode
+        <select
+          className="mt-1 w-full rounded-surface border border-border bg-background px-2 py-1 text-sm"
+          value={data.mode}
+          onChange={(event) => {
+            const value = event.target.value;
+            if (value === "split" || value === "unified") {
+              onChange({ ...data, mode: value });
+            }
+          }}
+        >
+          <option value="split">Split</option>
+          <option value="unified">Unified</option>
+        </select>
+      </label>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="text-xs text-muted-foreground">
+          Before
+          <textarea
+            className="mt-1 min-h-32 w-full rounded-surface border border-border bg-background px-2 py-1 font-mono text-xs"
+            value={data.before}
+            onChange={(event) =>
+              onChange({ ...data, before: event.target.value })
+            }
+          />
+        </label>
+        <label className="text-xs text-muted-foreground">
+          After
+          <textarea
+            className="mt-1 min-h-32 w-full rounded-surface border border-border bg-background px-2 py-1 font-mono text-xs"
+            value={data.after}
+            onChange={(event) =>
+              onChange({ ...data, after: event.target.value })
+            }
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function SplitDiff({ before, after }: { before: string; after: string }) {
+  return (
+    <div className="grid sm:grid-cols-2">
+      <pre className="overflow-x-auto border-r border-border bg-red-500/5 p-3 text-xs leading-relaxed">
+        {before}
+      </pre>
+      <pre className="overflow-x-auto bg-green-500/5 p-3 text-xs leading-relaxed">
+        {after}
+      </pre>
+    </div>
+  );
+}
+
+function UnifiedDiff({ before, after }: { before: string; after: string }) {
+  const changes = diffLines(before, after);
+  return (
+    <pre className="overflow-x-auto p-3 text-xs leading-relaxed">
+      {changes.map((part, index) => {
+        if (part.added) {
+          return (
+            <span
+              key={index}
+              className="bg-green-500/20 text-green-700 dark:text-green-400"
+            >
+              {part.value}
+            </span>
+          );
+        }
+        if (part.removed) {
+          return (
+            <span
+              key={index}
+              className="bg-red-500/20 text-red-700 dark:text-red-400"
+            >
+              {part.value}
+            </span>
+          );
+        }
+        return <span key={index}>{part.value}</span>;
+      })}
+    </pre>
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/renderers/FileTreeBlock.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/renderers/FileTreeBlock.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { BlockProps, FileTreeChange } from "../types";
+
+const CHANGE_LABEL: Record<FileTreeChange, string> = {
+  added: "A",
+  modified: "M",
+  removed: "R",
+  renamed: "→",
+};
+
+const CHANGE_CLASS: Record<FileTreeChange, string> = {
+  added: "text-green-600 dark:text-green-400",
+  modified: "text-amber-600 dark:text-amber-400",
+  removed: "text-red-600 dark:text-red-400",
+  renamed: "text-blue-600 dark:text-blue-400",
+};
+
+export function FileTreeBlock({
+  data,
+  readOnly,
+  onChange,
+}: BlockProps<"file-tree">) {
+  if (readOnly) {
+    return (
+      <div className="rounded-surface border border-border p-3 font-mono text-xs">
+        {data.entries.length === 0 ? (
+          <p className="text-muted-foreground">No files listed.</p>
+        ) : (
+          <ul className="space-y-1">
+            {data.entries.map((entry) => (
+              <li key={entry.path} className="flex items-start gap-2">
+                <span
+                  className={`w-4 shrink-0 font-semibold ${CHANGE_CLASS[entry.change]}`}
+                >
+                  {CHANGE_LABEL[entry.change]}
+                </span>
+                <span className="min-w-0 flex-1 break-all">{entry.path}</span>
+                {entry.note ? (
+                  <span className="text-muted-foreground">{entry.note}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  const text = data.entries
+    .map(
+      (entry) =>
+        `${entry.change}\t${entry.path}${entry.note ? `\t${entry.note}` : ""}`,
+    )
+    .join("\n");
+
+  return (
+    <div className="rounded-surface border border-border p-3">
+      <p className="mb-2 text-xs text-muted-foreground">
+        One entry per line: change, path, optional note (tab-separated).
+        Changes: added, modified, removed, renamed.
+      </p>
+      <textarea
+        className="min-h-32 w-full rounded-surface border border-border bg-background px-2 py-1 font-mono text-xs"
+        value={text}
+        onChange={(event) => {
+          const entries = event.target.value
+            .split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .map((line) => {
+              const [changeRaw, path, note] = line.split("\t");
+              const change = parseChange(changeRaw ?? "");
+              if (!change || !path) return null;
+              return note ? { path, change, note } : { path, change };
+            })
+            .filter(
+              (entry): entry is NonNullable<typeof entry> => entry !== null,
+            );
+          onChange({ entries });
+        }}
+        placeholder={"added\tapps/web/src/App.tsx\tNew route"}
+      />
+    </div>
+  );
+}
+
+function parseChange(value: string): FileTreeChange | null {
+  if (
+    value === "added" ||
+    value === "modified" ||
+    value === "removed" ||
+    value === "renamed"
+  ) {
+    return value;
+  }
+  return null;
+}

--- a/apps/web/src/lib/components/docs/_blocks/renderers/ImageBlock.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/renderers/ImageBlock.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Spinner } from "@conductor/ui";
+import type { Id } from "@conductor/backend";
+import type { BlockProps } from "../types";
+import { useDocImageUrl, useImageUpload } from "../useImageUpload";
+
+export function ImageBlock({
+  blockId,
+  data,
+  readOnly,
+  onChange,
+  docId,
+}: BlockProps<"image"> & { docId: Id<"docs"> }) {
+  const imageUrl = useDocImageUrl(docId, data.storageId);
+  const { uploadImage } = useImageUpload(docId);
+
+  if (readOnly) {
+    if (!data.storageId) {
+      return (
+        <div className="rounded-surface border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          No image
+        </div>
+      );
+    }
+    if (imageUrl === undefined) {
+      return (
+        <div className="flex justify-center rounded-surface border border-border p-6">
+          <Spinner size="sm" />
+        </div>
+      );
+    }
+    if (!imageUrl) {
+      return (
+        <div className="rounded-surface border border-border p-6 text-center text-sm text-muted-foreground">
+          Image unavailable
+        </div>
+      );
+    }
+    return (
+      <figure className="rounded-surface border border-border p-2">
+        <img
+          src={imageUrl}
+          alt={data.alt ?? ""}
+          style={data.width ? { width: `${data.width}px` } : undefined}
+          className="mx-auto max-w-full rounded-surface"
+        />
+        {data.alt ? (
+          <figcaption className="mt-2 text-center text-xs text-muted-foreground">
+            {data.alt}
+          </figcaption>
+        ) : null}
+      </figure>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-surface border border-border p-3">
+      <input
+        type="file"
+        accept="image/*"
+        onChange={async (event) => {
+          const file = event.target.files?.[0];
+          if (!file) return;
+          const storageId = await uploadImage(file);
+          onChange({ ...data, storageId });
+        }}
+      />
+      <label className="text-xs text-muted-foreground">
+        Alt text
+        <input
+          className="mt-1 w-full rounded-surface border border-border bg-background px-2 py-1 text-sm"
+          value={data.alt ?? ""}
+          onChange={(event) => onChange({ ...data, alt: event.target.value })}
+        />
+      </label>
+      <label className="text-xs text-muted-foreground">
+        Width (px)
+        <input
+          type="number"
+          className="mt-1 w-full rounded-surface border border-border bg-background px-2 py-1 text-sm"
+          value={data.width ?? ""}
+          onChange={(event) => {
+            const parsed = Number(event.target.value);
+            onChange({
+              ...data,
+              width: Number.isFinite(parsed) ? parsed : undefined,
+            });
+          }}
+        />
+      </label>
+      {data.storageId && imageUrl ? (
+        <img
+          src={imageUrl}
+          alt={data.alt ?? ""}
+          className="max-h-48 rounded-surface border border-border object-contain"
+        />
+      ) : null}
+      <p className="text-[10px] text-muted-foreground">Block id: {blockId}</p>
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/renderers/WireframeBlock.tsx
+++ b/apps/web/src/lib/components/docs/_blocks/renderers/WireframeBlock.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { BlockProps, WireframeSurface } from "../types";
+import { sanitizeWireframeHtml } from "../sanitizeWireframeHtml";
+import "../wireframe.css";
+
+const SURFACE_CLASS: Record<WireframeSurface, string> = {
+  browser: "eva-wireframe-frame--browser",
+  desktop: "",
+  mobile: "eva-wireframe-frame--mobile",
+  popover: "",
+  panel: "",
+};
+
+export function WireframeBlock({
+  data,
+  readOnly,
+  onChange,
+}: BlockProps<"wireframe">) {
+  const frameClass = SURFACE_CLASS[data.surface];
+  const skeletonClass = data.skeleton ? "skeleton" : "";
+
+  if (readOnly) {
+    return (
+      <div
+        className={`eva-wireframe eva-wireframe-frame ${frameClass} ${skeletonClass}`}
+        dangerouslySetInnerHTML={{
+          __html: sanitizeWireframeHtml(data.html),
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-surface border border-border p-3">
+      <label className="text-xs text-muted-foreground">
+        Surface
+        <select
+          className="mt-1 w-full rounded-surface border border-border bg-background px-2 py-1 text-sm"
+          value={data.surface}
+          onChange={(event) => {
+            const value = event.target.value;
+            if (
+              value === "browser" ||
+              value === "desktop" ||
+              value === "mobile" ||
+              value === "popover" ||
+              value === "panel"
+            ) {
+              onChange({ ...data, surface: value });
+            }
+          }}
+        >
+          <option value="browser">Browser</option>
+          <option value="desktop">Desktop</option>
+          <option value="mobile">Mobile</option>
+          <option value="popover">Popover</option>
+          <option value="panel">Panel</option>
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={data.skeleton === true}
+          onChange={(event) =>
+            onChange({ ...data, skeleton: event.target.checked })
+          }
+        />
+        Skeleton mode
+      </label>
+      <label className="text-xs text-muted-foreground">
+        HTML
+        <textarea
+          className="mt-1 min-h-32 w-full rounded-surface border border-border bg-background px-2 py-1 font-mono text-xs"
+          value={data.html}
+          onChange={(event) => onChange({ ...data, html: event.target.value })}
+        />
+      </label>
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/sanitizeWireframeHtml.ts
+++ b/apps/web/src/lib/components/docs/_blocks/sanitizeWireframeHtml.ts
@@ -1,0 +1,83 @@
+const ALLOWED_TAGS = new Set([
+  "div",
+  "span",
+  "p",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "button",
+  "input",
+  "label",
+  "ul",
+  "ol",
+  "li",
+  "img",
+  "a",
+  "header",
+  "footer",
+  "section",
+  "nav",
+  "main",
+  "form",
+  "textarea",
+  "select",
+  "option",
+]);
+
+const ALLOWED_ATTRS = new Set([
+  "class",
+  "href",
+  "src",
+  "alt",
+  "type",
+  "placeholder",
+  "value",
+  "aria-label",
+  "role",
+  "disabled",
+  "readonly",
+]);
+
+const GLOBAL_ATTR_PREFIXES = ["data-", "aria-"];
+
+function isAllowedAttr(name: string): boolean {
+  if (ALLOWED_ATTRS.has(name)) return true;
+  return GLOBAL_ATTR_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+/** Minimal allowlist HTML sanitizer for wireframe/diagram HTML blocks. */
+export function sanitizeWireframeHtml(html: string): string {
+  if (typeof window === "undefined") return html;
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  sanitizeNode(template.content);
+  const wrapper = document.createElement("div");
+  wrapper.appendChild(template.content.cloneNode(true));
+  return wrapper.innerHTML;
+}
+
+function sanitizeNode(parent: ParentNode): void {
+  const children = [...parent.childNodes];
+  for (const child of children) {
+    if (child.nodeType === Node.TEXT_NODE) continue;
+    if (child.nodeType !== Node.ELEMENT_NODE) {
+      child.remove();
+      continue;
+    }
+    const el = child as Element;
+    const tag = el.tagName.toLowerCase();
+    if (!ALLOWED_TAGS.has(tag)) {
+      while (el.firstChild) {
+        parent.insertBefore(el.firstChild, el);
+      }
+      el.remove();
+      continue;
+    }
+    for (const attr of [...el.attributes]) {
+      if (!isAllowedAttr(attr.name.toLowerCase())) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+}

--- a/apps/web/src/lib/components/docs/_blocks/types.ts
+++ b/apps/web/src/lib/components/docs/_blocks/types.ts
@@ -1,0 +1,91 @@
+export type EvaBlockType =
+  | "callout"
+  | "diff"
+  | "file-tree"
+  | "diagram"
+  | "wireframe"
+  | "image";
+
+export type CalloutTone = "info" | "warn" | "decision";
+
+export type CalloutBlockData = {
+  tone: CalloutTone;
+  markdown: string;
+};
+
+export type DiffMode = "split" | "unified";
+
+export type DiffBlockData = {
+  filename: string;
+  language: string;
+  before: string;
+  after: string;
+  mode: DiffMode;
+  summary?: string;
+  annotations?: Array<{ lines: string; note: string }>;
+};
+
+export type FileTreeChange = "added" | "modified" | "removed" | "renamed";
+
+export type FileTreeEntry = {
+  path: string;
+  change: FileTreeChange;
+  note?: string;
+};
+
+export type FileTreeBlockData = {
+  entries: FileTreeEntry[];
+};
+
+export type DiagramKind = "mermaid" | "html";
+
+export type DiagramBlockData = {
+  kind: DiagramKind;
+  source?: string;
+  html?: string;
+  css?: string;
+};
+
+export type WireframeSurface =
+  | "browser"
+  | "desktop"
+  | "mobile"
+  | "popover"
+  | "panel";
+
+export type WireframeBlockData = {
+  surface: WireframeSurface;
+  html: string;
+  skeleton?: boolean;
+};
+
+export type ImageBlockData = {
+  storageId?: string;
+  alt?: string;
+  width?: number;
+};
+
+export type EvaBlockDataByType = {
+  callout: CalloutBlockData;
+  diff: DiffBlockData;
+  "file-tree": FileTreeBlockData;
+  diagram: DiagramBlockData;
+  wireframe: WireframeBlockData;
+  image: ImageBlockData;
+};
+
+export type BlockProps<T extends EvaBlockType> = {
+  blockId: string;
+  data: EvaBlockDataByType[T];
+  readOnly: boolean;
+  onChange: (data: object) => void;
+};
+
+export const EVA_BLOCK_TYPES: EvaBlockType[] = [
+  "callout",
+  "diff",
+  "file-tree",
+  "diagram",
+  "wireframe",
+  "image",
+];

--- a/apps/web/src/lib/components/docs/_blocks/useImageUpload.ts
+++ b/apps/web/src/lib/components/docs/_blocks/useImageUpload.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@conductor/backend";
+import type { Id } from "@conductor/backend";
+import { useCallback } from "react";
+
+export function useImageUpload(docId: Id<"docs">) {
+  const generateUploadUrl = useMutation(api.docs.generateUploadUrl);
+
+  const uploadImage = useCallback(
+    async (file: File): Promise<Id<"_storage">> => {
+      const uploadUrl = await generateUploadUrl({ docId });
+      const response = await fetch(uploadUrl, {
+        method: "POST",
+        headers: { "Content-Type": file.type || "application/octet-stream" },
+        body: file,
+      });
+      if (!response.ok) {
+        throw new Error("Image upload failed");
+      }
+      const json: { storageId?: Id<"_storage"> } = await response.json();
+      if (!json.storageId) {
+        throw new Error("Upload response missing storageId");
+      }
+      return json.storageId;
+    },
+    [docId, generateUploadUrl],
+  );
+
+  return { uploadImage };
+}
+
+export function useDocImageUrl(
+  docId: Id<"docs">,
+  storageId: string | undefined,
+) {
+  return useQuery(
+    api.docs.getImageUrl,
+    storageId ? { docId, storageId } : "skip",
+  );
+}

--- a/apps/web/src/lib/components/docs/_blocks/wireframe.css
+++ b/apps/web/src/lib/components/docs/_blocks/wireframe.css
@@ -1,0 +1,77 @@
+.eva-wireframe {
+  --wf-bg: var(--card);
+  --wf-border: var(--border);
+  --wf-text: var(--foreground);
+  --wf-muted: var(--muted-foreground);
+  --wf-primary: var(--primary);
+  --wf-radius: var(--radius);
+  --wf-surface: var(--muted);
+}
+
+.eva-wireframe .wf-card {
+  border: 1px solid var(--wf-border);
+  border-radius: var(--wf-radius);
+  background: var(--wf-bg);
+  padding: 0.75rem 1rem;
+}
+
+.eva-wireframe .wf-pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--wf-border);
+  border-radius: 9999px;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--wf-muted);
+}
+
+.eva-wireframe .wf-muted {
+  color: var(--wf-muted);
+  font-size: 0.875rem;
+}
+
+.eva-wireframe button.primary {
+  border: 1px solid var(--wf-border);
+  border-radius: var(--wf-radius);
+  background: var(--wf-primary);
+  color: var(--primary-foreground);
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.eva-wireframe-frame {
+  border: 1px solid var(--wf-border);
+  border-radius: var(--wf-radius);
+  background: var(--wf-surface);
+  padding: 0.75rem;
+}
+
+.eva-wireframe-frame--browser {
+  padding-top: 2rem;
+  position: relative;
+}
+
+.eva-wireframe-frame--browser::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  left: 0.75rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: var(--wf-muted);
+  box-shadow:
+    0.75rem 0 0 var(--wf-muted),
+    1.5rem 0 0 var(--wf-muted);
+}
+
+.eva-wireframe-frame--mobile {
+  max-width: 20rem;
+  margin-inline: auto;
+}
+
+.eva-wireframe.skeleton * {
+  color: transparent !important;
+  background: color-mix(in oklab, var(--wf-muted) 25%, transparent);
+  border-radius: 0.25rem;
+}

--- a/apps/web/src/lib/components/docs/_components/DocBlockMenu.tsx
+++ b/apps/web/src/lib/components/docs/_components/DocBlockMenu.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { Editor } from "@tiptap/core";
+import { Button } from "@conductor/ui";
+import {
+  IconAlertCircle,
+  IconBinaryTree,
+  IconChartDots,
+  IconColumns,
+  IconPhoto,
+  IconRoute,
+} from "@tabler/icons-react";
+import { EVA_BLOCK_TYPES, type EvaBlockType } from "../_blocks/types";
+
+const BLOCK_LABELS: Record<EvaBlockType, string> = {
+  callout: "Callout",
+  diff: "Diff",
+  "file-tree": "File tree",
+  diagram: "Diagram",
+  wireframe: "Wireframe",
+  image: "Image",
+};
+
+const BLOCK_ICONS: Record<EvaBlockType, typeof IconAlertCircle> = {
+  callout: IconAlertCircle,
+  diff: IconColumns,
+  "file-tree": IconBinaryTree,
+  diagram: IconChartDots,
+  wireframe: IconRoute,
+  image: IconPhoto,
+};
+
+export function DocBlockMenu({ editor }: { editor: Editor }) {
+  return (
+    <div className="flex flex-wrap gap-1 border-b border-border px-3 py-2">
+      {EVA_BLOCK_TYPES.map((blockType) => {
+        const Icon = BLOCK_ICONS[blockType];
+        return (
+          <Button
+            key={blockType}
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="h-7 gap-1 px-2 text-xs"
+            onClick={() => editor.commands.insertEvaBlock(blockType)}
+          >
+            <Icon size={14} />
+            {BLOCK_LABELS[blockType]}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/docs/_components/DocContentTab.tsx
+++ b/apps/web/src/lib/components/docs/_components/DocContentTab.tsx
@@ -38,6 +38,9 @@ import {
   setCommentHighlightState,
   scrollToAnchor,
 } from "../_utils/docCommentAnchors";
+import { EvaBlock } from "../_blocks/EvaBlock";
+import { editorDocToMarkdown } from "../_blocks/pmJsonToMarkdown";
+import { DocBlockMenu } from "./DocBlockMenu";
 
 type Doc = NonNullable<FunctionReturnType<typeof api.docs.get>>;
 
@@ -87,13 +90,14 @@ export function DocContentTab({
   const extensions = useMemo(
     () => [
       ...baseEditorExtensions,
+      EvaBlock.configure({ docId: doc._id }),
       SuggestChangesKit.configure({ getUserId: () => userIdRef.current }),
       DocCommentMark,
       DocCommentHighlight.configure({
         onAnchorClick: (anchorId) => anchorClickRef.current(anchorId),
       }),
     ],
-    [],
+    [doc._id],
   );
 
   const sync = useTiptapSync(api.prosemirrorSync, doc._id);
@@ -194,7 +198,7 @@ export function DocContentTab({
     if (!editor) return;
 
     const syncTocContent = () => {
-      setTocContent(editor.getMarkdown());
+      setTocContent(editorDocToMarkdown(editor.state.doc.toJSON()));
     };
 
     syncTocContent();
@@ -227,7 +231,7 @@ export function DocContentTab({
       if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
       idleTimerRef.current = setTimeout(() => {
         if (editCountRef.current > 0 && editor) {
-          const markdown = editor.getMarkdown();
+          const markdown = editorDocToMarkdown(editor.state.doc.toJSON());
           const pmContent = JSON.stringify(editor.state.doc.toJSON());
           saveVersion({
             docId: doc._id,
@@ -312,7 +316,7 @@ export function DocContentTab({
       // (dedupe in saveVersion makes this free when nothing changed).
       saveVersion({
         docId: doc._id,
-        content: editor.getMarkdown(),
+        content: editorDocToMarkdown(editor.state.doc.toJSON()),
         pmContent: JSON.stringify(editor.state.doc.toJSON()),
       });
       try {
@@ -348,42 +352,47 @@ export function DocContentTab({
             />
           </div>
         ) : (
-          <div className="flex min-h-0 flex-1 gap-6 overflow-hidden">
-            {!commentsOpen &&
-              !historyOpen &&
-              !suggestionsOpen &&
-              tocContent.trim().length > 0 && (
-                <FloatingToc
-                  containerRef={contentScrollRef}
-                  content={tocContent}
-                  className="hidden w-52 shrink-0 border-r border-border py-1 lg:block"
-                />
-              )}
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            {effectiveMode !== "viewing" && editor ? (
+              <DocBlockMenu editor={editor} />
+            ) : null}
+            <div className="flex min-h-0 flex-1 gap-6 overflow-hidden">
+              {!commentsOpen &&
+                !historyOpen &&
+                !suggestionsOpen &&
+                tocContent.trim().length > 0 && (
+                  <FloatingToc
+                    containerRef={contentScrollRef}
+                    content={tocContent}
+                    className="hidden w-52 shrink-0 border-r border-border py-1 lg:block"
+                  />
+                )}
 
-            <div
-              ref={contentScrollRef}
-              className="scrollbar min-h-0 flex-1 overflow-y-auto"
-            >
-              <EditorContent
-                editor={editor}
-                className="[&_.tiptap]:min-h-[12rem] [&_.tiptap]:outline-none"
-              />
-              {editor && (
-                <BubbleMenu
+              <div
+                ref={contentScrollRef}
+                className="scrollbar min-h-0 flex-1 overflow-y-auto"
+              >
+                <EditorContent
                   editor={editor}
-                  className="rounded-menu-item border border-border bg-popover p-1 shadow-md"
-                >
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-7 px-2 text-xs"
-                    onClick={handleStartComment}
+                  className="[&_.tiptap]:min-h-[12rem] [&_.tiptap]:outline-none"
+                />
+                {editor && (
+                  <BubbleMenu
+                    editor={editor}
+                    className="rounded-menu-item border border-border bg-popover p-1 shadow-md"
                   >
-                    <IconMessage size={14} />
-                    Comment
-                  </Button>
-                </BubbleMenu>
-              )}
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-xs"
+                      onClick={handleStartComment}
+                    >
+                      <IconMessage size={14} />
+                      Comment
+                    </Button>
+                  </BubbleMenu>
+                )}
+              </div>
             </div>
           </div>
         )}

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Eva doc visual blocks and MCP feedback pull - 2026-06-24
+
+- Docs now support typed `evaBlock` nodes (callout, diff, file-tree, diagram, wireframe, image) with markdown `eva:` fence round-trip so LLM/MCP consumers and version history stay in sync with the live editor.
+- Agents can pull threaded doc comments and tracked-change suggestions via `get_eva_doc_feedback` MCP, complementing the in-app Ask Eva revise flow.
+
 ## PR recap version history, agent comments, and MCP tools - 2026-06-24
 
 - PR recaps now snapshot prior ready content on each regeneration so reviewers can browse version history with head SHA context, matching how other Eva docs evolve.

--- a/packages/backend/convex/_docEditor/collectSuggestionsFromPmJson.ts
+++ b/packages/backend/convex/_docEditor/collectSuggestionsFromPmJson.ts
@@ -1,0 +1,79 @@
+type PMNode = {
+  type: string;
+  attrs?: Record<string, string | number | boolean | null>;
+  content?: PMNode[];
+  text?: string;
+  marks?: Array<{
+    type: string;
+    attrs?: Record<string, string | number | boolean | null>;
+  }>;
+};
+
+export type SuggestionKind = "insertion" | "deletion" | "modification";
+
+export type SuggestionFromPmJson = {
+  id: string;
+  kind: SuggestionKind;
+  text: string;
+  userId: string | null;
+  createdAt: number | null;
+};
+
+function toSuggestionKind(markName: string): SuggestionKind | null {
+  if (
+    markName === "insertion" ||
+    markName === "deletion" ||
+    markName === "modification"
+  ) {
+    return markName;
+  }
+  return null;
+}
+
+export function parseSuggestionAuthor(id: string): {
+  userId: string | null;
+  createdAt: number | null;
+} {
+  const parts = id.split("|");
+  if (parts.length < 2) return { userId: null, createdAt: null };
+  const userId = parts[0] && parts[0] !== "unknown" ? parts[0] : null;
+  const ts = Number(parts[1]);
+  return { userId, createdAt: Number.isFinite(ts) ? ts : null };
+}
+
+/** Walks PM JSON and groups suggestion marks by id (no ProseMirror dependency). */
+export function collectSuggestionsFromPmJson(
+  doc: PMNode,
+): SuggestionFromPmJson[] {
+  const byId = new Map<string, SuggestionFromPmJson>();
+
+  function walk(node: PMNode): void {
+    if (node.text) {
+      const marks = node.marks ?? [];
+      for (const mark of marks) {
+        const kind = toSuggestionKind(mark.type);
+        if (!kind) continue;
+        const id = String(mark.attrs?.id ?? "");
+        if (!id) continue;
+        const existing = byId.get(id);
+        const text = node.text;
+        if (existing) {
+          existing.text += text;
+        } else {
+          const { userId, createdAt } = parseSuggestionAuthor(id);
+          byId.set(id, { id, kind, text, userId, createdAt });
+        }
+      }
+    }
+    for (const child of node.content ?? []) {
+      walk(child);
+    }
+  }
+
+  walk(doc);
+  return [...byId.values()].sort((a, b) => {
+    const aTime = a.createdAt ?? 0;
+    const bTime = b.createdAt ?? 0;
+    return aTime - bTime;
+  });
+}

--- a/packages/backend/convex/_docEditor/evaBlocks.ts
+++ b/packages/backend/convex/_docEditor/evaBlocks.ts
@@ -1,0 +1,78 @@
+import type { JSONContent } from "@tiptap/core";
+
+const EVA_FENCE_PREFIX = "eva:";
+
+export function evaBlockToMarkdown(
+  blockType: string,
+  data: Record<string, unknown>,
+): string {
+  return (
+    "```" +
+    EVA_FENCE_PREFIX +
+    blockType +
+    "\n" +
+    JSON.stringify(data, null, 2) +
+    "\n```\n\n"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseEvaFenceLanguage(language: string): string | null {
+  if (!language.startsWith(EVA_FENCE_PREFIX)) return null;
+  const blockType = language.slice(EVA_FENCE_PREFIX.length);
+  return blockType.length > 0 ? blockType : null;
+}
+
+function newBlockId(): string {
+  return `blk_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Converts codeBlock nodes with `eva:` language into evaBlock nodes. */
+export function convertEvaFencesInDocJson(doc: JSONContent): JSONContent {
+  if (!doc.content) return doc;
+  return {
+    ...doc,
+    content: doc.content.map((node) => convertEvaFencesInNode(node)),
+  };
+}
+
+function convertEvaFencesInNode(node: JSONContent): JSONContent {
+  if (node.type === "codeBlock" && typeof node.attrs?.language === "string") {
+    const blockType = parseEvaFenceLanguage(node.attrs.language);
+    if (blockType) {
+      const text = extractTextFromNode(node);
+      try {
+        const parsed: unknown = JSON.parse(text);
+        if (isRecord(parsed)) {
+          return {
+            type: "evaBlock",
+            attrs: {
+              blockId: newBlockId(),
+              blockType,
+              data: parsed,
+            },
+          };
+        }
+      } catch {
+        return node;
+      }
+    }
+  }
+
+  if (node.content) {
+    return {
+      ...node,
+      content: node.content.map((child) => convertEvaFencesInNode(child)),
+    };
+  }
+  return node;
+}
+
+function extractTextFromNode(node: JSONContent): string {
+  if (node.text) return node.text;
+  if (!node.content) return "";
+  return node.content.map((child) => extractTextFromNode(child)).join("");
+}

--- a/packages/backend/convex/_docEditor/markdown.ts
+++ b/packages/backend/convex/_docEditor/markdown.ts
@@ -1,6 +1,7 @@
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown, MarkdownManager } from "@tiptap/markdown";
 import type { JSONContent } from "@tiptap/core";
+import { convertEvaFencesInDocJson } from "./evaBlocks";
 
 const EMPTY_DOC: JSONContent = {
   type: "doc",
@@ -35,5 +36,5 @@ export function markdownToDocJson(markdown: string): JSONContent {
   // A doc node must have at least one block child; fall back if parsing yielded
   // nothing usable.
   if (!json.content || json.content.length === 0) return EMPTY_DOC;
-  return json;
+  return convertEvaFencesInDocJson(json);
 }

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -51,6 +51,8 @@ import type * as _designSessions_mutations from "../_designSessions/mutations.js
 import type * as _designSessions_queries from "../_designSessions/queries.js";
 import type * as _designSessions_sandbox from "../_designSessions/sandbox.js";
 import type * as _designSessions_workflow from "../_designSessions/workflow.js";
+import type * as _docEditor_collectSuggestionsFromPmJson from "../_docEditor/collectSuggestionsFromPmJson.js";
+import type * as _docEditor_evaBlocks from "../_docEditor/evaBlocks.js";
 import type * as _docEditor_markdown from "../_docEditor/markdown.js";
 import type * as _drafts_helpers from "../_drafts/helpers.js";
 import type * as _drafts_mutations from "../_drafts/mutations.js";
@@ -297,6 +299,8 @@ declare const fullApi: ApiFromModules<{
   "_designSessions/queries": typeof _designSessions_queries;
   "_designSessions/sandbox": typeof _designSessions_sandbox;
   "_designSessions/workflow": typeof _designSessions_workflow;
+  "_docEditor/collectSuggestionsFromPmJson": typeof _docEditor_collectSuggestionsFromPmJson;
+  "_docEditor/evaBlocks": typeof _docEditor_evaBlocks;
   "_docEditor/markdown": typeof _docEditor_markdown;
   "_drafts/helpers": typeof _drafts_helpers;
   "_drafts/mutations": typeof _drafts_mutations;

--- a/packages/backend/convex/artifacts.ts
+++ b/packages/backend/convex/artifacts.ts
@@ -81,6 +81,7 @@ const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
   "count_table",
   "list_repos",
   "list_tables",
+  "get_eva_doc_feedback",
 ]);
 
 function isReadOnlyTool(name: string): boolean {

--- a/packages/backend/convex/docs.ts
+++ b/packages/backend/convex/docs.ts
@@ -5,6 +5,7 @@ import {
   internalMutation,
   internalQuery,
   type MutationCtx,
+  type DatabaseReader,
 } from "./_generated/server";
 import { components } from "./_generated/api";
 import { internal } from "./_generated/api";
@@ -17,6 +18,7 @@ import {
 import { docFields } from "./validators";
 import { prosemirrorSync } from "./prosemirrorSync";
 import { markdownToDocJson } from "./_docEditor/markdown";
+import { collectSuggestionsFromPmJson } from "./_docEditor/collectSuggestionsFromPmJson";
 import { workflow } from "./workflowManager";
 import { trackDocWorkflow } from "./workflowWatchdog";
 import {
@@ -676,5 +678,245 @@ export const reviseRecapFromFeedback = authMutation({
     });
 
     return null;
+  },
+});
+
+async function canAccessDocByKind(
+  db: DatabaseReader,
+  doc: { repoId: Id<"githubRepos">; kind?: "document" | "pr-recap" },
+  userId: Id<"users">,
+): Promise<boolean> {
+  if (doc.kind === "pr-recap") {
+    return hasCodebaseRepoAccess(db, doc.repoId, userId);
+  }
+  return hasRepoAccess(db, doc.repoId, userId);
+}
+
+function authorDisplayName(user: {
+  fullName?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+}): string {
+  const fromParts = `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim();
+  if (fromParts) return fromParts;
+  if (user.fullName?.trim()) return user.fullName.trim();
+  if (user.email?.trim()) return user.email.trim();
+  return "Unknown";
+}
+
+const feedbackAuthorValidator = v.object({
+  id: v.union(v.id("users"), v.null()),
+  displayName: v.string(),
+});
+
+const feedbackCommentValidator = v.object({
+  _id: v.id("docComments"),
+  content: v.string(),
+  anchorId: v.optional(v.string()),
+  anchorText: v.optional(v.string()),
+  resolutionTarget: v.optional(v.union(v.literal("agent"), v.literal("human"))),
+  resolvedAt: v.optional(v.number()),
+  createdAt: v.number(),
+  author: feedbackAuthorValidator,
+  replies: v.array(
+    v.object({
+      _id: v.id("docComments"),
+      content: v.string(),
+      createdAt: v.number(),
+      author: feedbackAuthorValidator,
+    }),
+  ),
+});
+
+const feedbackSuggestionValidator = v.object({
+  id: v.string(),
+  kind: v.union(
+    v.literal("insertion"),
+    v.literal("deletion"),
+    v.literal("modification"),
+  ),
+  text: v.string(),
+  createdAt: v.union(v.number(), v.null()),
+  author: feedbackAuthorValidator,
+});
+
+/** Returns threaded comments and tracked-change suggestions for agent review pull. */
+export const getFeedback = authQuery({
+  args: {
+    id: v.id("docs"),
+    includeResolved: v.optional(v.boolean()),
+    resolutionTarget: v.optional(
+      v.union(v.literal("agent"), v.literal("human")),
+    ),
+  },
+  returns: v.object({
+    comments: v.array(feedbackCommentValidator),
+    suggestions: v.array(feedbackSuggestionValidator),
+  }),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.id);
+    if (!doc) {
+      return { comments: [], suggestions: [] };
+    }
+    if (!(await canAccessDocByKind(ctx.db, doc, ctx.userId))) {
+      return { comments: [], suggestions: [] };
+    }
+
+    const rows = await ctx.db
+      .query("docComments")
+      .withIndex("by_doc", (q) => q.eq("docId", args.id))
+      .collect();
+
+    const activeRows = rows.filter((row) => row.deletedAt === undefined);
+    const authorIds = new Set<Id<"users">>();
+    for (const row of activeRows) {
+      if (row.authorId) authorIds.add(row.authorId);
+    }
+
+    const authorNameById = new Map<Id<"users">, string>();
+    for (const authorId of authorIds) {
+      const user = await ctx.db.get(authorId);
+      authorNameById.set(authorId, user ? authorDisplayName(user) : "Unknown");
+    }
+
+    const replyMap = new Map<Id<"docComments">, typeof activeRows>();
+    for (const row of activeRows) {
+      if (!row.parentId) continue;
+      const existing = replyMap.get(row.parentId) ?? [];
+      existing.push(row);
+      replyMap.set(row.parentId, existing);
+    }
+
+    const includeResolved = args.includeResolved === true;
+    const roots = activeRows
+      .filter((row) => !row.parentId)
+      .filter((row) => includeResolved || row.resolvedAt === undefined)
+      .filter((row) => {
+        if (args.resolutionTarget === undefined) return true;
+        return row.resolutionTarget === args.resolutionTarget;
+      })
+      .sort((a, b) => a.createdAt - b.createdAt);
+
+    const comments = roots.map((root) => {
+      const replies = (replyMap.get(root._id) ?? [])
+        .filter((reply) => reply.deletedAt === undefined)
+        .sort((a, b) => a.createdAt - b.createdAt)
+        .map((reply) => ({
+          _id: reply._id,
+          content: reply.content,
+          createdAt: reply.createdAt,
+          author: {
+            id: reply.authorId ?? null,
+            displayName: reply.authorId
+              ? (authorNameById.get(reply.authorId) ?? "Unknown")
+              : "Unknown",
+          },
+        }));
+
+      return {
+        _id: root._id,
+        content: root.content,
+        anchorId: root.anchorId,
+        anchorText: root.anchorText,
+        resolutionTarget: root.resolutionTarget,
+        resolvedAt: root.resolvedAt,
+        createdAt: root.createdAt,
+        author: {
+          id: root.authorId ?? null,
+          displayName: root.authorId
+            ? (authorNameById.get(root.authorId) ?? "Unknown")
+            : "Unknown",
+        },
+        replies,
+      };
+    });
+
+    const snapshot = await ctx.runQuery(
+      components.prosemirrorSync.lib.getSnapshot,
+      { id: args.id },
+    );
+
+    const suggestions: Array<{
+      id: string;
+      kind: "insertion" | "deletion" | "modification";
+      text: string;
+      createdAt: number | null;
+      author: { id: Id<"users"> | null; displayName: string };
+    }> = [];
+
+    if (snapshot.content !== null) {
+      const pmContent = JSON.stringify(snapshot.content);
+      try {
+        const parsed = JSON.parse(pmContent);
+        if (
+          parsed !== null &&
+          typeof parsed === "object" &&
+          !Array.isArray(parsed) &&
+          "type" in parsed &&
+          typeof parsed.type === "string"
+        ) {
+          const extracted = collectSuggestionsFromPmJson({
+            type: parsed.type,
+            content: Array.isArray(parsed.content) ? parsed.content : undefined,
+          });
+          for (const item of extracted) {
+            let displayName = "Unknown";
+            let authorId: Id<"users"> | null = null;
+            if (item.userId) {
+              const normalized = ctx.db.normalizeId("users", item.userId);
+              if (normalized) {
+                authorId = normalized;
+                const user = await ctx.db.get(normalized);
+                if (user) displayName = authorDisplayName(user);
+              }
+            }
+            suggestions.push({
+              id: item.id,
+              kind: item.kind,
+              text: item.text,
+              createdAt: item.createdAt,
+              author: { id: authorId, displayName },
+            });
+          }
+        }
+      } catch {
+        // ignore malformed snapshots
+      }
+    }
+
+    return { comments, suggestions };
+  },
+});
+
+/** Upload URL for doc image blocks (repo access required). */
+export const generateUploadUrl = authMutation({
+  args: { docId: v.id("docs") },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.docId);
+    if (!doc) throw new Error("Document not found");
+    if (!(await canAccessDocByKind(ctx.db, doc, ctx.userId))) {
+      throw new Error("Not authorized");
+    }
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+/** Resolves a doc image storage id to a signed URL. */
+export const getImageUrl = authQuery({
+  args: {
+    docId: v.id("docs"),
+    storageId: v.string(),
+  },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.docId);
+    if (!doc) return null;
+    if (!(await canAccessDocByKind(ctx.db, doc, ctx.userId))) {
+      return null;
+    }
+    if (!args.storageId) return null;
+    return await ctx.storage.getUrl(args.storageId);
   },
 });

--- a/packages/backend/convex/mcp/nodeActions.ts
+++ b/packages/backend/convex/mcp/nodeActions.ts
@@ -967,6 +967,34 @@ export const getEvaDoc = internalAction({
   },
 });
 
+export const getEvaDocFeedback = internalAction({
+  args: {
+    clerkUserId: v.string(),
+    docId: v.string(),
+    includeResolved: v.optional(v.boolean()),
+    resolutionTarget: v.optional(
+      v.union(v.literal("agent"), v.literal("human")),
+    ),
+  },
+  returns: v.any(),
+  handler: async (
+    _ctx,
+    { clerkUserId, docId, includeResolved, resolutionTarget },
+  ) => {
+    const args: Record<string, boolean | string> = { id: docId };
+    if (includeResolved !== undefined) args.includeResolved = includeResolved;
+    if (resolutionTarget !== undefined) {
+      args.resolutionTarget = resolutionTarget;
+    }
+    return runQueryAsUser(
+      getEvaConvexCloudUrl(),
+      clerkUserId,
+      "docs:getFeedback",
+      args,
+    );
+  },
+});
+
 export const listEvaDocs = internalAction({
   args: {
     clerkUserId: v.string(),

--- a/packages/backend/convex/mcp/tools.ts
+++ b/packages/backend/convex/mcp/tools.ts
@@ -798,6 +798,35 @@ This creates 3 tasks where Build API depends on Setup DB schema, and Build UI de
   );
 
   server.tool(
+    "get_eva_doc_feedback",
+    "Get all comments and tracked-change suggestions on an Eva doc (authors + dates) so you can act on the review feedback.",
+    {
+      docId: z.string().describe("The Eva doc ID"),
+      includeResolved: z
+        .boolean()
+        .optional()
+        .describe("Include resolved comment threads (default false)"),
+      resolutionTarget: z
+        .enum(["agent", "human"])
+        .optional()
+        .describe("Filter root comments by resolution target"),
+    },
+    async ({ docId, includeResolved, resolutionTarget }) => {
+      await getContext();
+      const feedback = await ctx.runAction(
+        internal.mcp.nodeActions.getEvaDocFeedback,
+        {
+          clerkUserId,
+          docId,
+          includeResolved,
+          resolutionTarget,
+        },
+      );
+      return textResult({ feedback: feedback ?? null });
+    },
+  );
+
+  server.tool(
     "list_eva_docs",
     "List all Eva design documents (PRDs) attached to one of your repos.",
     {

--- a/packages/backend/convex/prosemirrorSync.ts
+++ b/packages/backend/convex/prosemirrorSync.ts
@@ -3,6 +3,7 @@ import type { DataModel } from "./_generated/dataModel";
 import { ProsemirrorSync } from "@convex-dev/prosemirror-sync";
 import { getCurrentUserId } from "./auth";
 import { hasRepoAccess } from "./functions";
+import { evaBlockToMarkdown } from "./_docEditor/evaBlocks";
 
 const prosemirrorSync = new ProsemirrorSync(components.prosemirrorSync);
 
@@ -14,6 +15,17 @@ interface PMNode {
   content?: PMNode[];
   text?: string;
   marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+}
+
+function readEvaBlockData(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const record: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    record[key] = entry;
+  }
+  return record;
 }
 
 function pmJsonToMarkdown(node: PMNode, depth?: number): string {
@@ -62,6 +74,11 @@ function pmJsonToMarkdown(node: PMNode, depth?: number): string {
     case "codeBlock": {
       const lang = String(node.attrs?.language ?? "");
       return "```" + lang + "\n" + children + "```\n\n";
+    }
+    case "evaBlock": {
+      const blockType = String(node.attrs?.blockType ?? "callout");
+      const data = readEvaBlockData(node.attrs?.data);
+      return evaBlockToMarkdown(blockType, data);
     }
     case "blockquote":
       return (


### PR DESCRIPTION
## Summary
- Add structured `eva:` visual blocks to the doc editor (callout, diff, file tree, diagram, wireframe, image) with markdown round-trip through Convex sync.
- Wire block inserts in edit mode, doc image upload via Convex storage, and TOC/version snapshots via custom markdown export.
- Add `get_eva_doc_feedback` MCP tool plus `docs.getFeedback` for threaded comments and PM snapshot suggestions.

## Test plan
- [ ] Open a doc in edit mode and insert each block type from the block menu; save and reload to confirm round-trip.
- [ ] Upload an image block and verify it renders after refresh.
- [ ] Call `get_eva_doc_feedback` via MCP on a doc with comments and suggest-mode edits.
- [ ] Run `npx tsc` in `apps/web` and `packages/backend` if not already verified.