### PR TITLE
fix(web): accept bare ?agent search param for agent sign-in

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { LandingPage } from "./_components/LandingPage";
 
 const searchSchema = z.object({
-  agent: z.boolean().optional(),
+  // A bare `?agent` (no value) parses as "", so accept it alongside `?agent=true`.
+  agent: z
+    .union([z.boolean(), z.literal("")])
+    .optional()
+    .transform((value) => (value === "" || value === true ? true : undefined)),
 });
 
 export const Route = createFileRoute("/")({


### PR DESCRIPTION
A bare `?agent` parses as the empty string, which failed the boolean search schema and threw SearchParamError. Accept both `?agent` and `?agent=true` by validating a boolean-or-empty-string union and normalising both to `true`.


Claude-Session: https://claude.ai/code/session_01Qkkxa8VojpQDVbz4jYcqkn