### PR TITLE
[PRESERVED / DO NOT MERGE] Seeded running-sandbox snapshots — revisit when stable

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/settings/AppClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/AppClient.tsx
@@ -30,6 +30,7 @@ export function AppClient() {
 
   const startupCommands = repo.startupCommands?.join("\n") ?? "";
   const backgroundCommands = repo.backgroundCommands?.join("\n") ?? "";
+  const stopCommands = repo.stopCommands?.join("\n") ?? "";
 
   const handleDevPortBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const raw = e.target.value.trim();
@@ -67,6 +68,12 @@ export function AppClient() {
     const next = e.target.value;
     if (next === backgroundCommands) return;
     updateConfig({ repoId, backgroundCommands: parseCommandLines(next) });
+  };
+
+  const handleStopCommandsBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    const next = e.target.value;
+    if (next === stopCommands) return;
+    updateConfig({ repoId, stopCommands: parseCommandLines(next) });
   };
 
   const handleSystemPromptBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
@@ -154,9 +161,11 @@ export function AppClient() {
               placeholder="npx supabase start&#10;psql -h localhost -p 54322 -U postgres -d postgres < /home/eva/sandbox-config/seed.sql"
             />
             <p className="mt-1 text-[11px] text-muted-foreground">
-              One command per line. Runs once when sandbox first starts (after
-              snapshot loads). Use for services like <code>supabase start</code>{" "}
-              or database seeding. Commands have a 10-minute timeout each.
+              One command per line. Runs <strong>once</strong> per sandbox (a
+              marker is left, so it is skipped on resume and baked into a seeded
+              snapshot). Use for one-time data <strong>seeding</strong> that
+              depends on services being up — put the services themselves in
+              Background Commands. Commands have a 10-minute timeout each.
             </p>
           </div>
         </div>
@@ -182,6 +191,27 @@ export function AppClient() {
               redirect. Commands respawn every time the sandbox starts or
               resumes. Use for daemons like <code>npx convex dev</code>. Output
               is written to <code>/tmp/bg-&lt;index&gt;.log</code>.
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+          <h3 className="text-sm font-medium">Stop Commands</h3>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Clean-shutdown commands run before snapshotting a seeded sandbox
+            </label>
+            <textarea
+              key={`stop-${repoId}`}
+              defaultValue={stopCommands}
+              onBlur={handleStopCommandsBlur}
+              className="w-full h-32 rounded-md bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="pkill -TERM -f 'convex dev'&#10;pnpm stop-db"
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              One command per line. Run by the seeded-snapshot build before the
+              filesystem snapshot is taken, so on-disk volumes (e.g. local
+              Postgres) flush consistently. Not run on normal sandbox starts.
             </p>
           </div>
         </div>

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/components/CronScheduleCard";
 import {
   IconCamera,
+  IconCheck,
   IconPlayerPlay,
   IconTrash,
   IconUpload,
@@ -51,6 +52,10 @@ export function SnapshotsClient({
   const snapshot = useQuery(api.repoSnapshots.getRepoSnapshot, { repoId });
   const builds = useQuery(
     api.repoSnapshots.listBuilds,
+    snapshot ? { repoSnapshotId: snapshot._id } : "skip",
+  );
+  const seededApps = useQuery(
+    api.repoSnapshots.getSeededAppStatus,
     snapshot ? { repoSnapshotId: snapshot._id } : "skip",
   );
   const saveRepoSnapshot = useMutation(api.repoSnapshots.saveRepoSnapshot);
@@ -123,6 +128,26 @@ export function SnapshotsClient({
   const isRunning =
     builds && builds.length > 0 && builds[0].status === "running";
   const lastBuild = builds && builds.length > 0 ? builds[0] : null;
+  // Base image is marked success before Step 5 seeding runs, so "in progress"
+  // must also cover an ongoing seed (any app still in the "running" state).
+  const isSeeding = (lastBuild?.seededApps ?? []).some(
+    (a) => a.status === "running",
+  );
+  const seedingRepoIds = new Set(
+    (lastBuild?.seededApps ?? [])
+      .filter((a) => a.status === "running")
+      .map((a) => a.repoId),
+  );
+  const warmupByRepoId = new Map(
+    (lastBuild?.seededApps ?? []).map((app) => [
+      app.repoId,
+      {
+        seededSnapshotName: app.seededSnapshotName,
+        warmupStatus: app.warmupStatus,
+        warmupError: app.warmupError,
+      },
+    ]),
+  );
 
   const handleSnapshotsTabChange = useCallback(
     (value: string) => {
@@ -259,75 +284,141 @@ export function SnapshotsClient({
 
         <TabsContent value="status" className="space-y-6">
           {snapshot ? (
-            <div className="rounded-surface border border-border bg-card p-4 space-y-3">
-              <h3 className="text-sm font-medium">Current Status</h3>
-              <div className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2 sm:gap-4">
-                <div>
-                  <span className="text-muted-foreground">Snapshot Name</span>
-                  <p className="font-mono mt-0.5">{snapshot.snapshotName}</p>
+            <>
+              <div className="rounded-surface border border-border bg-card p-4 space-y-3">
+                <h3 className="text-sm font-medium">Current Status</h3>
+                <div className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2 sm:gap-4">
+                  <div>
+                    <span className="text-muted-foreground">Snapshot Name</span>
+                    <p className="font-mono mt-0.5">{snapshot.snapshotName}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Schedule</span>
+                    <p className="mt-0.5">
+                      {snapshot.schedule === "manual"
+                        ? "Manual"
+                        : (() => {
+                            const result = describeCron(snapshot.schedule);
+                            return result.valid
+                              ? result.text
+                              : snapshot.schedule;
+                          })()}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Clone Branch</span>
+                    <p className="font-mono mt-0.5">
+                      {snapshot.workflowRef ?? "main"}
+                    </p>
+                  </div>
+                  {lastBuild && (
+                    <>
+                      <div>
+                        <span className="text-muted-foreground">
+                          Last Build
+                        </span>
+                        <p className="mt-0.5">
+                          {new Date(lastBuild.startedAt).toLocaleDateString(
+                            "en-GB",
+                            {
+                              day: "numeric",
+                              month: "short",
+                              year: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                            },
+                          )}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Status</span>
+                        <p className="mt-0.5">
+                          <BuildStatusBadge status={lastBuild.status} />
+                        </p>
+                      </div>
+                    </>
+                  )}
                 </div>
-                <div>
-                  <span className="text-muted-foreground">Schedule</span>
-                  <p className="mt-0.5">
-                    {snapshot.schedule === "manual"
-                      ? "Manual"
-                      : (() => {
-                          const result = describeCron(snapshot.schedule);
-                          return result.valid ? result.text : snapshot.schedule;
-                        })()}
+                <Button
+                  size="sm"
+                  onClick={handleRebuild}
+                  disabled={building || isRunning || isSeeding}
+                >
+                  {building || isRunning || isSeeding ? (
+                    <Spinner size="sm" className="mr-1.5" />
+                  ) : (
+                    <IconPlayerPlay size={14} className="mr-1.5" />
+                  )}
+                  {building || isRunning
+                    ? "Building..."
+                    : isSeeding
+                      ? "Seeding..."
+                      : "Rebuild Now"}
+                </Button>
+              </div>
+              <div className="rounded-lg bg-muted/40 p-4 space-y-3">
+                <h3 className="text-sm font-medium">Seeded Snapshots</h3>
+                <p className="text-xs text-muted-foreground">
+                  Per-app running-sandbox snapshots with the DB already seeded.
+                  Apps without one fall back to the base Image (slower cold
+                  start).
+                </p>
+                {seededApps === undefined ? (
+                  <p className="text-xs text-muted-foreground">Loading…</p>
+                ) : seededApps.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No seedable apps for this snapshot.
                   </p>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Clone Branch</span>
-                  <p className="font-mono mt-0.5">
-                    {snapshot.workflowRef ?? "main"}
-                  </p>
-                </div>
-                {lastBuild && (
-                  <>
-                    <div>
-                      <span className="text-muted-foreground">Last Build</span>
-                      <p className="mt-0.5">
-                        {new Date(lastBuild.startedAt).toLocaleDateString(
-                          "en-GB",
-                          {
-                            day: "numeric",
-                            month: "short",
-                            year: "numeric",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          },
-                        )}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Status</span>
-                      <p className="mt-0.5">
-                        <BuildStatusBadge status={lastBuild.status} />
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Warmup</span>
-                      <p className="mt-0.5">
-                        <WarmupStatusBadge status={lastBuild.warmupStatus} />
-                      </p>
-                    </div>
-                  </>
+                ) : (
+                  <div className="space-y-2 text-xs">
+                    {seededApps.map((app) => {
+                      const warmup = warmupByRepoId.get(app.repoId);
+                      const warmupMatchesSnapshot =
+                        app.seededSnapshotName !== null &&
+                        warmup?.seededSnapshotName === app.seededSnapshotName;
+                      return (
+                        <div
+                          key={app.repoId}
+                          className="flex items-start justify-between gap-3"
+                        >
+                          <span className="font-medium shrink-0">
+                            {app.app ?? app.name}
+                          </span>
+                          {seedingRepoIds.has(app.repoId) ? (
+                            <span className="inline-flex shrink-0 items-center gap-1 text-blue-500">
+                              <Spinner size="sm" />
+                              Seeding…
+                            </span>
+                          ) : app.seededSnapshotName ? (
+                            <span className="inline-flex min-w-0 items-start gap-1 text-green-500">
+                              <IconCheck
+                                size={12}
+                                className="mt-0.5 shrink-0"
+                              />
+                              <span className="min-w-0 space-y-1">
+                                <span className="block font-mono break-all">
+                                  {app.seededSnapshotName}
+                                </span>
+                                {warmupMatchesSnapshot && (
+                                  <WarmupStatusBadge
+                                    status={warmup.warmupStatus}
+                                    error={warmup.warmupError}
+                                  />
+                                )}
+                              </span>
+                            </span>
+                          ) : (
+                            <span className="shrink-0 text-muted-foreground">
+                              Using base Image
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
                 )}
               </div>
-              <Button
-                size="sm"
-                onClick={handleRebuild}
-                disabled={building || isRunning}
-              >
-                {isRunning ? (
-                  <Spinner size="sm" className="mr-1.5" />
-                ) : (
-                  <IconPlayerPlay size={14} className="mr-1.5" />
-                )}
-                {isRunning ? "Building..." : "Rebuild Now"}
-              </Button>
-            </div>
+            </>
           ) : (
             <div className="rounded-surface border border-border bg-card p-8 text-center">
               <p className="text-sm text-muted-foreground">
@@ -356,6 +447,7 @@ export function SnapshotsClient({
                       <th className="px-2 py-2 font-medium sm:px-4">Trigger</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Status</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Warmup</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">Seeded</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
@@ -4,8 +4,23 @@ import {
   IconChevronDown,
   IconChevronRight,
   IconClock,
+  IconLoader2,
   IconX,
 } from "@tabler/icons-react";
+
+type SeededAppResult = {
+  repoId: Id<"githubRepos">;
+  app?: string;
+  status?: "running" | "seeded" | "fallback";
+  seededSnapshotName: string | null;
+  warmupStatus?: "pending" | "success" | "error";
+  warmupError?: string;
+};
+
+/** A per-app entry counts as seeded by explicit status, or (legacy rows) by name. */
+function isSeededEntry(a: SeededAppResult): boolean {
+  return a.status ? a.status === "seeded" : a.seededSnapshotName !== null;
+}
 
 export function BuildRow({
   build,
@@ -23,6 +38,7 @@ export function BuildRow({
     completedAt?: number;
     warmupStatus?: "pending" | "success" | "error";
     warmupError?: string;
+    seededApps?: SeededAppResult[];
   };
   isExpanded: boolean;
   duration: string;
@@ -52,24 +68,65 @@ export function BuildRow({
           <BuildStatusBadge status={build.status} />
         </td>
         <td className="px-2 py-2 sm:px-4">
-          <WarmupStatusBadge status={build.warmupStatus} />
+          <WarmupStatusBadge
+            status={build.warmupStatus}
+            error={build.warmupError}
+          />
+        </td>
+        <td className="px-2 py-2 sm:px-4">
+          <SeededSummary seededApps={build.seededApps} />
         </td>
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={6} className="px-4 py-3">
+          <td colSpan={7} className="px-4 py-3">
             {build.error && (
               <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 {build.error}
               </div>
             )}
-            {build.warmupError && (
-              <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                Warmup failed: {build.warmupError}
+            {build.seededApps && build.seededApps.length > 0 && (
+              <div className="mb-2 space-y-1 text-xs">
+                {build.seededApps.map((a) => (
+                  <div key={a.repoId} className="flex items-start gap-2">
+                    {a.status === "running" ? (
+                      <span className="inline-flex items-center gap-1 text-blue-500">
+                        <IconLoader2
+                          size={12}
+                          className="shrink-0 animate-spin"
+                        />
+                        {a.app ?? a.repoId} — seeding…
+                      </span>
+                    ) : a.seededSnapshotName ? (
+                      <>
+                        <span className="inline-flex shrink-0 items-center gap-1 text-green-500">
+                          <IconCheck size={12} className="shrink-0" />
+                          {a.app ?? a.repoId}
+                        </span>
+                        <span className="min-w-0 space-y-1">
+                          <span className="block font-mono break-all text-muted-foreground">
+                            {a.seededSnapshotName}
+                          </span>
+                          <WarmupStatusBadge
+                            status={a.warmupStatus}
+                            error={a.warmupError}
+                          />
+                        </span>
+                      </>
+                    ) : (
+                      <span className="inline-flex items-start gap-1 text-muted-foreground">
+                        <IconX size={12} className="mt-0.5 shrink-0" />
+                        <span className="break-words">
+                          {a.app ?? a.repoId} — fell back to base Image
+                        </span>
+                      </span>
+                    )}
+                  </div>
+                ))}
               </div>
             )}
             {build.logs ? (
-              <pre className="max-h-64 overflow-auto rounded bg-muted/50 p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap sm:p-3 sm:text-[11px]">
+              <pre className="max-h-64 overflow-y-auto overflow-x-hidden rounded bg-muted/50 p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap break-all sm:p-3 sm:text-[11px]">
                 {build.logs}
               </pre>
             ) : (
@@ -81,6 +138,42 @@ export function BuildRow({
         </tr>
       )}
     </>
+  );
+}
+
+export function WarmupStatusBadge({
+  status,
+  error,
+}: {
+  status?: "pending" | "success" | "error";
+  error?: string;
+}) {
+  if (!status) {
+    return null;
+  }
+  if (status === "pending") {
+    return (
+      <span className="inline-flex items-center gap-1 text-blue-500">
+        <IconLoader2 size={12} className="shrink-0 animate-spin" />
+        warming snapshot cache
+      </span>
+    );
+  }
+  if (status === "success") {
+    return (
+      <span className="inline-flex items-center gap-1 text-green-500">
+        <IconCheck size={12} className="shrink-0" />
+        cache warmed
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-start gap-1 text-amber-500">
+      <IconX size={12} className="mt-0.5 shrink-0" />
+      <span className="break-words">
+        cache warm failed{error ? `: ${error}` : ""}
+      </span>
+    </span>
   );
 }
 
@@ -113,34 +206,31 @@ export function BuildStatusBadge({
   );
 }
 
-export function WarmupStatusBadge({
-  status,
-}: {
-  status?: "pending" | "success" | "error";
-}) {
-  if (!status) {
+/** Compact per-build seeding summary: seeded/total, coloured by completeness. */
+function SeededSummary({ seededApps }: { seededApps?: SeededAppResult[] }) {
+  if (!seededApps || seededApps.length === 0) {
     return <span className="text-muted-foreground">&mdash;</span>;
   }
-  if (status === "pending") {
+  const total = seededApps.length;
+  const seeded = seededApps.filter(isSeededEntry).length;
+  // Still seeding: show a spinner with progress so far.
+  if (seededApps.some((a) => a.status === "running")) {
     return (
       <span className="inline-flex items-center gap-1 text-blue-500">
-        <IconClock size={12} />
-        Pending
+        <IconLoader2 size={12} className="animate-spin" />
+        {seeded}/{total}
       </span>
     );
   }
-  if (status === "success") {
-    return (
-      <span className="inline-flex items-center gap-1 text-success">
-        <IconCheck size={12} />
-        Warmed
-      </span>
-    );
-  }
+  const color =
+    seeded === total
+      ? "text-green-500"
+      : seeded === 0
+        ? "text-destructive"
+        : "text-amber-500";
   return (
-    <span className="inline-flex items-center gap-1 text-destructive">
-      <IconX size={12} />
-      Failed
+    <span className={`inline-flex items-center gap-1 ${color}`}>
+      {seeded}/{total}
     </span>
   );
 }

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## Seeded snapshot database restore artifact - 2026-07-05
+
+- Captured a compressed Supabase Postgres dump into the seeded snapshot filesystem after seed commands complete, then restored it once when fresh sandboxes boot from that snapshot.
+- Restored the dump before preview dev servers and workflow background commands start, while leaving non-Supabase and non-seeded snapshots as no-ops.
+- Reason for change: Daytona snapshot creation did not preserve the Supabase Docker volume for fresh sandboxes, so a warmed seeded snapshot could still start with an empty local DB unless the database state was exported as ordinary filesystem data.
+
+## Preserve seeded snapshot runtime state - 2026-07-05
+
+- Preserved untracked runtime state when booting from a seeded snapshot marker so post-create repo cleanup does not remove stopped local database restore files while still skipping seed commands.
+- Started session background services before running startup/seed commands, and made background command launches return immediately after detaching the daemon script.
+- Reason for change: fresh sandboxes could boot from the correct seeded snapshot but start an empty Supabase DB if `git clean -fd` removed the snapshot's untracked local-service state before background services restarted; repair/retry paths also need Supabase and Convex local daemons running before seed/import commands wait on them.
+
+## Seeded snapshot config restore and warm-up fix - 2026-07-05
+
+- Force-restored baked sandbox config files when creating fresh session/task/project sandboxes from seeded snapshots so the app keeps the DB connection and seed files captured during the snapshot build.
+- Reintroduced per-app seeded snapshot cache warming during snapshot builds so the first slow Daytona create-from-snapshot happens before a user creates a sandbox, with build-level warmup status staying pending until every app has settled.
+- Reason for change: seeded snapshots carry the startup-complete marker by design, but that marker was also preventing config restore after checkout, and fresh seeded snapshots still need an explicit warm-up pass before normal sandbox creation is fast.
+
+## Snapshot seed bootstrap and leak guard - 2026-07-05
+
+- Added an explicit base-Image seeding mode for snapshot builds so stale per-app seeded snapshots can be refreshed without triggering cron retry cascades.
+- Label new seed-prep sandboxes and sweep unreferenced labelled prep sandboxes at build start to prevent future runner-pool leaks.
+- Reason for change: eprocurement needed a safe bootstrap path out of a stale seeded snapshot while preserving keep-last-good behavior for normal builds.
+
+## Seeded-snapshot capture polling fix - 2026-05-31
+
+- Fixed seeded-snapshot filesystem capture timeouts by switching from a blocking SDK call to non-blocking trigger-and-poll, preventing silent fallback to the base image when DB volumes exceed the 600s Convex action ceiling.
+
+## Seeded running-sandbox snapshots for fast cold starts - 2026-05-31
+
+- Bake the seeded local database into per-app Daytona filesystem snapshots so new sandboxes skip the ~10-minute Supabase and Convex seed on every start.
+- Added per-app Stop Commands to app settings, and clarified Startup commands (seed, run once) versus Background commands (services, run every start).
+- Sandbox prep now runs background services before startup commands so seeding has its dependencies available; sandboxes prefer the app's seeded snapshot when one exists.
+
+## Seeded-snapshot reliability and observability - 2026-05-31
+
+- Gate per-app seeding on a base-image propagation probe so seeding only starts once the freshly built snapshot is actually bootable, fixing "No available runners" failures and silent fallbacks to the base image.
+- Surface per-app seeding outcomes in snapshot settings: the status tab shows each app's current state (seeded with snapshot name, or using the base image), and build history shows per-build results as a seeded/total count with per-app detail on expand.
+- Removed the snapshot-cache warmup pass (now redundant with the propagation probe, which also warms the runner cache) and cleared its orphaned fields from existing build records.
+
 ## Sandbox chats surface in the sessions sidebar - 2026-07-02
 
 - Project sandbox chats and quick-task sandbox chats now appear in the sessions sidebar as virtual entries whenever they have at least one message, interleaved with real sessions by last activity, so ongoing conversations are reachable from one place instead of buried in project/task pages.

--- a/internal/plans/todo/running-sandbox-snapshot-seeded-db.md
+++ b/internal/plans/todo/running-sandbox-snapshot-seeded-db.md
@@ -1,0 +1,289 @@
+# Running-sandbox filesystem snapshots (seeded DB baked in)
+
+## Goal
+
+Cut ~10-min cold-start cost. Today the per-repo Daytona snapshot is a **Dockerfile/Image**
+build (clone + `pnpm install` + buildCommands). The DB setup + seed (local Supabase + Convex
+in Docker-in-Docker, migrate, seed) runs as **startup commands on every sandbox start** — that's
+the 10 min.
+
+New: daily cron produces a **filesystem snapshot of a fully-prepared, DB-seeded running sandbox**,
+so new sandboxes resume with seeded Docker volumes already on disk and skip the seed.
+
+## Key SDK facts (verified)
+
+- `sandbox._experimental_createSnapshot(name, timeout?)` → captures **filesystem only** (not
+  memory/processes). Sandbox enters `snapshotting` then returns to prior state. Returns `Promise<void>`.
+- `daytona.create({ snapshot: name })` consumes it — same call we use today.
+- Endpoints landed in `@daytonaio/sdk` 0.165.0 (14 Apr 2026). We are on **0.143.0** → upgrade required.
+- Method is `_experimental_`-prefixed (unstable name) but **docs show no region gating**. The
+  "experimental region" in the announcement is for _memory_ pause/resume — not needed here.
+
+## Why filesystem-only is the right fit
+
+Docker-in-Docker stores Postgres/Convex data under `/var/lib/docker`. A filesystem snapshot
+captures it **iff the data is flushed + consistent at snapshot time**. So: seed → **cleanly stop
+DB containers** (Postgres checkpoint/flush) → snapshot. Memory state is irrelevant; on resume we
+just restart containers against the existing volumes — no re-seed.
+
+## Architecture: AUGMENT the existing Image build (revised — simplest path)
+
+The existing per-repo Image already bakes a perfect boot base: toolchain (node, docker, chrome, VNC,
+CLIs, claude plugins, supabase/convex CLI) + clone + deps + buildCommands + uploaded config files
+(`/home/eva/sandbox-config/`, incl. `data.sql` / `carepulse-staging-backup.zip`). **Keep it as-is.**
+
+Add ONE new stage to the cron, after the Image is `active`:
+
+1. Boot a sandbox from the per-repo Image.
+2. Run `startupCommands` (services up) → `seedCommands` (the ~10-min seed, once).
+3. Run `stopCommands` (clean-stop) so volumes flush.
+4. `sandbox._experimental_createSnapshot(seededSnapshotName)` — captures the full filesystem incl.
+   seeded Docker volumes.
+5. Delete the prep sandbox.
+
+Sandboxes then `daytona.create({ snapshot: seededSnapshotName })` — a self-contained filesystem with
+the seeded DB on disk. The Image is only a build-time base.
+
+Why this over the earlier "replace / two-layer split": no separate global base-toolchain image to
+build or scope; reuses ALL existing code (Image build, config files, delete-existing, cron, UI);
+strictly smaller surface. The seeded snapshot uses a distinct name (e.g. `snapshot-<repoId>-seeded`)
+so it doesn't collide with the Image name it booted from; the cron deletes the prior seeded snapshot
+each run → latest-only (matches the daily 24 h retention).
+
+## Config model — split today's single startup-commands blob
+
+Today `settings/app` has ONE "Startup commands" list, run on every start. The seed steps depend on
+services being up, so they interleave — but they split into two **ordered phases** (startup brings
+services up; seed runs after). Introduce on `githubRepos` (settings/app UI):
+
+- **`startupCommands`** (repurpose existing) — bring services up. Run on EVERY start incl. warm
+  restore from a seeded snapshot.
+- **`seedCommands`** (new) — data load. Run ONCE during snapshot build, after startup. Baked in.
+- **`stopCommands`** (new) — clean shutdown before snapshot, so on-disk data is consistent.
+
+### carepulse-ts mapping (current commands, re-split)
+
+```
+# startupCommands (always; carepulse)
+pnpm start-db                                   # supabase start — reuses seeded volumes on warm restore
+cd apps/web && (nohup env CONVEX_AGENT_MODE=anonymous npx convex dev > /tmp/convex.log 2>&1 &) \
+  && for i in $(seq 1 120); do grep -q "Convex functions ready" /tmp/convex.log && break; sleep 2; done \
+  && (grep -q "Convex functions ready" /tmp/convex.log || (tail -80 /tmp/convex.log && exit 1))
+
+# seedCommands (once, during build, after startup)
+cp data.sql packages/db/data.sql
+cp carepulse-staging-backup.zip apps/web/carepulse-staging-backup.zip
+rm -f data.sql carepulse-staging-backup.zip
+pnpm seed:sql                                   # seeds postgres (volume captured by snapshot)
+cd apps/web && npx convex import carepulse-staging-backup.zip
+cd apps/web && npx convex env set BASE_APP_URL http://localhost:3000
+cd apps/web && npx convex env set NEXT_PUBLIC_API_URL https://staging.carepulse.co.uk
+touch /home/eva/.db-seeded
+
+# stopCommands (clean shutdown before _experimental_createSnapshot)
+pkill -TERM -f "convex dev" 2>/dev/null || true            # flush convex local backend (sqlite)
+pkill -TERM -f "convex-local-backend" 2>/dev/null || true
+sleep 3
+pnpm stop-db                                                # supabase stop — retains seeded volumes
+```
+
+Note: `convex env set` values persist in the local backend store (captured) → no re-run on resume.
+The `.db-seeded` marker (captured) lets cold/no-snapshot starts know whether to seed.
+
+## Build flow (cron — existing Image build, then a NEW seed-snapshot stage)
+
+Existing steps unchanged: delete old Image → `kickOffSnapshotBuild` (Dockerfile) → poll until
+`active`. Then add the new stage as further workflow steps:
+
+1. Delete prior seeded snapshot (`snapshot-<repoId>-seeded`) — reuse `deleteExistingSnapshot` logic.
+2. `daytona.create({ snapshot: <repo Image> })` (warming/ephemeral lifecycle, disk 10 GB).
+3. Start dockerd; run **`startupCommands`** (services up) then **`seedCommands`** (the ~10-min seed,
+   ONCE; ends with `touch /home/eva/.db-seeded`).
+4. Run **`stopCommands`** — clean-stop convex local backend + `supabase stop` so volumes flush
+   consistently. Keep volumes.
+5. `sandbox._experimental_createSnapshot("snapshot-<repoId>-seeded", timeout)`.
+6. `sandbox.delete()` the prep sandbox; record build success.
+7. `getRepoSnapshotName` returns the **seeded** name when its build succeeded, else falls back to the
+   Image name → `createSandbox` picks it up via `daytona.create({ snapshot })`.
+
+Reuse existing `repoSnapshots` / `snapshotBuilds` tables, cron schedule, logs, settings UI, config
+files — add only the seed-snapshot workflow steps + the `seeded` snapshot name + the three command
+fields.
+
+## Resume flow (sandbox created from seeded snapshot — warm-start path)
+
+`createSandboxAndPrepareRepo` already: normalize worktree, sync git, install cred helper, copy config.
+Then the startup path simply runs **`startupCommands` only** (NOT `seedCommands`), because the
+snapshot already carries `.db-seeded` + seeded volumes:
+
+- `pnpm start-db` (supabase start) re-attaches to the seeded Postgres volume.
+- Relaunch `convex dev` (anonymous) → reads the existing seeded local-backend store + env vars.
+- App dev server launches as today (`launchDevServerInBackground`).
+- `ensureDockerDaemon` + eva-entrypoint already restart dockerd on resume.
+
+Cold/no-snapshot fallback path runs `startupCommands` + `seedCommands` (full setup) as today.
+
+**Primary risks to validate in the spike:**
+
+1. `supabase start` re-attaches to existing on-disk volumes after a fresh snapshot create (container
+   IDs/networks gone, volumes remain) — and does NOT re-run migrations/seed over them.
+2. Anonymous `convex dev` reuses the existing local deployment + seeded data (deployment identity is
+   on the snapshotted filesystem) rather than spinning a fresh empty deployment.
+
+## Region decision — DECIDED: stay on default region
+
+No pool migration. Filesystem snapshot/fork are SDK methods available without the experimental
+region. Keep `getDaytona` on the default region; the only prerequisite is the SDK bump. Avoids the
+high blast radius of migrating every call site and orphaning existing default-region `sandboxId`s
+in the DB. (Phase 0 spike still empirically confirms the endpoints work on the default region.)
+
+## Phases
+
+- **Phase 0 — Spike (make-or-break, do first).** Target repo: `carepulse-ts`. Branch-bump SDK
+  ≥0.165.0; confirm `_experimental_createSnapshot`/`_experimental_fork` exist by reading
+  `node_modules/@daytonaio/sdk/dist/*.d.ts`. Manually: boot from base, run startup+seed, clean-stop,
+  `_experimental_createSnapshot`, create new sandbox from it. Verify: (a) seeded Postgres present &
+  `supabase start` does not re-migrate/seed; (b) anonymous `convex dev` reuses seeded deployment;
+  (c) services up in <~1 min vs ~10; (d) snapshot size + restore time acceptable; (e) endpoints work
+  on default region. Decide go/no-go.
+- **Phase 1 — SDK upgrade + breaking-change audit** across all `@daytonaio/sdk` call sites
+  (create/get/start/stop/archive/delete/refreshData, process.executeCommand, fs, git._, volume._,
+  snapshot.\*, Image). Typecheck via `cd packages/backend && npx convex codegen --typecheck enable`.
+- **Phase 2 — Config fields. ✅ DONE (Model A).** Reused existing `startupCommands` (run-once, seed) +
+  `backgroundCommands` (every-start, services); added ONE new field `stopCommands`. Files: schema
+  `_validators/tableFields.ts` (githubRepoFields), `updateConfig` mutation, settings/app `AppClient.tsx`
+  (new Stop Commands section + clarified Startup/Background copy). Also **reordered `prepareSandboxSteps`**
+  so `backgroundCommands` (services) run BEFORE `startupCommands` (seed) — safe because on resume startup
+  is marker-skipped, so background never depends on a same-boot startup. Seeds now self-wait for service
+  readiness (background launches detached). Backend + web typecheck clean.
+  **DB migrated on dev:evalucom (good-mule-506)** — carepulse-ts is a 3-repo monorepo; rebucketed each:
+  web `mh7fdbcr` (supabase+convex), eproc `mh78235g` (convex-only, secrets preserved in-DB), parent
+  `mh7ca667` (supabase-only). Migration done via throwaway `_spike/migrateCommands.ts` (read-transform-
+  write, so secrets never hit source). NOTE: convex-readiness wait greps `/tmp/bg-<index>.log` — index
+  depends on backgroundCommands order (web convex=bg-1, eproc convex=bg-0).
+- **Phase 3 — Seed-snapshot workflow stage. ✅ DONE (per-app model).** After the base Image goes
+  `active`, `snapshotWorkflow.ts` now builds a seeded snapshot for EACH app repo with stopCommands
+  (`getSeedableAppRepos`): boot prep sandbox from the Image (`createSeedPrepSandbox`, explicit Image
+  name to bypass the seeded preference) → `runBackgroundCommands`(services) → `runStartupCommands`(seed)
+  → `runStopCommands`(NEW, clean-stop) → `createSeededSnapshot`(NEW, `_experimental_createSnapshot`,
+  timeout 600) → `deleteSandbox` → `setSeededSnapshotName`. Best-effort: on failure the prep sandbox is
+  deleted and the app falls back to the Image (seededSnapshotName left clear). New schema field
+  `githubRepos.seededSnapshotName`; `getRepoSnapshotName` prefers it. New re-exports in `repoSnapshots.ts`.
+  Backend typechecks clean. Every new code path smoke-tested end-to-end on dev for the web app
+  (chain ran 0-error; getRepoSnapshotName flipped to the seeded name; smoke artifact then cleaned up).
+- **Phase 4 — Warm-start path. ✅ SATISFIED by Phase 2's reorder + the marker.** A sandbox created
+  from a seeded snapshot has the `/tmp/.startup-commands-done` marker baked in, so `runStartupCommands`
+  (seed) is skipped; `runBackgroundCommands` (services) runs every start (now before startup). No
+  separate code needed. Verified end-to-end in Phase 2's verification run.
+
+## Minimised surface
+
+- Schema: add `startupCommands` / `seedCommands` / `stopCommands` to `githubRepos`; seeded build
+  reuses `repoSnapshots` / `snapshotBuilds` (no new tables).
+- Existing Image build, config-files pipeline, cron trigger, delete-existing logic: unchanged —
+  new workflow steps appended, not rewritten.
+- `getRepoSnapshotName` returns the seeded name (fallback to Image) — consumers unchanged.
+- `getDaytona` unchanged (no region migration).
+
+## Unresolved questions
+
+1. ~~**Region**~~ — DECIDED: default region, SDK upgrade only.
+2. ~~**Seed/startup commands**~~ — RESOLVED: `startupCommands` / `seedCommands` / `stopCommands`
+   split (carepulse mapping above). Confirm `stopCommands` checkpoint convex cleanly in the spike.
+3. ~~**Disk size**~~ — DECIDED: keep at 10 GB max. ⚠ RISK: seeded Postgres + supabase/convex docker
+   images + node_modules may be tight in 10 GB — the spike MUST measure actual `/` + `/var/lib/docker`
+   usage; if it overflows, slim (prune unused docker images, drop dev deps) before proceeding.
+4. ~~**Base toolchain scope**~~ — DROPPED: augment approach reuses the existing per-repo Image; no
+   separate base image.
+5. ~~**Seed-data confidentiality**~~ — ACCEPTED by user (staging backup baked into snapshot is fine).
+6. ~~**Snapshot retention**~~ — DECIDED: latest-only, rebuilt daily (24 h); reuse delete-existing.
+
+## Phase 0 spike — runnable checklist (the gate)
+
+Goal: empirically answer the two make-or-break unknowns (fits in 10 GB? services re-attach to seeded
+volumes?) before any production code. Target repo: `carepulse-ts`. Throwaway only — delete after.
+
+### Setup
+
+- [ ] Branch off `main`.
+- [x] Bump `@daytonaio/sdk` → `^0.167.0` (the version Daytona's announcement validated; latest is
+      0.183 — Phase 1 can go latest with a full audit). `pnpm install` done; backend resolves 0.167.0.
+- [x] **Methods verified in installed source** (`node_modules/.pnpm/@daytonaio+sdk@0.167.0/.../Sandbox.d.ts`):
+      `_experimental_createSnapshot(name: string, timeout?: number): Promise<void>` (filesystem-only,
+      enters 'snapshotting' then restores state) and `_experimental_fork(params?, timeout?)`.
+- [x] Typecheck CLEAN: `npx convex codegen --typecheck enable` → exit 0. No breaking changes from
+      0.143→0.167 across any SDK call site; spike file typechecks (proves the method is on the type).
+
+### Harness (throwaway internalAction, triggered from Convex dashboard)
+
+Write a temporary `internalAction` (e.g. `convex/_spike/seededSnapshot.ts`) reusing `getDaytona`,
+`getSandbox`, `exec`. It should log timings + disk at each step. Steps:
+
+1. [ ] Create sandbox from carepulse's **existing Image** snapshot (`snapshot-<repoId>`), default
+       region. Log `sandbox.target` (confirm NOT experimental) + `sandbox.id`.
+2. [ ] Run `startupCommands` (start-db; launch + await `convex dev`). Log elapsed.
+3. [ ] Run `seedCommands` (cp's, `pnpm seed:sql`, `convex import`, `convex env set` ×2, `touch
+   /home/eva/.db-seeded`). Log elapsed (expect ~10 min).
+4. [ ] **Measure disk BEFORE snapshot**: `df -h /`, `du -sh /var/lib/docker`, `du -sh ~`. Record
+       total vs 10 GB cap. ← gate (1).
+5. [ ] Run `stopCommands` (pkill convex (TERM), `supabase stop`). Confirm no errors; check the
+       supabase postgres volume still listed (`docker volume ls`).
+6. [ ] `sandbox._experimental_createSnapshot("spike-carepulse-seeded")`. Log elapsed + any state
+       transitions; confirm it returns and the call doesn't error.
+7. [ ] Create a NEW sandbox from `spike-carepulse-seeded`. Log create/restore elapsed.
+8. [ ] On the new sandbox, run `startupCommands` ONLY (no seed). Log elapsed. ← target ≪ 10 min.
+9. [ ] **Validate re-attach** ← gate (2):
+   - Postgres: query a seeded table row count via `supabase`/psql; matches step 3. Confirm
+     `supabase start` did NOT re-run migrations/seed (check its log output).
+   - Convex: query seeded data; `convex env get BASE_APP_URL` returns the seeded value (proves
+     deployment reuse, not a fresh empty one).
+   - App: dev server boots, page loads.
+10. [ ] Record: snapshot size, create-from-snapshot time, total warm-start time (create → app ready).
+11. [ ] Cleanup: delete both sandboxes + the `spike-carepulse-seeded` snapshot; remove the spike
+        action + revert the SDK bump if not proceeding.
+
+### RESULTS — 2026-05-30, dev:evalucom (good-mule-506), carepulse-ts — ✅ GREEN
+
+Ran end-to-end against real Daytona (default `eu` region). Both gates pass.
+
+- **GATE 2 (re-attach) — PASS.** Restored sandbox from the seeded snapshot:
+  Postgres `140 tables / ~1,603,273 live rows` survived; Convex env var `BASE_APP_URL=http://localhost:3000`
+  persisted (anonymous deployment + 54,112 imported docs re-attached); `.db-seeded` marker present.
+  **No re-seed ran** — only `pnpm start-db` + `convex dev`.
+- **GATE 1 (disk) — PASS / reframed.** `/var/lib/docker` = **12–13 G on a SEPARATE mount**, larger than
+  the 10 G root overlay (root only ~0.8 G used, 8%). The filesystem snapshot **captured + restored the
+  separate docker mount fully** — this was the key uncertainty, resolved positively. The 10 G "cap" is the
+  root disk param and is NOT the binding constraint; Daytona stores the full multi-mount state.
+- **Region — confirmed default.** Sandbox `target=eu`; `_experimental_createSnapshot` works without the
+  experimental region. No migration needed.
+- **Timings.** Seed (one-off): start-db 56 s + seed:sql 13 s + convex import 17 s. Snapshot create **~4.7 min**.
+  Warm restore: create 26 s + start-db 33 s + convex dev 14 s ≈ **73 s to a seeded, running stack** (vs ~10 min).
+
+Findings to fold into the real implementation (Phases 1–4):
+
+1. `_experimental_createSnapshot(name, timeout)` — `timeout` is the **HTTP request timeout** (timeout\*1000 ms).
+   `0` aborts immediately ("fetch failed"). Pass a positive value (used 600 s).
+2. Convex import must be **`--replace-all --yes`** — the anonymous deployment is non-empty after `convex dev`
+   boots the app, so a plain import hits an ID-space collision.
+3. `ensureDockerDaemon` logs "Docker not available" right after restore (race), but the snapshot's
+   entrypoint brings dockerd up — `supabase start` succeeded. Benign, but the warm-start path should
+   tolerate the race (it does).
+4. SDK 0.143→0.167 bump validated at runtime on dev (create/get/exec/git all worked). Phase 1 unblocked.
+
+### Pass criteria (go/no-go)
+
+- Total disk ≤ 10 GB with headroom. (else: slimming pass first)
+- `supabase start` + `convex dev` re-attach to seeded data with NO re-seed/re-migrate.
+- Warm start materially faster than ~10 min (target ≲ 2 min).
+- `_experimental_createSnapshot` works on the default region.
+
+### Gotchas to watch
+
+- `supabase start` may run `migration up` on boot — confirm it's a no-op against an already-migrated
+  volume and doesn't wipe data.
+- Anonymous `convex dev` deployment identity must live on the snapshotted filesystem (else it spins a
+  fresh empty deployment). Note WHERE it persists (project `.convex` vs `~/.cache`).
+- Postgres consistency: if `supabase stop` didn't flush cleanly, restored data may be corrupt — watch
+  postgres startup logs on the restored sandbox.
+- Snapshot may require a particular sandbox state; confirm whether containers must be stopped (we stop
+  them anyway for consistency).

--- a/packages/backend/convex/_daytona/devServer.ts
+++ b/packages/backend/convex/_daytona/devServer.ts
@@ -1,7 +1,11 @@
 "use node";
 
 import type { Sandbox } from "@daytonaio/sdk";
-import { exec, workspaceDirShell } from "./helpers";
+import { ensureDockerDaemon, exec, workspaceDirShell } from "./helpers";
+
+const SUPABASE_DUMP_PATH =
+  "/home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz";
+const SUPABASE_RESTORE_MARKER = "/tmp/.eva-supabase-db-web-restored";
 
 /** Detects the package manager (pnpm, yarn, or npm) by checking lock files. */
 export async function detectPackageManager(
@@ -87,6 +91,8 @@ export async function startSessionServices(
   rootDir: string,
   overrides?: { devPort?: number; devCommand?: string },
 ): Promise<{ port: number; devCommand: string }> {
+  await restoreSeededRuntimeState(sandbox);
+
   const port =
     overrides?.devPort !== undefined
       ? overrides.devPort
@@ -102,6 +108,52 @@ export async function startSessionServices(
     : workspaceDirShell();
   const devCommand = `cd ${dir} && PORT=${port} ${pm} run dev`;
   return { port, devCommand };
+}
+
+/** Restores service state that was exported into a seeded snapshot filesystem. */
+export async function restoreSeededRuntimeState(
+  sandbox: Sandbox,
+): Promise<void> {
+  try {
+    await exec(sandbox, `test -f ${SUPABASE_DUMP_PATH}`, 5);
+  } catch {
+    return;
+  }
+
+  try {
+    await exec(sandbox, `test -f ${SUPABASE_RESTORE_MARKER}`, 5);
+    return;
+  } catch {
+    // No marker means this fresh sandbox still needs its local service state.
+  }
+
+  await ensureDockerDaemon(sandbox);
+  await exec(
+    sandbox,
+    [
+      "set -e",
+      "set -o pipefail",
+      "cd /tmp/repo",
+      "if docker ps --filter name=supabase_db_web --filter status=running -q | grep -q .; then",
+      '  echo "supabase_db_web already running"',
+      "elif docker ps -a --filter name=supabase_db_web -q | grep -q .; then",
+      "  docker start supabase_db_web >/dev/null",
+      '  echo "started existing supabase_db_web"',
+      "else",
+      "  pnpm start-db",
+      "fi",
+      "for i in $(seq 1 240); do",
+      "  if docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1; then break; fi",
+      "  sleep 1",
+      "done",
+      "docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1",
+      `docker exec supabase_db_web psql -U postgres -d postgres -v ON_ERROR_STOP=1 -c "DO \\$\\$ DECLARE tables text; BEGIN SELECT string_agg(format('%I.%I', schemaname, tablename), ', ') INTO tables FROM pg_tables WHERE schemaname = 'public'; IF tables IS NOT NULL THEN EXECUTE 'TRUNCATE TABLE ' || tables || ' CASCADE'; END IF; END \\$\\$;" >/tmp/eva-supabase-db-web-truncate.log 2>&1 || { tail -120 /tmp/eva-supabase-db-web-truncate.log; exit 1; }`,
+      `gzip -dc ${SUPABASE_DUMP_PATH} | docker exec -i supabase_db_web psql -U postgres -d postgres -v ON_ERROR_STOP=1 >/tmp/eva-supabase-db-web-restore.log 2>&1 || { tail -120 /tmp/eva-supabase-db-web-restore.log; exit 1; }`,
+      `touch ${SUPABASE_RESTORE_MARKER}`,
+      'echo "restored supabase_db_web from seeded snapshot dump"',
+    ].join("; "),
+    600,
+  );
 }
 
 /** Stable default terminal pane id — must match `sandboxPanes.defaultPane`. */

--- a/packages/backend/convex/_daytona/execution.ts
+++ b/packages/backend/convex/_daytona/execution.ts
@@ -32,6 +32,7 @@ import { startDesktopWithChrome } from "./desktop";
 import { ensurePreviewNavigationProxy } from "./previewProxy";
 import { getPreviewGrantPublicJwk, signPreviewGrant } from "../previewGrant";
 import { PREVIEW_GRANT_PARAM } from "../previewGrantConfig";
+import { restoreSeededRuntimeState as restoreSeededRuntimeStateInSandbox } from "./devServer";
 
 const sessionPersistenceKindValidator = v.union(
   v.literal("sessions"),
@@ -104,6 +105,20 @@ export const startupCommandsMarkerExists = internalAction({
   },
 });
 
+/** Restores service state exported into a seeded snapshot before services boot. */
+export const restoreSeededRuntimeState = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    await restoreSeededRuntimeStateInSandbox(sandbox);
+    return null;
+  },
+});
+
 /** Runs startup commands on a sandbox if configured. Returns success status. */
 export const runStartupCommands = internalAction({
   args: {
@@ -170,11 +185,20 @@ export const runStartupCommands = internalAction({
       }
     }
 
-    // Create marker file to prevent re-running on sandbox resume
-    try {
-      await exec(sandbox, "touch /tmp/.startup-commands-done", 5);
-    } catch {
-      // Non-fatal
+    // Create the marker only when every command succeeded. Writing it after a
+    // failed run permanently branded the sandbox as seeded: every resume then
+    // marker-skipped the seed and the DB stayed empty forever. Leaving the
+    // marker absent lets the next resume retry the full startup sequence.
+    if (errors.length === 0) {
+      try {
+        await exec(sandbox, "touch /tmp/.startup-commands-done", 5);
+      } catch {
+        // Non-fatal
+      }
+    } else {
+      console.error(
+        `[daytona] runStartupCommands: ${errors.length}/${commands.length} command(s) failed — NOT writing marker so the next resume retries`,
+      );
     }
 
     return { ran: true, commandCount: commands.length, errors };
@@ -224,13 +248,20 @@ export const runBackgroundCommands = internalAction({
       const command = commands[i];
       const logPath = `/tmp/bg-${i}.log`;
       // Escape single quotes for the bash -lc payload.
-      const escaped = command.replace(/'/g, "'\\''");
+      // Write the command to a script file and launch THAT, rather than
+      // inlining it via `bash -lc '<command>'`: the inline form puts the whole
+      // command text into the wrapper shell's cmdline, so a user guard like
+      // `pgrep -f "[c]onvex dev" || npx convex dev` matches its own wrapper
+      // (the unguarded "npx convex dev" launch text) and silently never starts
+      // the daemon. With a script file the cmdline is just the file path.
+      // Base64 transport also makes user quoting unbreakable.
+      const cb64 = Buffer.from(command, "utf8").toString("base64");
       // setsid + </dev/null fully detaches the daemon into its own session, so
       // it survives the exec session teardown even when the user's command
       // self-backgrounds. A trailing `&` would otherwise let bash -lc exit
       // immediately, letting a process-group SIGTERM reach the daemon (nohup
       // only blocks SIGHUP).
-      const launchCmd = `setsid nohup bash -lc '${escaped}' </dev/null > ${logPath} 2>&1 &`;
+      const launchCmd = `echo ${cb64} | base64 -d > /tmp/bg-cmd-${i}.sh && chmod +x /tmp/bg-cmd-${i}.sh && (setsid nohup bash -l /tmp/bg-cmd-${i}.sh </dev/null > ${logPath} 2>&1 & echo $! > /tmp/bg-${i}.pid) && echo LAUNCHED`;
       console.log(
         `[daytona] runBackgroundCommands: launching: ${command} (log: ${logPath})`,
       );
@@ -243,6 +274,58 @@ export const runBackgroundCommands = internalAction({
           `[daytona] runBackgroundCommands: failed to launch: ${command}`,
           msg,
         );
+        errors.push(`${command}: ${msg}`);
+      }
+    }
+
+    return { ran: true, commandCount: commands.length, errors };
+  },
+});
+
+/**
+ * Runs a repo's clean-stop commands (e.g. `supabase stop`, `pkill convex dev`)
+ * sequentially, foreground, so on-disk volumes flush before a filesystem
+ * snapshot. Used only by the seeded-snapshot build; never on normal starts.
+ * Non-fatal per command so a partial stop still lets the snapshot proceed.
+ */
+export const runStopCommands = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.object({
+    ran: v.boolean(),
+    commandCount: v.number(),
+    errors: v.array(v.string()),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ ran: boolean; commandCount: number; errors: string[] }> => {
+    const commands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getStopCommands,
+      { repoId: args.repoId },
+    );
+
+    if (!commands || commands.length === 0) {
+      return { ran: false, commandCount: 0, errors: [] };
+    }
+
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+
+    console.log(
+      `[daytona] runStopCommands: running ${commands.length} stop command(s)`,
+    );
+
+    const errors: string[] = [];
+    for (const command of commands) {
+      console.log(`[daytona] runStopCommands: running: ${command}`);
+      try {
+        await exec(sandbox, command, 300);
+        console.log(`[daytona] runStopCommands: completed: ${command}`);
+      } catch (e) {
+        const msg = errorMessage(e, "command failed");
+        console.error(`[daytona] runStopCommands: failed: ${command}`, msg);
         errors.push(`${command}: ${msg}`);
       }
     }

--- a/packages/backend/convex/_daytona/git.ts
+++ b/packages/backend/convex/_daytona/git.ts
@@ -36,6 +36,7 @@ export type SandboxLifecycle = {
   autoArchiveInterval?: number;
   autoDeleteInterval?: number;
   ephemeral?: boolean;
+  labels?: Record<string, string>;
 };
 
 export type RepoSyncStrategy =
@@ -311,6 +312,7 @@ export async function createSandbox(
 
     const commonParams = {
       ...(volumes ? { volumes } : {}),
+      ...(lifecycle.labels ? { labels: lifecycle.labels } : {}),
       envVars: {
         // VNC_RESOLUTION is read by the snapshot's ComputerUse plugin at startup
         // (Xvfb + x11vnc). Setting it here makes the desktop start at 1920x1080
@@ -686,7 +688,14 @@ export async function checkoutFetchedBaseBranch(
   });
 }
 
-/** Resets the snapshot worktree to a clean state via hard reset and clean. */
+/**
+ * Resets tracked files from a snapshot worktree.
+ *
+ * Seeded runtime snapshots carry /tmp/.startup-commands-done and may also carry
+ * untracked local-service state used to restore stopped databases. In that case
+ * preserve untracked files; deleting them makes the sandbox skip seeding while
+ * starting from an empty DB.
+ */
 export async function normalizeSnapshotWorktree(
   sandbox: Sandbox,
 ): Promise<void> {
@@ -697,7 +706,7 @@ export async function normalizeSnapshotWorktree(
     async () => {
       await execGitCommand(
         sandbox,
-        `cd ${workspaceDir} && git reset --hard HEAD && git clean -fd`,
+        `cd ${workspaceDir} && git reset --hard HEAD && if [ -f /tmp/.startup-commands-done ]; then echo "seeded snapshot marker found; preserving untracked runtime state"; else git clean -fd; fi`,
         60,
       );
     },
@@ -707,15 +716,20 @@ export async function normalizeSnapshotWorktree(
 /** Copies baked sandbox config files into the codebase root after git cleanup. */
 export async function copySandboxConfigFilesToWorkspace(
   sandbox: Sandbox,
+  options?: { force?: boolean },
 ): Promise<void> {
   const workspaceDir = workspaceDirShell();
+  const markerGuard =
+    options?.force === true
+      ? ""
+      : 'if [ -f /tmp/.startup-commands-done ]; then echo "startup commands already ran; skipping sandbox-config copy"; exit 0; fi; ';
   await runLoggedGitStep(
     "copySandboxConfigFilesToWorkspace",
     WORKSPACE_DIR,
     async () => {
       await execGitCommand(
         sandbox,
-        `if [ -f /tmp/.startup-commands-done ]; then echo "startup commands already ran; skipping sandbox-config copy"; exit 0; fi; if [ -d /home/eva/sandbox-config ] && find /home/eva/sandbox-config -mindepth 1 -maxdepth 1 | read first; then cp -a /home/eva/sandbox-config/. ${workspaceDir}/; fi`,
+        `${markerGuard}if [ -d /home/eva/sandbox-config ] && find /home/eva/sandbox-config -mindepth 1 -maxdepth 1 | read first; then cp -a /home/eva/sandbox-config/. ${workspaceDir}/; fi`,
         30,
       );
     },
@@ -927,6 +941,11 @@ export async function createSandboxAndPrepareRepo(
   onSandboxAcquired?: (sandbox: Sandbox) => Promise<void>,
   onProgress?: (label: string) => Promise<void>,
   syncStrategy: RepoSyncStrategy = { mode: "all" },
+  // Override the SDK create-ready wait. Large seeded snapshots (~10GB) take
+  // well over the 30s default to start, so callers that boot from them (seeded
+  // snapshot builds) pass a longer value to avoid spurious create timeouts +
+  // the orphaned sandboxes they leave server-side.
+  readyTimeoutSeconds?: number,
 ): Promise<{ sandbox: Sandbox; usedSnapshot: boolean }> {
   let sandbox: Sandbox | undefined;
   try {
@@ -945,6 +964,7 @@ export async function createSandboxAndPrepareRepo(
             lifecycle,
             effectiveSnapshot,
             volumes,
+            readyTimeoutSeconds,
           );
         } catch (err) {
           if (effectiveSnapshot && isSnapshotUnusableError(err)) {
@@ -961,6 +981,7 @@ export async function createSandboxAndPrepareRepo(
               lifecycle,
               undefined,
               volumes,
+              readyTimeoutSeconds,
             );
           } else {
             throw err;
@@ -979,7 +1000,7 @@ export async function createSandboxAndPrepareRepo(
             if (onProgress) await onProgress("Syncing repository...");
             await syncRepo(sandbox, owner, name, syncStrategy);
           }
-          await copySandboxConfigFilesToWorkspace(sandbox);
+          await copySandboxConfigFilesToWorkspace(sandbox, { force: true });
           return { sandbox, usedSnapshot: true };
         }
         if (lifecycle.ephemeral && syncStrategy.mode === "none") {

--- a/packages/backend/convex/_daytona/lifecycle.ts
+++ b/packages/backend/convex/_daytona/lifecycle.ts
@@ -3,17 +3,7 @@
 import { v } from "convex/values";
 import { internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
-import {
-  exec,
-  resolveSandboxContext,
-  getSandbox,
-  sleep,
-  WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
-} from "./helpers";
-import { createSandbox, WARMING_LIFECYCLE } from "./git";
-
-const MAX_WARMUP_RETRIES = 2;
-const WARMUP_RETRY_DELAY_MS = 5_000;
+import { exec, getSandbox } from "./helpers";
 
 /**
  * Short wait window for the start kick-off. A stopped→started fast resume
@@ -35,67 +25,6 @@ const CALLBACK_LIVENESS_COMMAND = [
 /** Agent CLI still running even if callback PID bookkeeping is stale. */
 const AGENT_PROCESS_LIVENESS_COMMAND =
   "pgrep -f 'claude-code|cursor-agent|codex run|opencode run|/\\.claude/' >/dev/null 2>&1";
-
-/** Warms the Daytona snapshot cache for a repo by creating and immediately deleting a sandbox, with retries. */
-export const warmSnapshotCache = internalAction({
-  args: {
-    repoId: v.id("githubRepos"),
-    buildId: v.id("snapshotBuilds"),
-  },
-  returns: v.null(),
-  handler: async (ctx, args) => {
-    const { daytona, sandboxEnvVars, snapshotName } =
-      await resolveSandboxContext(ctx, args.repoId);
-    if (!snapshotName) return null;
-    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
-      repoId: args.repoId,
-    });
-    if (!repo) return null;
-
-    let lastError = "";
-    for (let attempt = 0; attempt <= MAX_WARMUP_RETRIES; attempt++) {
-      try {
-        if (attempt > 0) {
-          console.log(
-            `[daytona] Warmup retry ${attempt}/${MAX_WARMUP_RETRIES} for ${repo.owner}/${repo.name}`,
-          );
-          await sleep(WARMUP_RETRY_DELAY_MS);
-        }
-        const sandbox = await createSandbox(
-          daytona,
-          repo.installationId,
-          sandboxEnvVars,
-          WARMING_LIFECYCLE,
-          snapshotName,
-          undefined,
-          WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
-        );
-        await sandbox.delete();
-        console.log(
-          `[daytona] Warmed snapshot cache for ${repo.owner}/${repo.name}`,
-        );
-        await ctx.runMutation(internal.repoSnapshots.updateWarmupStatus, {
-          buildId: args.buildId,
-          status: "success",
-        });
-        return null;
-      } catch (err) {
-        lastError = err instanceof Error ? err.message : String(err);
-        console.error(
-          `[daytona] warmSnapshotCache attempt ${attempt + 1} failed:`,
-          lastError,
-        );
-      }
-    }
-
-    await ctx.runMutation(internal.repoSnapshots.updateWarmupStatus, {
-      buildId: args.buildId,
-      status: "error",
-      error: lastError,
-    });
-    return null;
-  },
-});
 
 /**
  * Verifies whether a sandbox and its callback runner are alive.

--- a/packages/backend/convex/_daytona/prepareSandboxSteps.ts
+++ b/packages/backend/convex/_daytona/prepareSandboxSteps.ts
@@ -198,9 +198,78 @@ export async function prepareSandboxSteps(
     );
   }
 
-  // Step 4: Run startup commands once per sandbox (marker file). Skipped for
+  // Step 4: Restore service state baked into seeded snapshots before daemons
+  // or startup commands touch local dependencies. No-ops for ordinary snapshots.
+  if (!args.skipStartupCommands) {
+    await emitSteps(step, args.streamingEntityId, [
+      ...completedSteps,
+      {
+        type: "tool",
+        label: "Restoring seeded runtime...",
+        status: "active",
+      },
+    ]);
+    await step.runAction(
+      internal.daytona.restoreSeededRuntimeState,
+      { sandboxId, repoId: args.repoId },
+      { retry: { maxAttempts: 1, initialBackoffMs: 1000, base: 2 } },
+    );
+    completedSteps.push({
+      type: "tool",
+      label: "Restoring seeded runtime...",
+      status: "complete",
+    });
+  }
+
+  // Step 5: Launch background commands (long-running daemons / services) FIRST,
+  // before startup commands, so one-time startup/seed work can depend on services
+  // being up (e.g. `supabase start`, `npx convex dev`). Skipped together with
+  // startup for read-only ephemeral flows (PR recap, interview). Non-fatal.
+  if (!args.skipStartupCommands) {
+    await emitSteps(step, args.streamingEntityId, [
+      ...completedSteps,
+      {
+        type: "tool",
+        label: "Launching background commands...",
+        status: "active",
+      },
+    ]);
+    try {
+      const result = await step.runAction(
+        internal.daytona.runBackgroundCommands,
+        { sandboxId, repoId: args.repoId },
+        { retry: { maxAttempts: 1, initialBackoffMs: 1000, base: 2 } },
+      );
+      if (result.ran) {
+        completedSteps.push({
+          type: "tool",
+          label: "Launching background commands...",
+          status: "complete",
+        });
+        if (result.commandCount > 0) {
+          console.log(
+            `[prepareSandbox] Launched ${result.commandCount} background command(s)`,
+          );
+          if (result.errors.length > 0) {
+            console.warn(
+              `[prepareSandbox] Background command errors: ${result.errors.join("; ")}`,
+            );
+          }
+        }
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(
+        `[prepareSandbox] Background commands failed — continuing: ${msg}`,
+      );
+    }
+  }
+
+  // Step 6: Run startup commands once per sandbox (marker file). Skipped for
   // read-only ephemeral flows (PR recap) and when a reused project sandbox
-  // already paid this cost on the first task.
+  // already paid this cost on the first task. Startup commands that depend on
+  // services should wait for readiness themselves, since background daemons
+  // above are launched detached.
   let shouldRunStartupCommands = !args.skipStartupCommands;
   if (shouldRunStartupCommands) {
     const markerExists = await step.runAction(
@@ -245,48 +314,6 @@ export async function prepareSandboxSteps(
       const msg = e instanceof Error ? e.message : String(e);
       console.warn(
         `[prepareSandbox] Startup commands failed — continuing: ${msg}`,
-      );
-    }
-  }
-
-  // Step 5: Launch background commands (long-running daemons). Skipped together
-  // with startup commands for read-only ephemeral flows (PR recap, interview).
-  if (!args.skipStartupCommands) {
-    await emitSteps(step, args.streamingEntityId, [
-      ...completedSteps,
-      {
-        type: "tool",
-        label: "Launching background commands...",
-        status: "active",
-      },
-    ]);
-    try {
-      const result = await step.runAction(
-        internal.daytona.runBackgroundCommands,
-        { sandboxId, repoId: args.repoId },
-        { retry: { maxAttempts: 1, initialBackoffMs: 1000, base: 2 } },
-      );
-      if (result.ran) {
-        completedSteps.push({
-          type: "tool",
-          label: "Launching background commands...",
-          status: "complete",
-        });
-        if (result.commandCount > 0) {
-          console.log(
-            `[prepareSandbox] Launched ${result.commandCount} background command(s)`,
-          );
-          if (result.errors.length > 0) {
-            console.warn(
-              `[prepareSandbox] Background command errors: ${result.errors.join("; ")}`,
-            );
-          }
-        }
-      }
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.warn(
-        `[prepareSandbox] Background commands failed — continuing: ${msg}`,
       );
     }
   }

--- a/packages/backend/convex/_daytona/sessions.ts
+++ b/packages/backend/convex/_daytona/sessions.ts
@@ -546,25 +546,6 @@ async function prepareSessionSandboxInternal(
             () => startDesktopWithChrome(sandbox),
           );
         }
-        // Note: runStartupCommands is intentionally not surfaced as a UI step
-        // on the reuse path — the marker file (`/tmp/.startup-commands-done`)
-        // makes it a no-op once the sandbox has been initialised, so showing
-        // "Running startup commands..." would be misleading on resume.
-        await runLoggedSessionStep(
-          "reuseSessionSandbox.runStartupCommands",
-          sandboxDetails,
-          async () => {
-            const result = await ctx.runAction(
-              internal.daytona.runStartupCommands,
-              { sandboxId: sandbox.id, repoId: args.repoId },
-            );
-            if (result.ran && result.commandCount > 0) {
-              logSession(
-                `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
-              );
-            }
-          },
-        );
         await emitSessionProgress(
           ctx,
           args.sessionId,
@@ -595,6 +576,25 @@ async function prepareSessionSandboxInternal(
             status: "complete",
           });
         }
+        // Note: runStartupCommands is intentionally not surfaced as a UI step
+        // on the reuse path — the marker file (`/tmp/.startup-commands-done`)
+        // makes it a no-op once the sandbox has been initialised, so showing
+        // "Running startup commands..." would be misleading on resume.
+        await runLoggedSessionStep(
+          "reuseSessionSandbox.runStartupCommands",
+          sandboxDetails,
+          async () => {
+            const result = await ctx.runAction(
+              internal.daytona.runStartupCommands,
+              { sandboxId: sandbox.id, repoId: args.repoId },
+            );
+            if (result.ran && result.commandCount > 0) {
+              logSession(
+                `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+              );
+            }
+          },
+        );
         reusedResult = {
           sandbox,
           isNew: false,
@@ -742,7 +742,7 @@ async function prepareSessionSandboxInternal(
   await runLoggedSessionStep(
     "newSessionSandbox.copyConfigFiles",
     sandboxDetails,
-    () => copySandboxConfigFilesToWorkspace(sandbox),
+    () => copySandboxConfigFilesToWorkspace(sandbox, { force: true }),
   );
   completedSteps.push({
     type: "tool",
@@ -790,33 +790,6 @@ async function prepareSessionSandboxInternal(
     ctx,
     args.sessionId,
     completedSteps,
-    "Running startup commands...",
-  );
-  await runLoggedSessionStep(
-    "newSessionSandbox.runStartupCommands",
-    sandboxDetails,
-    async () => {
-      const result = await ctx.runAction(internal.daytona.runStartupCommands, {
-        sandboxId: sandbox.id,
-        repoId: args.repoId,
-      });
-      if (result.ran && result.commandCount > 0) {
-        logSession(
-          `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
-        );
-      }
-    },
-  );
-  completedSteps.push({
-    type: "tool",
-    label: "Running startup commands...",
-    status: "complete",
-  });
-
-  await emitSessionProgress(
-    ctx,
-    args.sessionId,
-    completedSteps,
     "Launching background commands...",
   );
   let bgRan = false;
@@ -843,6 +816,33 @@ async function prepareSessionSandboxInternal(
       status: "complete",
     });
   }
+
+  await emitSessionProgress(
+    ctx,
+    args.sessionId,
+    completedSteps,
+    "Running startup commands...",
+  );
+  await runLoggedSessionStep(
+    "newSessionSandbox.runStartupCommands",
+    sandboxDetails,
+    async () => {
+      const result = await ctx.runAction(internal.daytona.runStartupCommands, {
+        sandboxId: sandbox.id,
+        repoId: args.repoId,
+      });
+      if (result.ran && result.commandCount > 0) {
+        logSession(
+          `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+        );
+      }
+    },
+  );
+  completedSteps.push({
+    type: "tool",
+    label: "Running startup commands...",
+    status: "complete",
+  });
 
   await completeSessionProgress(ctx, args.sessionId);
   return {
@@ -1418,7 +1418,7 @@ async function prepareTaskPreviewSandboxInternal(
   await runLoggedSessionStep(
     "newTaskSandbox.copyConfigFiles",
     sandboxDetails,
-    () => copySandboxConfigFilesToWorkspace(sandbox),
+    () => copySandboxConfigFilesToWorkspace(sandbox, { force: true }),
   );
   completedSteps.push({
     type: "tool",
@@ -1847,7 +1847,7 @@ async function prepareProjectPreviewSandboxInternal(
   await runLoggedSessionStep(
     "newProjectSandbox.copyConfigFiles",
     sandboxDetails,
-    () => copySandboxConfigFilesToWorkspace(sandbox),
+    () => copySandboxConfigFilesToWorkspace(sandbox, { force: true }),
   );
   completedSteps.push({
     type: "tool",

--- a/packages/backend/convex/_daytona/snapshotStates.ts
+++ b/packages/backend/convex/_daytona/snapshotStates.ts
@@ -1,0 +1,18 @@
+/**
+ * Snapshot lifecycle states that end a build/capture poll loop: "active" is
+ * success; "error" / "build_failed" are failures.
+ *
+ * This module is intentionally dependency-free. The snapshot SDK service
+ * (snapshots.ts) is node-only and cannot be imported by the build workflow,
+ * which runs in the Convex isolate — so the shared terminal-state definition
+ * lives here where both sides can import it.
+ */
+export const TERMINAL_SNAPSHOT_STATES: readonly string[] = [
+  "active",
+  "error",
+  "build_failed",
+];
+
+export function isTerminalSnapshotState(state: string): boolean {
+  return TERMINAL_SNAPSHOT_STATES.includes(state);
+}

--- a/packages/backend/convex/_daytona/snapshots.ts
+++ b/packages/backend/convex/_daytona/snapshots.ts
@@ -1,0 +1,105 @@
+"use node";
+
+import type { Daytona } from "@daytonaio/sdk";
+import { DaytonaTimeoutError } from "@daytonaio/sdk";
+
+/**
+ * Daytona snapshot mechanics — the "how" of talking to the snapshot SDK,
+ * centralized so the action/workflow layers own only the "when/why" (poll
+ * cadence, retry policy, build-status transitions, per-app fallback).
+ *
+ * Every function takes an already-resolved `daytona` client as an explicit
+ * parameter and never touches Convex ctx/DB — callers resolve the client and
+ * apply their own domain policy (e.g. whether a missing API key fails the build
+ * or throws).
+ */
+
+/** Narrowed view of a Daytona snapshot — the fields callers actually read. */
+export type SnapshotInfo = {
+  id: string;
+  state: string;
+  errorReason: string | null;
+};
+
+/**
+ * Looks up a snapshot by name. Returns a narrowed SnapshotInfo, or null when the
+ * snapshot is not registered (the SDK throws on not-found). Callers decide what
+ * "missing" means — still building, already removed, etc.
+ */
+export async function getSnapshot(
+  daytona: Daytona,
+  name: string,
+): Promise<SnapshotInfo | null> {
+  try {
+    const snapshot = await daytona.snapshot.get(name);
+    return {
+      id: String(snapshot.id),
+      state: String(snapshot.state),
+      errorReason:
+        snapshot.errorReason != null ? String(snapshot.errorReason) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deletes a snapshot by name. Returns true if it existed and was deleted, false
+ * if it was not found. Never throws on a missing snapshot.
+ */
+export async function deleteSnapshotByName(
+  daytona: Daytona,
+  name: string,
+): Promise<boolean> {
+  try {
+    const snapshot = await daytona.snapshot.get(name);
+    await daytona.snapshot.delete(snapshot);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Polls until a snapshot name no longer resolves. snapshot.delete() returns
+ * immediately but the snapshot lingers in a "removing" state, and recreating the
+ * same name 409s until removal finishes. Best-effort and bounded: returns once
+ * the snapshot is gone or the attempts are exhausted.
+ */
+export async function waitForSnapshotRemoval(
+  daytona: Daytona,
+  name: string,
+  opts: { attempts?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const attempts = opts.attempts ?? 30;
+  const intervalMs = opts.intervalMs ?? 2000;
+  for (let i = 0; i < attempts; i++) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    if ((await getSnapshot(daytona, name)) === null) return;
+  }
+}
+
+/**
+ * Fires a sandbox→snapshot capture (the seeded-DB filesystem snapshot) and
+ * returns WITHOUT waiting for it to finish.
+ *
+ * The SDK helper blocks the caller polling the source sandbox's state for the
+ * entire capture, which for a seeded DB volume routinely exceeds Convex's 600s
+ * per-action ceiling. We pass a short timeout so the helper bails fast with a
+ * DaytonaTimeoutError (the capture keeps running server-side) and let the caller
+ * poll completion via getSnapshot. Any non-timeout error is a real failure and
+ * propagates.
+ */
+export async function triggerSandboxSnapshot(
+  daytona: Daytona,
+  sandboxId: string,
+  name: string,
+  timeoutSec: number,
+): Promise<void> {
+  const sandbox = await daytona.get(sandboxId);
+  try {
+    await sandbox._experimental_createSnapshot(name, timeoutSec);
+  } catch (e) {
+    if (!(e instanceof DaytonaTimeoutError)) throw e;
+  }
+}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -45,6 +45,8 @@ import type * as _daytona_resumeSandboxSteps from "../_daytona/resumeSandboxStep
 import type * as _daytona_runDevServer from "../_daytona/runDevServer.js";
 import type * as _daytona_services from "../_daytona/services.js";
 import type * as _daytona_sessions from "../_daytona/sessions.js";
+import type * as _daytona_snapshotStates from "../_daytona/snapshotStates.js";
+import type * as _daytona_snapshots from "../_daytona/snapshots.js";
 import type * as _daytona_volumes from "../_daytona/volumes.js";
 import type * as _deployment_vercel from "../_deployment/vercel.js";
 import type * as _designSessions_execution from "../_designSessions/execution.js";
@@ -294,6 +296,8 @@ declare const fullApi: ApiFromModules<{
   "_daytona/runDevServer": typeof _daytona_runDevServer;
   "_daytona/services": typeof _daytona_services;
   "_daytona/sessions": typeof _daytona_sessions;
+  "_daytona/snapshotStates": typeof _daytona_snapshotStates;
+  "_daytona/snapshots": typeof _daytona_snapshots;
   "_daytona/volumes": typeof _daytona_volumes;
   "_deployment/vercel": typeof _deployment_vercel;
   "_designSessions/execution": typeof _designSessions_execution;

--- a/packages/backend/convex/_githubRepos/mutations.ts
+++ b/packages/backend/convex/_githubRepos/mutations.ts
@@ -174,6 +174,7 @@ export const updateConfig = authMutation({
     devCommand: v.optional(v.string()),
     startupCommands: v.optional(v.array(v.string())),
     backgroundCommands: v.optional(v.array(v.string())),
+    stopCommands: v.optional(v.array(v.string())),
     systemPrompt: v.optional(v.string()),
   },
   returns: v.null(),
@@ -268,6 +269,13 @@ export const updateConfig = authMutation({
       });
     }
 
+    if (args.stopCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        stopCommands:
+          args.stopCommands.length > 0 ? args.stopCommands : undefined,
+      });
+    }
+
     if (args.systemPrompt !== undefined) {
       await ctx.db.patch(args.repoId, {
         systemPrompt:
@@ -342,6 +350,48 @@ export const updateMcpRootPrompt = authMutation({
     for (const siblingId of siblingIds) {
       await ctx.db.patch(siblingId, {
         mcpRootPrompt: args.mcpRootPrompt,
+      });
+    }
+    return null;
+  },
+});
+
+/**
+ * Sets an app repo's command config directly (internal, CLI/ops use). Stop
+ * commands gate seeded-snapshot builds (findSeedableAppRepos), and updateConfig
+ * is auth+ownership-checked so it cannot be driven from `npx convex run` when a
+ * deployment's config needs backfilling or repair (e.g. prod after a dev-only
+ * setup). Each array is optional; an empty array clears the field.
+ */
+export const setRepoCommandsInternal = internalMutation({
+  args: {
+    repoId: v.id("githubRepos"),
+    startupCommands: v.optional(v.array(v.string())),
+    backgroundCommands: v.optional(v.array(v.string())),
+    stopCommands: v.optional(v.array(v.string())),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const repo = await ctx.db.get(args.repoId);
+    if (!repo) throw new Error("Repository not found");
+    if (args.startupCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        startupCommands:
+          args.startupCommands.length > 0 ? args.startupCommands : undefined,
+      });
+    }
+    if (args.backgroundCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        backgroundCommands:
+          args.backgroundCommands.length > 0
+            ? args.backgroundCommands
+            : undefined,
+      });
+    }
+    if (args.stopCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        stopCommands:
+          args.stopCommands.length > 0 ? args.stopCommands : undefined,
       });
     }
     return null;

--- a/packages/backend/convex/_repoSnapshots/builds.ts
+++ b/packages/backend/convex/_repoSnapshots/builds.ts
@@ -5,6 +5,8 @@ import {
   snapshotBuildStatusValidator,
   snapshotBuildTriggerValidator,
   snapshotWarmupStatusValidator,
+  seededAppResultValidator,
+  seededAppStatusValidator,
 } from "../validators";
 import { authQuery, authMutation } from "../functions";
 import { workflow } from "../workflowManager";
@@ -30,6 +32,7 @@ export const listBuilds = authQuery({
       retryCount: v.optional(v.number()),
       warmupStatus: v.optional(snapshotWarmupStatusValidator),
       warmupError: v.optional(v.string()),
+      seededApps: v.optional(v.array(seededAppResultValidator)),
     }),
   ),
   handler: async (ctx, args) => {
@@ -62,6 +65,7 @@ export const getBuild = authQuery({
       retryCount: v.optional(v.number()),
       warmupStatus: v.optional(snapshotWarmupStatusValidator),
       warmupError: v.optional(v.string()),
+      seededApps: v.optional(v.array(seededAppResultValidator)),
     }),
     v.null(),
   ),
@@ -83,7 +87,14 @@ export const getBuildStatus = internalQuery({
 
 /** Cron-triggered handler that starts a new snapshot build if none is currently running. */
 export const triggerScheduledBuild = internalMutation({
-  args: { repoSnapshotId: v.id("repoSnapshots") },
+  args: {
+    repoSnapshotId: v.id("repoSnapshots"),
+    // For operational debugging: keep the existing cron entry point but record
+    // the build as manual so completeBuild does not enqueue cron retries.
+    disableRetries: v.optional(v.boolean()),
+    forceImageRebuild: v.optional(v.boolean()),
+    forceBaseSeed: v.optional(v.boolean()),
+  },
   returns: v.null(),
   handler: async (ctx, args) => {
     const config = await ctx.db.get(args.repoSnapshotId);
@@ -113,7 +124,7 @@ export const triggerScheduledBuild = internalMutation({
     const buildId = await ctx.db.insert("snapshotBuilds", {
       repoSnapshotId: args.repoSnapshotId,
       status: "running",
-      triggeredBy: "cron",
+      triggeredBy: args.disableRetries === true ? "manual" : "cron",
       logs: "",
       startedAt: now,
     });
@@ -121,9 +132,50 @@ export const triggerScheduledBuild = internalMutation({
     await workflow.start(ctx, internal.snapshotWorkflow.snapshotBuildWorkflow, {
       buildId,
       repoSnapshotId: args.repoSnapshotId,
+      forceImageRebuild: args.forceImageRebuild,
+      forceBaseSeed: args.forceBaseSeed,
     });
 
     return null;
+  },
+});
+
+/**
+ * Internal: all sandbox ids with a real product owner. Credential-helper rows
+ * are intentionally excluded: they are implementation detail rows created for
+ * every sandbox, including leaked seed-prep sandboxes.
+ */
+export const listReferencedSandboxIds = internalQuery({
+  args: {},
+  returns: v.array(v.string()),
+  handler: async (ctx) => {
+    const ids: string[] = [];
+    const add = (sandboxId: string | undefined): void => {
+      if (sandboxId && !ids.includes(sandboxId)) ids.push(sandboxId);
+    };
+
+    const tasks = await ctx.db.query("agentTasks").collect();
+    for (const task of tasks) add(task.sandboxId);
+
+    const runs = await ctx.db.query("agentRuns").collect();
+    for (const run of runs) add(run.sandboxId);
+
+    const sessions = await ctx.db.query("sessions").collect();
+    for (const session of sessions) add(session.sandboxId);
+
+    const projects = await ctx.db.query("projects").collect();
+    for (const project of projects) add(project.sandboxId);
+
+    const designSessions = await ctx.db.query("designSessions").collect();
+    for (const session of designSessions) add(session.sandboxId);
+
+    const docs = await ctx.db.query("docs").collect();
+    for (const doc of docs) add(doc.sandboxId);
+
+    const automationRuns = await ctx.db.query("automationRuns").collect();
+    for (const run of automationRuns) add(run.sandboxId);
+
+    return ids;
   },
 });
 
@@ -173,7 +225,7 @@ export const startBuild = authMutation({
   },
 });
 
-/** Marks a build as complete (success/error), triggers warmup on success or retries on cron failure. */
+/** Marks a build as complete (success/error); retries on cron failure. */
 export const completeBuild = internalMutation({
   args: {
     buildId: v.id("snapshotBuilds"),
@@ -195,16 +247,6 @@ export const completeBuild = internalMutation({
       error: args.error,
       completedAt: Date.now(),
     });
-    if (args.status === "success") {
-      const snapshot = await ctx.db.get(build.repoSnapshotId);
-      if (snapshot) {
-        await ctx.db.patch(args.buildId, { warmupStatus: "pending" });
-        await ctx.scheduler.runAfter(0, internal.daytona.warmSnapshotCache, {
-          repoId: snapshot.repoId,
-          buildId: args.buildId,
-        });
-      }
-    }
     if (
       args.status === "error" &&
       build.triggeredBy === "cron" &&
@@ -233,25 +275,6 @@ export const completeBuild = internalMutation({
   },
 });
 
-/** Updates the warmup status and optional error for a snapshot build. */
-export const updateWarmupStatus = internalMutation({
-  args: {
-    buildId: v.id("snapshotBuilds"),
-    status: snapshotWarmupStatusValidator,
-    error: v.optional(v.string()),
-  },
-  returns: v.null(),
-  handler: async (ctx, args) => {
-    const build = await ctx.db.get(args.buildId);
-    if (!build) return null;
-    await ctx.db.patch(args.buildId, {
-      warmupStatus: args.status,
-      warmupError: args.error,
-    });
-    return null;
-  },
-});
-
 /** Appends a log chunk to an existing snapshot build record. */
 export const appendLogs = internalMutation({
   args: {
@@ -264,6 +287,86 @@ export const appendLogs = internalMutation({
     if (!build) return null;
     await ctx.db.patch(args.buildId, {
       logs: build.logs + args.chunk,
+    });
+    return null;
+  },
+});
+
+/**
+ * Records a single app's seeding outcome on a build (called during Step 5).
+ * seededSnapshotName is the captured snapshot name on success, or null when the
+ * app fell back to the base Image. Replaces any prior entry for the same repo so
+ * the operation is idempotent under workflow retries.
+ */
+export const recordSeededApp = internalMutation({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoId: v.id("githubRepos"),
+    status: seededAppStatusValidator,
+    seededSnapshotName: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const build = await ctx.db.get(args.buildId);
+    if (!build) return null;
+    const repo = await ctx.db.get(args.repoId);
+    const seededApps = [
+      ...(build.seededApps ?? []).filter((a) => a.repoId !== args.repoId),
+      {
+        repoId: args.repoId,
+        app: repo?.rootDirectory,
+        status: args.status,
+        seededSnapshotName: args.seededSnapshotName,
+      },
+    ];
+    await ctx.db.patch(args.buildId, { seededApps });
+    return null;
+  },
+});
+
+/** Updates a seeded app's cache-warm status without changing its seed outcome. */
+export const updateSeededAppWarmupStatus = internalMutation({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoId: v.id("githubRepos"),
+    status: snapshotWarmupStatusValidator,
+    error: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const build = await ctx.db.get(args.buildId);
+    if (!build) return null;
+    const seededApps = (build.seededApps ?? []).map((app) => {
+      if (app.repoId !== args.repoId) return app;
+      return {
+        repoId: app.repoId,
+        app: app.app,
+        status: app.status,
+        seededSnapshotName: app.seededSnapshotName,
+        warmupStatus: args.status,
+        warmupError: args.error,
+      };
+    });
+    const seededEntries = seededApps.filter((app) => app.status === "seeded");
+    const warmupStatus: "pending" | "success" | "error" | undefined =
+      seededApps.some((app) => app.status === "running")
+        ? "pending"
+        : seededEntries.some((app) => app.warmupStatus === "error")
+          ? "error"
+          : seededEntries.some(
+                (app) => !app.warmupStatus || app.warmupStatus === "pending",
+              )
+            ? "pending"
+            : seededEntries.length > 0
+              ? "success"
+              : undefined;
+    const warmupError = seededEntries.find(
+      (app) => app.warmupStatus === "error" && app.warmupError,
+    )?.warmupError;
+    await ctx.db.patch(args.buildId, {
+      seededApps,
+      warmupStatus,
+      warmupError,
     });
     return null;
   },

--- a/packages/backend/convex/_repoSnapshots/config.ts
+++ b/packages/backend/convex/_repoSnapshots/config.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { internalQuery } from "../_generated/server";
+import { internalQuery, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { GenericDatabaseReader } from "convex/server";
 import type { DataModel, Doc, Id } from "../_generated/dataModel";
@@ -60,6 +60,7 @@ export const getRepoSnapshot = authQuery({
       cronJobId: v.optional(v.string()),
       workflowRef: v.optional(v.string()),
       buildCommands: v.optional(v.array(v.string())),
+      imageFingerprint: v.optional(v.string()),
       createdAt: v.number(),
       updatedAt: v.number(),
     }),
@@ -70,11 +71,22 @@ export const getRepoSnapshot = authQuery({
   },
 });
 
-/** Returns the snapshot name for a repo, only if a successful build exists. */
+/**
+ * Returns the snapshot name a sandbox for this repo should boot from.
+ * Prefers the app's own seeded running-sandbox snapshot (DB already seeded) when
+ * present; otherwise falls back to the shared base Image snapshot, but only if a
+ * successful Image build exists.
+ */
 export const getRepoSnapshotName = internalQuery({
   args: { repoId: v.id("githubRepos") },
   returns: v.union(v.object({ snapshotName: v.string() }), v.null()),
   handler: async (ctx, args) => {
+    // Per-app seeded snapshot takes precedence (fast start with seeded DB).
+    const repo = await ctx.db.get(args.repoId);
+    if (repo?.seededSnapshotName) {
+      return { snapshotName: repo.seededSnapshotName };
+    }
+
     const snapshot = await findSnapshotForRepo(ctx.db, args.repoId);
     if (!snapshot) return null;
 
@@ -91,6 +103,207 @@ export const getRepoSnapshotName = internalQuery({
   },
 });
 
+/**
+ * Lists the app repos a seeded snapshot should be built for after the base Image
+ * build. Seeded snapshots are PER APP, not per monorepo: an app is a sibling
+ * (same owner/name) with stopCommands configured that is NOT the monorepo parent
+ * (i.e. no other sibling points to it via parentRepoId). For a single-app repo
+ * the lone repo qualifies (it parents nobody). For carepulse this yields web +
+ * eprocurement, excluding the parent root.
+ */
+/**
+ * Shared resolver for the seedable app repos of a snapshot config (see
+ * getSeedableAppRepos doc for the rule). Returns the full repo docs so callers
+ * can read display fields / seededSnapshotName.
+ */
+export async function findSeedableAppRepos(
+  db: GenericDatabaseReader<DataModel>,
+  repoSnapshotId: Id<"repoSnapshots">,
+): Promise<Doc<"githubRepos">[]> {
+  const config = await db.get(repoSnapshotId);
+  if (!config) return [];
+  const configRepo = await db.get(config.repoId);
+  if (!configRepo) return [];
+  const siblings = await db
+    .query("githubRepos")
+    .withIndex("by_owner_and_name", (q) =>
+      q.eq("owner", configRepo.owner).eq("name", configRepo.name),
+    )
+    .collect();
+  // Repos that are a monorepo parent of another sibling — skip these.
+  const parentIds = new Set<Id<"githubRepos">>();
+  for (const r of siblings) {
+    if (r.parentRepoId) parentIds.add(r.parentRepoId);
+  }
+  return siblings.filter(
+    (r) => (r.stopCommands?.length ?? 0) > 0 && !parentIds.has(r._id),
+  );
+}
+
+export const getSeedableAppRepos = internalQuery({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.array(
+    v.object({
+      repoId: v.id("githubRepos"),
+      // Current live seeded snapshot (null when falling back to the Image).
+      // The build workflow warm-boots the seed-prep sandbox from this and
+      // deletes it only after the replacement capture succeeds.
+      seededSnapshotName: v.union(v.string(), v.null()),
+      // Seed-input fingerprint stored at the last successful capture — when it
+      // still matches the current inputs the workflow skips re-seeding.
+      seededFingerprint: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const apps = await findSeedableAppRepos(ctx.db, args.repoSnapshotId);
+    return apps.map((r) => ({
+      repoId: r._id,
+      seededSnapshotName: r.seededSnapshotName ?? null,
+      seededFingerprint: r.seededFingerprint ?? null,
+    }));
+  },
+});
+
+/**
+ * Siblings that still carry a seededSnapshotName but are NO LONGER seedable
+ * (e.g. an app that dropped its stopCommands, or the monorepo parent). The
+ * per-app rebuild loop only deletes snapshots for CURRENTLY seedable apps, so
+ * without cleanup an ex-seedable app's seeded-<repoId> snapshot lingers in
+ * Daytona forever. The build workflow uses this to delete those snapshots and
+ * clear the stale name.
+ */
+export const getOrphanedSeededApps = internalQuery({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.array(
+    v.object({
+      repoId: v.id("githubRepos"),
+      seededSnapshotName: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const config = await ctx.db.get(args.repoSnapshotId);
+    if (!config) return [];
+    const configRepo = await ctx.db.get(config.repoId);
+    if (!configRepo) return [];
+    const siblings = await ctx.db
+      .query("githubRepos")
+      .withIndex("by_owner_and_name", (q) =>
+        q.eq("owner", configRepo.owner).eq("name", configRepo.name),
+      )
+      .collect();
+    const seedable = await findSeedableAppRepos(ctx.db, args.repoSnapshotId);
+    const seedableIds = new Set(seedable.map((r) => r._id));
+    const orphans: Array<{
+      repoId: Id<"githubRepos">;
+      seededSnapshotName: string;
+    }> = [];
+    for (const r of siblings) {
+      // The !== undefined guard narrows seededSnapshotName to string.
+      if (!seedableIds.has(r._id) && r.seededSnapshotName !== undefined) {
+        orphans.push({
+          repoId: r._id,
+          seededSnapshotName: r.seededSnapshotName,
+        });
+      }
+    }
+    return orphans;
+  },
+});
+
+/**
+ * Current per-app seeded-snapshot state for a snapshot config: each seedable app
+ * with its live seededSnapshotName (null = falling back to the base Image).
+ * Used by the snapshot status tab.
+ */
+export const getSeededAppStatus = authQuery({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.array(
+    v.object({
+      repoId: v.id("githubRepos"),
+      app: v.optional(v.string()),
+      owner: v.string(),
+      name: v.string(),
+      seededSnapshotName: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const apps = await findSeedableAppRepos(ctx.db, args.repoSnapshotId);
+    return apps.map((r) => ({
+      repoId: r._id,
+      app: r.rootDirectory,
+      owner: r.owner,
+      name: r.name,
+      seededSnapshotName: r.seededSnapshotName ?? null,
+    }));
+  },
+});
+
+/** Sets (or clears) an app repo's seeded snapshot name (+ input fingerprint). */
+export const setSeededSnapshotName = internalMutation({
+  args: {
+    repoId: v.id("githubRepos"),
+    seededSnapshotName: v.union(v.string(), v.null()),
+    seededFingerprint: v.optional(v.union(v.string(), v.null())),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.repoId, {
+      seededSnapshotName: args.seededSnapshotName ?? undefined,
+      ...(args.seededFingerprint !== undefined
+        ? { seededFingerprint: args.seededFingerprint ?? undefined }
+        : {}),
+    });
+    return null;
+  },
+});
+
+/**
+ * Fingerprint of an app's seed inputs: its startup/background/stop commands
+ * plus the config-file blobs of the app repo and the snapshot config's repo
+ * (data.sql / backup zips live on the parent). When this matches the value
+ * stored at the last successful seeded capture, the build workflow skips
+ * re-seeding: the resulting snapshot's data would be identical, and rebuilding
+ * it only contends with the concurrent base-image build on Daytona.
+ */
+export const getSeedFingerprint = internalQuery({
+  args: {
+    repoSnapshotId: v.id("repoSnapshots"),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const app = await ctx.db.get(args.repoId);
+    if (!app) return "missing-repo";
+    const config = await ctx.db.get(args.repoSnapshotId);
+    const fileKeys = async (repoId: Id<"githubRepos">): Promise<string[]> => {
+      const files = await ctx.db
+        .query("sandboxConfigFiles")
+        .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+        .collect();
+      return files
+        .map(
+          (f) =>
+            `${f.fileName}:${f.fileSize}:${(f.chunks ?? (f.storageId ? [f.storageId] : [])).join(",")}`,
+        )
+        .sort();
+    };
+    const payload = JSON.stringify({
+      startup: app.startupCommands ?? [],
+      background: app.backgroundCommands ?? [],
+      stop: app.stopCommands ?? [],
+      appFiles: await fileKeys(args.repoId),
+      parentFiles: config ? await fileKeys(config.repoId) : [],
+    });
+    // djb2 — cheap, deterministic, collision-resistant enough for a
+    // change-detection fingerprint (a false match only skips a re-seed).
+    let hash = 5381;
+    for (let i = 0; i < payload.length; i++) {
+      hash = (hash * 33) ^ payload.charCodeAt(i);
+    }
+    return `fp-${(hash >>> 0).toString(36)}-${payload.length}`;
+  },
+});
+
 /** Internal query to get snapshot config fields needed for rebuild actions. */
 export const getRepoSnapshotInternal = internalQuery({
   args: { repoSnapshotId: v.id("repoSnapshots") },
@@ -100,6 +313,7 @@ export const getRepoSnapshotInternal = internalQuery({
       snapshotName: v.string(),
       workflowRef: v.optional(v.string()),
       buildCommands: v.optional(v.array(v.string())),
+      imageFingerprint: v.optional(v.string()),
     }),
     v.null(),
   ),
@@ -111,7 +325,23 @@ export const getRepoSnapshotInternal = internalQuery({
       snapshotName: doc.snapshotName,
       workflowRef: doc.workflowRef,
       buildCommands: doc.buildCommands,
+      imageFingerprint: doc.imageFingerprint,
     };
+  },
+});
+
+/** Stores the image-input fingerprint after a successful Image build. */
+export const setImageFingerprint = internalMutation({
+  args: {
+    repoSnapshotId: v.id("repoSnapshots"),
+    imageFingerprint: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.repoSnapshotId, {
+      imageFingerprint: args.imageFingerprint ?? undefined,
+    });
+    return null;
   },
 });
 

--- a/packages/backend/convex/_repoSnapshots/repoMetadata.ts
+++ b/packages/backend/convex/_repoSnapshots/repoMetadata.ts
@@ -23,6 +23,17 @@ export const getBackgroundCommands = internalQuery({
   },
 });
 
+/** Returns the clean-stop commands for a repo/app, if any. */
+export const getStopCommands = internalQuery({
+  args: { repoId: v.id("githubRepos") },
+  returns: v.union(v.array(v.string()), v.null()),
+  handler: async (ctx, args) => {
+    const repo = await ctx.db.get(args.repoId);
+    if (!repo) return null;
+    return repo.stopCommands ?? null;
+  },
+});
+
 /** Internal query to get GitHub repo metadata (owner, name, installationId). */
 export const getRepo = internalQuery({
   args: { repoId: v.id("githubRepos") },

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -17,6 +17,7 @@ import {
   runStatusValidator,
   sessionModeValidator,
   sessionStatusValidator,
+  snapshotWarmupStatusValidator,
   taskActivityFieldValidator,
   taskSandboxEventValidator,
   taskSandboxStatusValidator,
@@ -180,6 +181,28 @@ export const repoSkillFields = {
   createdAt: v.number(),
 };
 
+// Lifecycle of a single app's seeded-snapshot build within Step 5: actively
+// seeding, captured successfully, or fell back to the base Image.
+export const seededAppStatusValidator = v.union(
+  v.literal("running"),
+  v.literal("seeded"),
+  v.literal("fallback"),
+);
+
+// Per-app outcome of a seeded-snapshot build (recorded per snapshotBuild during
+// Step 5). status tracks the lifecycle (running while in progress); is optional
+// for build records created before the field existed (treat absent as terminal,
+// inferred from seededSnapshotName). seededSnapshotName is the captured snapshot
+// name on success, or null while running / when it fell back to the base Image.
+export const seededAppResultValidator = v.object({
+  repoId: v.id("githubRepos"),
+  app: v.optional(v.string()),
+  status: v.optional(seededAppStatusValidator),
+  seededSnapshotName: v.union(v.string(), v.null()),
+  warmupStatus: v.optional(snapshotWarmupStatusValidator),
+  warmupError: v.optional(v.string()),
+});
+
 export const githubRepoFields = {
   owner: v.string(),
   name: v.string(),
@@ -204,8 +227,19 @@ export const githubRepoFields = {
   screenshotsVideosEnabled: v.optional(v.boolean()),
   startupCommands: v.optional(v.array(v.string())),
   backgroundCommands: v.optional(v.array(v.string())),
+  // Clean-shutdown commands run before snapshotting a seeded sandbox so on-disk
+  // volumes (e.g. local Postgres) flush consistently. Used by the seeded-snapshot
+  // build stage; not run on normal sandbox starts.
   stopCommands: v.optional(v.array(v.string())),
+  // Name of this app's seeded running-sandbox snapshot (filesystem snapshot with
+  // the DB already seeded), set by the seeded-snapshot build when it succeeds.
+  // Preferred over the base Image snapshot at sandbox-create time for fast starts.
   seededSnapshotName: v.optional(v.string()),
+  // Fingerprint of the seed inputs (startup/background/stop commands + config
+  // file blobs) captured when seededSnapshotName was built. When unchanged, the
+  // build workflow skips re-seeding — the existing snapshot's data is identical
+  // and re-capturing it would only contend with the image build.
+  seededFingerprint: v.optional(v.string()),
   devPort: v.optional(v.number()),
   devCommand: v.optional(v.string()),
   systemPrompt: v.optional(v.string()),

--- a/packages/backend/convex/daytona.ts
+++ b/packages/backend/convex/daytona.ts
@@ -1,7 +1,6 @@
 "use node";
 
 export {
-  warmSnapshotCache,
   killSandboxProcess,
   stopSandbox,
   deleteSandbox,
@@ -14,9 +13,11 @@ export {
 
 export {
   runSandboxCommand,
+  restoreSeededRuntimeState,
   runStartupCommands,
   startupCommandsMarkerExists,
   runBackgroundCommands,
+  runStopCommands,
   getPreviewUrl,
   prepareSandbox,
   createOrResumeSandbox,

--- a/packages/backend/convex/githubRepos.ts
+++ b/packages/backend/convex/githubRepos.ts
@@ -20,6 +20,7 @@ export {
   updateConfig,
   updateMcpRootPrompt,
   toggleHidden,
+  setRepoCommandsInternal,
   deleteInternal,
 } from "./_githubRepos/mutations";
 

--- a/packages/backend/convex/repoSnapshots.ts
+++ b/packages/backend/convex/repoSnapshots.ts
@@ -5,6 +5,12 @@ export {
   saveRepoSnapshot,
   setSnapshotEnabled,
   deleteRepoSnapshot,
+  getSeedableAppRepos,
+  getOrphanedSeededApps,
+  getSeededAppStatus,
+  setSeededSnapshotName,
+  getSeedFingerprint,
+  setImageFingerprint,
 } from "./_repoSnapshots/config";
 
 export {
@@ -14,12 +20,15 @@ export {
   triggerScheduledBuild,
   startBuild,
   completeBuild,
-  updateWarmupStatus,
   appendLogs,
+  recordSeededApp,
+  updateSeededAppWarmupStatus,
+  listReferencedSandboxIds,
 } from "./_repoSnapshots/builds";
 
 export {
   getStartupCommands,
   getBackgroundCommands,
+  getStopCommands,
   getRepo,
 } from "./_repoSnapshots/repoMetadata";

--- a/packages/backend/convex/sandboxConfigFiles.ts
+++ b/packages/backend/convex/sandboxConfigFiles.ts
@@ -192,3 +192,40 @@ export const getConfigFilesForSnapshot = internalQuery({
     return Array.from(filesByName.values());
   },
 });
+
+/**
+ * Stable identity keys for the config files baked into a snapshot — same
+ * sibling aggregation as getConfigFilesForSnapshot but returns
+ * `fileName:fileSize:chunkIds` strings (storage ids are immutable, unlike the
+ * signed chunk URLs). Used to fingerprint image/seed inputs for skip decisions.
+ */
+export const getConfigFileKeys = internalQuery({
+  args: { repoId: v.id("githubRepos") },
+  returns: v.array(v.string()),
+  handler: async (ctx, args) => {
+    const anchorRepo = await ctx.db.get(args.repoId);
+    if (!anchorRepo) return [];
+    const siblings = await ctx.db
+      .query("githubRepos")
+      .withIndex("by_owner_and_name", (q) =>
+        q.eq("owner", anchorRepo.owner).eq("name", anchorRepo.name),
+      )
+      .collect();
+    const keysByName = new Map<string, string>();
+    for (const sibling of siblings) {
+      const files = await ctx.db
+        .query("sandboxConfigFiles")
+        .withIndex("by_repo", (q) => q.eq("repoId", sibling._id))
+        .collect();
+      for (const file of files) {
+        const chunkIds =
+          file.chunks ?? (file.storageId ? [file.storageId] : []);
+        keysByName.set(
+          file.fileName,
+          `${file.fileName}:${file.fileSize}:${chunkIds.join(",")}`,
+        );
+      }
+    }
+    return Array.from(keysByName.values()).sort();
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -10,6 +10,7 @@ import {
   snapshotScheduleValidator,
   snapshotBuildStatusValidator,
   snapshotBuildTriggerValidator,
+  seededAppResultValidator,
   snapshotWarmupStatusValidator,
   teamMemberRoleValidator,
   webhookEventStatusValidator,
@@ -264,6 +265,11 @@ const schema = defineSchema({
     cronJobId: v.optional(v.string()),
     workflowRef: v.optional(v.string()),
     buildCommands: v.optional(v.array(v.string())),
+    // Fingerprint of the image inputs (lockfile sha on the build branch,
+    // buildCommands, config-file blobs, image definition version) stored at the
+    // last successful Image build. When unchanged, the build workflow skips the
+    // ~11-15m image rebuild — its output would be byte-identical.
+    imageFingerprint: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
   }).index("by_repo", ["repoId"]),
@@ -279,16 +285,8 @@ const schema = defineSchema({
     retryCount: v.optional(v.number()),
     warmupStatus: v.optional(snapshotWarmupStatusValidator),
     warmupError: v.optional(v.string()),
-    seededApps: v.optional(
-      v.array(
-        v.object({
-          app: v.string(),
-          repoId: v.id("githubRepos"),
-          seededSnapshotName: v.union(v.string(), v.null()),
-          status: v.optional(v.string()),
-        }),
-      ),
-    ),
+    // Per-app seeding outcomes captured during Step 5 of the build workflow.
+    seededApps: v.optional(v.array(seededAppResultValidator)),
   })
     .index("by_repo_snapshot", ["repoSnapshotId"])
     .index("by_repo_snapshot_and_status", ["repoSnapshotId", "status"])

--- a/packages/backend/convex/snapshotActions.ts
+++ b/packages/backend/convex/snapshotActions.ts
@@ -3,18 +3,84 @@
 import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { resolveAllEnvVars } from "./envVarResolver";
+import { resolveAllEnvVars, resolveDaytonaApiKey } from "./envVarResolver";
 import { getInstallationToken } from "./githubAuth";
 import {
   getDaytona,
   buildConfigFileDownloadCommands,
   filterDownloadableConfigFiles,
+  exec,
+  getSandbox,
   type SandboxConfigFile,
 } from "./_daytona/helpers";
+import {
+  createSandbox,
+  createSandboxAndPrepareRepo,
+  SESSION_LIFECYCLE,
+  WARMING_LIFECYCLE,
+} from "./_daytona/git";
+import {
+  getSnapshot,
+  deleteSnapshotByName,
+  waitForSnapshotRemoval,
+  triggerSandboxSnapshot,
+} from "./_daytona/snapshots";
+import { isTerminalSnapshotState } from "./_daytona/snapshotStates";
 import { Image } from "@daytonaio/sdk";
 import type { Id } from "./_generated/dataModel";
 
 const DAYTONA_API_URL = "https://app.daytona.io/api";
+const SEED_PREP_LABEL_KEY = "eva.purpose";
+const SEED_PREP_LABEL_VALUE = "snapshot-seed-prep";
+const SEEDED_SNAPSHOT_WARM_READY_TIMEOUT_SECONDS = 300;
+
+function shouldCaptureSupabaseState(commands: string[]): boolean {
+  return commands.some((command) => {
+    const lower = command.toLowerCase();
+    return (
+      lower.includes("supabase") ||
+      lower.includes("start-db") ||
+      lower.includes("seed:sql")
+    );
+  });
+}
+
+function seededRuntimeStateCaptureLines(
+  requireSupabaseDump: boolean,
+): string[] {
+  return [
+    'echo "SEEDRUN-STAGE:capture-runtime-state"',
+    `REQUIRE_SUPABASE_DUMP=${requireSupabaseDump ? "1" : "0"}`,
+    "mkdir -p /home/eva/.eva-snapshot-state",
+    "rm -f /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz",
+    'if [ "$REQUIRE_SUPABASE_DUMP" != "1" ]; then',
+    '  echo "repo does not require Supabase state capture; skipping"',
+    "elif ! docker ps --filter name=supabase_db_web --filter status=running -q | grep -q .; then",
+    "  if docker ps -a --filter name=supabase_db_web -q | grep -q .; then",
+    "    docker start supabase_db_web >/dev/null",
+    "  else",
+    "    ( cd /tmp/repo && pnpm start-db ) || true",
+    "  fi",
+    "fi",
+    'if [ "$REQUIRE_SUPABASE_DUMP" = "1" ]; then',
+    "  for i in $(seq 1 240); do docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done",
+    '  docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1 || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }',
+    "  dump_supabase_public_data() { ( set -o pipefail; docker exec supabase_db_web pg_dump -U postgres -d postgres --schema=public --data-only --no-owner --no-privileges | gzip -1 > /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz ); }",
+    "  count_supabase_dump_rows() { gzip -dc /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz | awk 'BEGIN{in_copy=0;c=0} /^COPY public\\./{in_copy=1;next} /^\\\\\\.$/{in_copy=0;next} in_copy{c++} END{print c}'; }",
+    '  dump_supabase_public_data || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }',
+    "  SUPABASE_DUMP_ROWS=$(count_supabase_dump_rows)",
+    '  if [ "$SUPABASE_DUMP_ROWS" = "0" ] && [ -f packages/db/data.sql ]; then echo "Supabase dump was empty; rerunning pnpm seed:sql before capture"; pnpm seed:sql || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }; dump_supabase_public_data || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }; SUPABASE_DUMP_ROWS=$(count_supabase_dump_rows); fi',
+    '  if [ "$SUPABASE_DUMP_ROWS" = "0" ]; then echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; fi',
+    '  echo "supabase_dump_rows=$SUPABASE_DUMP_ROWS"',
+    "  ls -lh /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz",
+    "fi",
+  ];
+}
+
+// Bump when buildSnapshotImage's content changes (new tools, base image, or
+// layer commands) so existing image fingerprints invalidate and the next build
+// rebuilds the Image even though repo/config inputs are unchanged.
+const IMAGE_DEF_VERSION = 1;
 
 // "eva ALL=(ALL) NOPASSWD: ALL\n" — base64-encoded to avoid parentheses breaking Dockerfile RUN
 const EVA_SUDOERS_B64 = "ZXZhIEFMTD0oQUxMKSBOT1BBU1NXRDogQUxMCg==";
@@ -373,11 +439,16 @@ export const pollSnapshotProgress = internalAction({
     }
 
     const daytona = getDaytona(daytonaApiKey);
-    const snapshot = await daytona.snapshot.get(args.snapshotName);
-    const state = String(snapshot.state);
+    const snapshot = await getSnapshot(daytona, args.snapshotName);
+    if (!snapshot) {
+      // The base snapshot was just kicked off, so a missing one is unexpected;
+      // throw so the workflow step fails (matches the prior get-throws path).
+      throw new Error(`Snapshot ${args.snapshotName} not found`);
+    }
+    const state = snapshot.state;
 
     // Terminal states: fetch build logs and complete the build
-    if (state === "active" || state === "error" || state === "build_failed") {
+    if (isTerminalSnapshotState(state)) {
       // Fetch full build logs from the Daytona API (only on terminal state to avoid wasted calls).
       // Both the URL endpoint AND the returned log-stream URL require Bearer auth.
       let logs = "";
@@ -415,9 +486,7 @@ export const pollSnapshotProgress = internalAction({
         return "active";
       }
 
-      const reason = snapshot.errorReason
-        ? String(snapshot.errorReason)
-        : "Unknown error";
+      const reason = snapshot.errorReason || "Unknown error";
       await ctx.runMutation(internal.repoSnapshots.completeBuild, {
         buildId: args.buildId,
         status: "error",
@@ -466,26 +535,13 @@ export const deleteExistingSnapshot = internalAction({
 
     const daytona = getDaytona(daytonaApiKey);
 
-    try {
-      const existing = await daytona.snapshot.get(args.snapshotName);
-      await daytona.snapshot.delete(existing);
-
+    const deleted = await deleteSnapshotByName(daytona, args.snapshotName);
+    if (deleted) {
       await ctx.runMutation(internal.repoSnapshots.appendLogs, {
         buildId: args.buildId,
         chunk: "Deleting existing snapshot, waiting for removal...\n",
       });
-
-      // Poll until the snapshot is fully removed (get throws on not-found)
-      for (let i = 0; i < 30; i++) {
-        await new Promise((r) => setTimeout(r, 2000));
-        try {
-          await daytona.snapshot.get(args.snapshotName);
-        } catch {
-          break;
-        }
-      }
-    } catch {
-      // Snapshot doesn't exist — nothing to delete
+      await waitForSnapshotRemoval(daytona, args.snapshotName);
     }
 
     return null;
@@ -507,11 +563,557 @@ export const deleteDaytonaSnapshot = internalAction({
     }
 
     const daytona = getDaytona(daytonaApiKey);
+    await deleteSnapshotByName(daytona, args.snapshotName);
+    return null;
+  },
+});
+
+/**
+ * Deletes seed-prep sandboxes that were created by the snapshot workflow and
+ * no longer have a product owner in Convex. This is intentionally label-gated:
+ * older unlabelled leaks still need a one-off guarded audit, while the workflow
+ * can safely self-heal everything it creates after this change.
+ */
+export const sweepSeedPrepSandboxes = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    scopedRepoIds: v.optional(v.array(v.id("githubRepos"))),
+    buildId: v.optional(v.id("snapshotBuilds")),
+  },
+  returns: v.object({
+    scanned: v.number(),
+    matched: v.number(),
+    deleted: v.number(),
+    skippedReferenced: v.number(),
+    failed: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
+    const daytona = getDaytona(daytonaApiKey);
+    const referenced = new Set(
+      await ctx.runQuery(internal.repoSnapshots.listReferencedSandboxIds, {}),
+    );
+    const scopedRepoIds = args.scopedRepoIds ?? [];
+    const scopedRepoIdStrings: string[] = [];
+    for (const repoId of scopedRepoIds) {
+      scopedRepoIdStrings.push(repoId);
+    }
+
+    let scanned = 0;
+    let matched = 0;
+    let deleted = 0;
+    let skippedReferenced = 0;
+    let failed = 0;
+    let page = 1;
+    const limit = 100;
+
+    while (true) {
+      const result = await daytona.list({
+        page: String(page),
+        limit: String(limit),
+      });
+      const items = result.items;
+      scanned += items.length;
+
+      for (const sandbox of items) {
+        if (sandbox.labels[SEED_PREP_LABEL_KEY] !== SEED_PREP_LABEL_VALUE) {
+          continue;
+        }
+        const sandboxRepoId = sandbox.labels["eva.repoId"];
+        if (
+          scopedRepoIdStrings.length > 0 &&
+          (sandboxRepoId === undefined ||
+            !scopedRepoIdStrings.includes(sandboxRepoId))
+        ) {
+          continue;
+        }
+        matched += 1;
+        if (referenced.has(sandbox.id)) {
+          skippedReferenced += 1;
+          continue;
+        }
+        try {
+          await sandbox.delete();
+          deleted += 1;
+          await ctx.runMutation(
+            internal.sandboxGitCredentials.deleteBySandboxId,
+            { sandboxId: sandbox.id },
+          );
+        } catch (e) {
+          failed += 1;
+          console.warn(
+            `[snapshot] failed to delete seed-prep sandbox ${sandbox.id}: ${
+              e instanceof Error ? e.message : String(e)
+            }`,
+          );
+        }
+      }
+
+      if (items.length < limit) break;
+      page += 1;
+    }
+
+    if (args.buildId) {
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk:
+          `[seed-prep sweep] scanned=${scanned}, matched=${matched}, deleted=${deleted}, ` +
+          `referenced=${skippedReferenced}, failed=${failed}\n`,
+      });
+    }
+
+    return { scanned, matched, deleted, skippedReferenced, failed };
+  },
+});
+
+/**
+ * Fingerprint of the Image inputs: the dependency lockfile's blob sha on the
+ * build branch, the build commands, the config-file blobs baked into the image,
+ * and IMAGE_DEF_VERSION. When this matches the value stored at the last
+ * successful Image build, the workflow skips the ~11-15m rebuild — the output
+ * would be byte-identical (sandboxes fetch fresh branches at boot, so a repo
+ * checkout that is a few commits stale costs nothing; node_modules only drift
+ * when the lockfile changes, which changes this fingerprint). Returns null when
+ * the inputs cannot be determined (e.g. lockfile lookup fails) — callers must
+ * treat null as "always rebuild".
+ */
+export const getImageFingerprint = internalAction({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args): Promise<string | null> => {
+    const config = await ctx.runQuery(
+      internal.repoSnapshots.getRepoSnapshotInternal,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+    if (!config) return null;
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: config.repoId,
+    });
+    if (!repo) return null;
+    const branch = config.workflowRef ?? "main";
+    let lockfileSha: string | null = null;
     try {
-      const snapshot = await daytona.snapshot.get(args.snapshotName);
-      await daytona.snapshot.delete(snapshot);
-    } catch {
-      // Snapshot may not exist
+      const token = await getInstallationToken(repo.installationId);
+      for (const lockfile of [
+        "pnpm-lock.yaml",
+        "package-lock.json",
+        "yarn.lock",
+      ]) {
+        const resp = await fetch(
+          `https://api.github.com/repos/${repo.owner}/${repo.name}/contents/${lockfile}?ref=${encodeURIComponent(branch)}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/vnd.github+json",
+            },
+          },
+        );
+        if (resp.ok) {
+          const data: unknown = await resp.json();
+          if (isRecord(data) && typeof data["sha"] === "string") {
+            lockfileSha = data["sha"];
+            break;
+          }
+        }
+      }
+    } catch (e) {
+      console.error(
+        `[snapshot] image fingerprint: lockfile lookup failed: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+      return null;
+    }
+    if (!lockfileSha) return null;
+    const fileKeys: string[] = await ctx.runQuery(
+      internal.sandboxConfigFiles.getConfigFileKeys,
+      { repoId: config.repoId },
+    );
+    const payload = JSON.stringify({
+      v: IMAGE_DEF_VERSION,
+      branch,
+      lockfileSha,
+      buildCommands: config.buildCommands ?? [],
+      files: fileKeys,
+    });
+    let hash = 5381;
+    for (let i = 0; i < payload.length; i++) {
+      hash = (hash * 33) ^ payload.charCodeAt(i);
+    }
+    return `img-${(hash >>> 0).toString(36)}-${payload.length}`;
+  },
+});
+
+/**
+ * Seeded-snapshot build — LAUNCH step. Composes the app's whole seed sequence
+ * (startup commands → marker → stop commands) into one bash script and launches
+ * it DETACHED on the prep sandbox (setsid nohup), returning immediately.
+ *
+ * Convex actions have a hard 600s ceiling, so running seed commands
+ * synchronously inside actions caps every command at ~9 minutes — cold docker
+ * pulls and slow readiness waits blew through it repeatedly on prod. Detached,
+ * the script takes as long as it needs; the workflow polls pollSeedRun for the
+ * outcome markers, mirroring the trigger+poll pattern used for captures.
+ */
+export const launchSeedRun = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+    // Branch to hard-reset /tmp/repo to (refs must already be fetched — the
+    // workflow runs daytona.fetchBaseBranch first, which owns git auth).
+    branch: v.string(),
+    // Repo build commands (pnpm install / codegen etc), run after the reset so
+    // the captured snapshot carries fresh node_modules and build artifacts.
+    buildCommands: v.array(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const startupCommands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getStartupCommands,
+      { repoId: args.repoId },
+    );
+    const backgroundCommands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getBackgroundCommands,
+      { repoId: args.repoId },
+    );
+    const stopCommands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getStopCommands,
+      { repoId: args.repoId },
+    );
+    const requireSupabaseDump = shouldCaptureSupabaseState([
+      ...(startupCommands ?? []),
+      ...(backgroundCommands ?? []),
+      ...(stopCommands ?? []),
+    ]);
+    const lines: string[] = [
+      "#!/bin/bash",
+      "exec > /tmp/seedrun.log 2>&1",
+      "set -x",
+      "rm -f /tmp/.seedrun-done",
+      // ---- update: latest code + fresh deps/artifacts ----
+      'echo "SEEDRUN-STAGE:update"',
+      'cd /tmp/repo || { echo "SEEDRUN-FAILED:no-repo"; exit 1; }',
+      `( git checkout -f ${args.branch} 2>/dev/null || git checkout -fb ${args.branch} origin/${args.branch} ) && git reset --hard origin/${args.branch} || { echo "SEEDRUN-FAILED:git-reset"; exit 1; }`,
+    ];
+    args.buildCommands.forEach((command, i) => {
+      lines.push(
+        `( ${command} ) || { echo "SEEDRUN-FAILED:build-${i}"; exit 1; }`,
+      );
+    });
+    // ---- daemons: launch each background command detached (b64 per command
+    // so quoting inside user commands can never break the script) ----
+    lines.push('echo "SEEDRUN-STAGE:daemons"');
+    (backgroundCommands ?? []).forEach((command, i) => {
+      const cb64 = Buffer.from(command, "utf8").toString("base64");
+      lines.push(
+        `echo ${cb64} | base64 -d > /tmp/bg-cmd-${i}.sh && chmod +x /tmp/bg-cmd-${i}.sh && setsid nohup bash -l /tmp/bg-cmd-${i}.sh </dev/null > /tmp/bg-${i}.log 2>&1 &`,
+      );
+    });
+    // ---- seed ----
+    lines.push('echo "SEEDRUN-STAGE:startup"');
+    (startupCommands ?? []).forEach((command, i) => {
+      // Subshell so `cd`/env in one command can't leak into the next, matching
+      // how runSandboxCommand executed them as separate execs.
+      lines.push(
+        `( ${command} ) || { echo "SEEDRUN-FAILED:startup-${i}"; exit 1; }`,
+      );
+    });
+    lines.push(...seededRuntimeStateCaptureLines(requireSupabaseDump));
+    // Marker so a sandbox booting from the captured snapshot skips the seed.
+    lines.push("touch /tmp/.startup-commands-done");
+    (stopCommands ?? []).forEach((command, i) => {
+      lines.push(
+        `( ${command} ) || { echo "SEEDRUN-FAILED:stop-${i}"; exit 1; }`,
+      );
+    });
+    lines.push('echo "SEEDRUN-DONE"', "touch /tmp/.seedrun-done");
+    const script = lines.join("\n");
+    const b64 = Buffer.from(script, "utf8").toString("base64");
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    // Process-based guard makes the launch idempotent so the workflow can
+    // retry a timed-out launch exec without racing a second copy. It must be
+    // the LIVE process (pgrep, self-match-proof bracket pattern), not a
+    // lockfile: a prep sandbox warm-booted from a previously captured seeded
+    // snapshot carries that capture's marker files baked into /tmp, and a
+    // file-based guard would skip the launch and instantly report the baked
+    // "done" — capturing without ever re-seeding. Stale markers are scrubbed
+    // before every fresh launch for the same reason.
+    await exec(
+      sandbox,
+      `if pgrep -f "[s]eedrun.sh" >/dev/null; then echo ALREADY-RUNNING; else rm -f /tmp/.seedrun-done /tmp/seedrun.log && echo ${b64} | base64 -d > /tmp/seedrun.sh && chmod +x /tmp/seedrun.sh && setsid nohup /tmp/seedrun.sh </dev/null >/dev/null 2>&1 & echo LAUNCHED; fi`,
+      120,
+    );
+    return null;
+  },
+});
+
+/**
+ * Seeded-snapshot build — DIAGNOSTICS step. Returns the tail of the seed-run
+ * log and background daemon logs so a failed seed can be appended to the build
+ * record BEFORE the prep sandbox is torn down (teardown destroys the evidence).
+ */
+export const fetchSeedDiagnostics = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    try {
+      return await exec(
+        sandbox,
+        [
+          'echo "== git state =="',
+          "( cd /tmp/repo && git rev-parse --short HEAD 2>&1; git status -s 2>&1 | head -5 )",
+          'echo "== convex versions =="',
+          "( cd /tmp/repo && npx convex --version 2>&1; ls -la ~/.convex/ 2>&1 | head; ls -la ~/.cache/convex/ 2>&1 | head )",
+          'echo "== 3210 listening? =="',
+          "curl -s -o /dev/null -w 'backend http:%{http_code}\\n' http://127.0.0.1:3210 2>&1 || echo '3210 unreachable'",
+          'echo "== seedrun.log (tail) =="; tail -c 4000 /tmp/seedrun.log 2>/dev/null',
+          'for f in /tmp/bg-*.log; do echo; echo "== $f =="; tail -c 3000 "$f" 2>/dev/null; done',
+          "true",
+        ].join("; "),
+        90,
+      );
+    } catch (e) {
+      return `diagnostics unavailable: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  },
+});
+
+/**
+ * Seeded-snapshot build — SEED POLL step. Returns "done" when the detached
+ * seed script finished cleanly, "failed:<stage>" when it aborted (stage names
+ * the command index, e.g. startup-3), and "running" otherwise.
+ */
+export const pollSeedRun = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    const out = await exec(
+      sandbox,
+      'test -f /tmp/.seedrun-done && echo DONE; grep -aoE "SEEDRUN-FAILED:[a-z0-9-]+" /tmp/seedrun.log 2>/dev/null | tail -1; true',
+      30,
+    );
+    if (out.includes("DONE")) return "done";
+    const failed = out.match(/SEEDRUN-FAILED:([a-z0-9-]+)/);
+    if (failed) return `failed:${failed[1]}`;
+    return "running";
+  },
+});
+
+/**
+ * Seeded-snapshot build step: creates + prepares a sandbox from the base Image
+ * snapshot (NOT a seeded one — passed explicitly to bypass the seeded preference
+ * in getRepoSnapshotName), ready to run the app's background/seed/stop commands.
+ */
+export const createSeedPrepSandbox = internalAction({
+  args: { repoId: v.id("githubRepos"), imageSnapshot: v.string() },
+  returns: v.object({ sandboxId: v.string() }),
+  handler: async (ctx, args): Promise<{ sandboxId: string }> => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const daytona = getDaytona(daytonaApiKey);
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) throw new Error("Repo not found");
+    const seedPrepLifecycle = {
+      ...SESSION_LIFECYCLE,
+      labels: {
+        "eva.managed": "true",
+        [SEED_PREP_LABEL_KEY]: SEED_PREP_LABEL_VALUE,
+        "eva.repoId": args.repoId,
+      },
+    };
+    const { sandbox } = await createSandboxAndPrepareRepo(
+      ctx,
+      daytona,
+      repo.installationId,
+      repo.owner,
+      repo.name,
+      { ...sandboxEnvVars, REPO_ID: args.repoId },
+      seedPrepLifecycle,
+      args.imageSnapshot,
+      undefined, // volumes
+      undefined, // onSandboxAcquired
+      undefined, // onProgress
+      { mode: "all" }, // syncStrategy
+      // Large seeded snapshots take well over the 30s default to boot; 180s
+      // avoids the spurious create timeout + orphaned sandbox on warm boots.
+      180,
+    );
+    return { sandboxId: sandbox.id };
+  },
+});
+
+// Trigger timeout (seconds) for the seeded-snapshot capture. The SDK's
+// _experimental_createSnapshot fires the POST then blocks polling the sandbox
+// state until the capture finishes OR this timeout elapses. We keep it small so
+// the trigger action returns quickly (the snapshot keeps building server-side)
+// and the workflow polls completion across separate steps — see
+// triggerSeededSnapshot. Comfortable for the POST; short enough to never near
+// Convex's 600s per-action ceiling.
+const SEEDED_SNAPSHOT_TRIGGER_TIMEOUT_SEC = 30;
+
+/**
+ * Seeded-snapshot build — TRIGGER step. Captures the (clean-stopped) sandbox's
+ * filesystem — including the seeded Docker volumes — into a reusable snapshot.
+ *
+ * Non-blocking by design: a seeded snapshot carries the whole seeded DB volume
+ * and its capture routinely runs for many minutes. The SDK helper blocks the
+ * caller polling the sandbox state for the entire capture, which exceeds
+ * Convex's hard 600s action limit — the action gets killed mid-await (the
+ * "unawaited operation" warning) and the app silently drops to the base Image.
+ * Instead we fire the POST with a short timeout so the helper bails fast with a
+ * DaytonaTimeoutError (the snapshot keeps building server-side), then poll
+ * completion in separate workflow steps via pollSeededSnapshotState. Any
+ * non-timeout error is a real failure and propagates to the per-app fallback.
+ */
+export const triggerSeededSnapshot = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    sandboxId: v.string(),
+    seededName: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
+    const daytona = getDaytona(daytonaApiKey);
+    await triggerSandboxSnapshot(
+      daytona,
+      args.sandboxId,
+      args.seededName,
+      SEEDED_SNAPSHOT_TRIGGER_TIMEOUT_SEC,
+    );
+    return null;
+  },
+});
+
+/**
+ * Seeded-snapshot build — POLL step. Returns the snapshot entity's current state
+ * ("active" on success, "error"/"build_failed" on failure, otherwise still
+ * building; "pending" if it is not registered yet).
+ *
+ * We poll the SNAPSHOT entity, not the sandbox state: a sandbox snapshot can
+ * reach "active" while the source sandbox still reports "snapshotting", so a
+ * sandbox-state poll can wait out the whole window and wrongly record a fallback
+ * for a snapshot that actually succeeded. The snapshot's own state is the
+ * authoritative signal — the same one the base-Image build polls.
+ */
+export const pollSeededSnapshotState = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    seededName: v.string(),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
+    const daytona = getDaytona(daytonaApiKey);
+    // Not registered yet (or a transient lookup miss) → treat as still pending.
+    const snapshot = await getSnapshot(daytona, args.seededName);
+    return snapshot ? snapshot.state : "pending";
+  },
+});
+
+/**
+ * Warms Daytona's create-from-snapshot cache for a newly active seeded snapshot.
+ * The first sandbox from a large seeded filesystem can take several minutes;
+ * paying that cost inside the build makes the next user-created sandbox fast.
+ */
+export const warmSeededSnapshotCache = internalAction({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoId: v.id("githubRepos"),
+    seededName: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) {
+      await ctx.runMutation(
+        internal.repoSnapshots.updateSeededAppWarmupStatus,
+        {
+          buildId: args.buildId,
+          repoId: args.repoId,
+          status: "error",
+          error: "Repo not found",
+        },
+      );
+      return null;
+    }
+
+    const daytona = getDaytona(daytonaApiKey);
+    let sandboxId: string | null = null;
+    try {
+      const sandbox = await createSandbox(
+        daytona,
+        repo.installationId,
+        { ...sandboxEnvVars, REPO_ID: args.repoId },
+        {
+          ...WARMING_LIFECYCLE,
+          labels: {
+            "eva.managed": "true",
+            "eva.purpose": "snapshot-warmup",
+            "eva.repoId": args.repoId,
+            "eva.snapshotName": args.seededName,
+          },
+        },
+        args.seededName,
+        undefined,
+        SEEDED_SNAPSHOT_WARM_READY_TIMEOUT_SECONDS,
+      );
+      sandboxId = sandbox.id;
+      await sandbox.delete();
+      sandboxId = null;
+      await ctx.runMutation(
+        internal.repoSnapshots.updateSeededAppWarmupStatus,
+        {
+          buildId: args.buildId,
+          repoId: args.repoId,
+          status: "success",
+        },
+      );
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[warm ${args.repoId}] warmed ${args.seededName}\n`,
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      await ctx.runMutation(
+        internal.repoSnapshots.updateSeededAppWarmupStatus,
+        {
+          buildId: args.buildId,
+          repoId: args.repoId,
+          status: "error",
+          error: message,
+        },
+      );
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[warm ${args.repoId}] failed for ${args.seededName}: ${message}\n`,
+      });
+      if (sandboxId) {
+        try {
+          const sandbox = await daytona.get(sandboxId);
+          await sandbox.delete();
+        } catch {
+          // Best-effort cleanup only; the warming lifecycle is ephemeral.
+        }
+      }
     }
     return null;
   },

--- a/packages/backend/convex/snapshotWorkflow.ts
+++ b/packages/backend/convex/snapshotWorkflow.ts
@@ -1,31 +1,71 @@
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { workflow } from "./workflowManager";
+import { isTerminalSnapshotState } from "./_daytona/snapshotStates";
 
 const POLL_DELAY_MS = 30_000;
 const MAX_POLLS = 60; // ~30 minutes at 30s intervals
 
-/** Terminal snapshot states that end the poll loop. */
-const TERMINAL_STATES = ["active", "error", "build_failed"];
+// Detached seed-run poll loop (per app). The whole per-app pipeline (git
+// update, deps/build, daemons, seed, clean stop) runs as ONE detached script on
+// the sandbox (launchSeedRun) so no Convex action ever waits on a slow command
+// — cold docker pulls or readiness waits can take as long as they need. The
+// workflow just polls the script's outcome markers.
+const SEED_RUN_POLL_DELAY_MS = 20_000;
+const MAX_SEED_RUN_POLLS = 150; // ~50 minutes at 20s intervals
+
+// Seeded-snapshot capture poll loop (per app). The capture is triggered
+// without blocking (triggerSeededSnapshot) then polled here across separate
+// steps, so a long DB-volume capture never exceeds Convex's 600s per-action
+// ceiling. We poll the snapshot entity until it reaches "active" (success) or a
+// failure state — see pollSeededSnapshotState for why the sandbox state is not
+// a reliable completion signal.
+const SEED_SNAPSHOT_POLL_DELAY_MS = 15_000;
+const MAX_SEED_SNAPSHOT_POLLS = 240; // ~60 minutes at 15s intervals — captures
+// normally finish in ~6m but have been observed taking 40m+ when the Daytona
+// builder/runner fleet is degraded; the window must outlast a bad day because
+// exhausting it costs the app its seeded refresh for this build.
 
 /**
- * Workflow that orchestrates a full Daytona snapshot build:
- *   0. Delete existing snapshot and wait for removal
- *   1. Kick off the build (non-blocking POST to Daytona API)
- *   2. Poll snapshot state + stream build logs until terminal
- *   3. Complete the build record
+ * Snapshot build workflow — sandbox-native model.
  *
- * Each step is a separate action with its own timeout, so builds
- * that take 15–20 minutes don't hit Convex action limits.
+ * Each app's snapshot is refreshed INSIDE a sandbox booted from its previous
+ * seeded snapshot (warm: toolchain, service docker images, node_modules and
+ * local backends all present), rather than via a separate declarative Image
+ * build:
+ *
+ *   per app, in parallel:
+ *     1. boot a sandbox from the app's previous seeded snapshot
+ *        (fallback: the base Image snapshot when no seeded exists yet)
+ *     2. fetch latest refs (fetchBaseBranch owns git auth)
+ *     3. run ONE detached script: git reset to the build branch → repo build
+ *        commands (fresh deps/artifacts) → launch background daemons → seed
+ *        commands → marker → clean stop; the workflow polls its markers
+ *     4. capture a versioned snapshot (seeded-<repoId>-<buildId>), poll to
+ *        active, swap the repo pointer, then delete the previous snapshot
+ *        (keep-last-good: a failure at any point leaves the old snapshot live)
+ *
+ * Everything a sandbox boot needs is refreshed every build — code, deps, build
+ * artifacts, seeded data — with no separate Image rebuild (~11-15m serial, and
+ * observed 2-4x slower when captures ran concurrently against Daytona's
+ * builder). The declarative Image build remains ONLY as the bootstrap /
+ * toolchain-change path, behind forceImageRebuild (run it when an app has no
+ * seeded snapshot yet, or buildSnapshotImage's tool layers change).
  */
 export const snapshotBuildWorkflow = workflow.define({
   args: {
     buildId: v.id("snapshotBuilds"),
     repoSnapshotId: v.id("repoSnapshots"),
+    // Rebuild the declarative base Image first (bootstrap / toolchain
+    // changes). The nightly cron and Rebuild Now leave this unset.
+    forceImageRebuild: v.optional(v.boolean()),
+    // Operational bootstrap path: seed app snapshots from the base Image
+    // instead of their previous seeded snapshots. Use once when a seeded app
+    // snapshot is too stale to boot its local services cleanly.
+    forceBaseSeed: v.optional(v.boolean()),
   },
   handler: async (step, args) => {
-    // Step 0: Resolve config to get snapshotName/repoId for the delete step.
-    // kickOffSnapshotBuild also resolves config, but we need the names up front.
+    // Resolve config + repo (owner/name/installation drive git fetch auth).
     const config = await step.runQuery(
       internal.repoSnapshots.getRepoSnapshotInternal,
       { repoSnapshotId: args.repoSnapshotId },
@@ -39,58 +79,388 @@ export const snapshotBuildWorkflow = workflow.define({
       });
       return;
     }
-
-    // Step 1: Delete existing snapshot and wait for removal to finish
-    await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
-      snapshotName: config.snapshotName,
+    const repo = await step.runQuery(internal.repoSnapshots.getRepo, {
       repoId: config.repoId,
-      buildId: args.buildId,
     });
-
-    // Step 2: Resolve config, POST to Daytona to start the build
-    const kickOffResult = await step.runAction(
-      internal.snapshotActions.kickOffSnapshotBuild,
-      {
-        buildId: args.buildId,
-        repoSnapshotId: args.repoSnapshotId,
-      },
-    );
-
-    // If kick-off failed, it already called completeBuild with error — stop
-    if (!kickOffResult) return;
-
-    const { snapshotName, repoId } = kickOffResult;
-
-    // Step 3: Poll snapshot state + stream logs until terminal state
-    let attempt = 0;
-    let state = "";
-    while (attempt < MAX_POLLS) {
-      attempt++;
-
-      const pollResult = await step.runAction(
-        internal.snapshotActions.pollSnapshotProgress,
-        {
-          buildId: args.buildId,
-          snapshotName,
-          repoId,
-          attempt,
-        },
-        { runAfter: attempt === 1 ? 10_000 : POLL_DELAY_MS },
-      );
-
-      state = pollResult;
-
-      if (TERMINAL_STATES.includes(state)) break;
-    }
-
-    // Step 4: Finalize — if we exhausted polls without terminal state, mark timeout
-    if (!TERMINAL_STATES.includes(state)) {
+    if (!repo) {
       await step.runMutation(internal.repoSnapshots.completeBuild, {
         buildId: args.buildId,
         status: "error",
-        logs: `Max poll attempts (${MAX_POLLS}) reached.\n`,
-        error:
-          "Snapshot build did not complete within polling window (~30 minutes)",
+        logs: "",
+        error: "GitHub repo not found",
+      });
+      return;
+    }
+    const branch = config.workflowRef ?? "main";
+
+    const apps = await step.runQuery(
+      internal.repoSnapshots.getSeedableAppRepos,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+
+    try {
+      await step.runAction(internal.snapshotActions.sweepSeedPrepSandboxes, {
+        repoId: config.repoId,
+        scopedRepoIds: apps.map((app) => app.repoId),
+        buildId: args.buildId,
+      });
+    } catch (e) {
+      await step.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[seed-prep sweep] skipped after error: ${e instanceof Error ? e.message : String(e)}\n`,
+      });
+    }
+
+    // Best-effort cleanup: delete seeded snapshots for siblings that are no
+    // longer seedable (e.g. dropped stopCommands) and clear their stale name.
+    // The per-app chains below only manage snapshots for CURRENTLY seedable
+    // apps, so without this an ex-seedable app's seeded-<repoId> would linger
+    // in Daytona forever. A failed cleanup must not fail the build.
+    const orphans = await step.runQuery(
+      internal.repoSnapshots.getOrphanedSeededApps,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+    for (const orphan of orphans) {
+      try {
+        await step.runAction(internal.snapshotActions.deleteDaytonaSnapshot, {
+          snapshotName: orphan.seededSnapshotName,
+          repoId: orphan.repoId,
+        });
+        await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
+          repoId: orphan.repoId,
+          seededSnapshotName: null,
+        });
+        console.log(
+          `[snapshot] cleaned up orphaned seeded snapshot ${orphan.seededSnapshotName} (repo ${orphan.repoId} no longer seedable)`,
+        );
+      } catch (e) {
+        console.error(
+          `[snapshot] failed to clean up orphaned seeded snapshot ${orphan.seededSnapshotName}: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      }
+    }
+
+    // Bootstrap / toolchain path: rebuild the declarative base Image first
+    // (serial — captures contending with the Image builder slow both down).
+    if (args.forceImageRebuild) {
+      await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
+        snapshotName: config.snapshotName,
+        repoId: config.repoId,
+        buildId: args.buildId,
+      });
+      const kickOffResult = await step.runAction(
+        internal.snapshotActions.kickOffSnapshotBuild,
+        { buildId: args.buildId, repoSnapshotId: args.repoSnapshotId },
+      );
+      // Kick-off failure already recorded completeBuild(error).
+      if (!kickOffResult) return;
+      let attempt = 0;
+      let state = "";
+      while (attempt < MAX_POLLS) {
+        attempt++;
+        state = await step.runAction(
+          internal.snapshotActions.pollSnapshotProgress,
+          {
+            buildId: args.buildId,
+            snapshotName: kickOffResult.snapshotName,
+            repoId: kickOffResult.repoId,
+            attempt,
+          },
+          { runAfter: attempt === 1 ? 10_000 : POLL_DELAY_MS },
+        );
+        if (isTerminalSnapshotState(state)) break;
+      }
+      if (state !== "active") {
+        // pollSnapshotProgress recorded the error terminal states; timeouts
+        // need recording here. Either way there is no bootable image to seed
+        // from, so stop.
+        if (!isTerminalSnapshotState(state)) {
+          await step.runMutation(internal.repoSnapshots.completeBuild, {
+            buildId: args.buildId,
+            status: "error",
+            logs: `Max poll attempts (${MAX_POLLS}) reached.\n`,
+            error:
+              "Snapshot build did not complete within polling window (~30 minutes)",
+          });
+        }
+        return;
+      }
+    } else {
+      await step.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: args.forceBaseSeed
+          ? `Sandbox-native build: updating + reseeding ${apps.length} app(s) from the base Image (branch: ${branch}).\n`
+          : `Sandbox-native build: updating + reseeding ${apps.length} app(s) from their previous seeded snapshots (branch: ${branch}).\n`,
+      });
+    }
+
+    // Whether the base Image exists (fallback boot source for apps that have
+    // no seeded snapshot yet).
+    const imageState = await step.runAction(
+      internal.snapshotActions.pollSeededSnapshotState,
+      { repoId: config.repoId, seededName: config.snapshotName },
+    );
+
+    // Per-app pipeline. Versioned capture name (buildId is unique per build):
+    // the previous seeded snapshot stays LIVE and untouched until the
+    // replacement is active, so a failed build never costs an app its warm
+    // snapshot — sandboxes keep booting from the old one and the next build
+    // warm-boots from it. Only after a successful swap is the old snapshot
+    // deleted (keep-last-good).
+    const runSeedChain = async (
+      app: (typeof apps)[number],
+    ): Promise<boolean> => {
+      const seededName = `seeded-${app.repoId}-${args.buildId}`;
+      let prepSandboxId: string | null = null;
+      try {
+        // Mark this app as actively seeding so the UI shows a spinner until
+        // it resolves to seeded/fallback below.
+        await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+          buildId: args.buildId,
+          repoId: app.repoId,
+          status: "running",
+          seededSnapshotName: null,
+        });
+        // Boot source cascade: previous seeded snapshot (warm: toolchain +
+        // service images + deps all present) → base Image (bootstrap). The
+        // retry/backoff absorbs runner propagation lag on fresh snapshots.
+        const sources = [
+          ...(app.seededSnapshotName && args.forceBaseSeed !== true
+            ? [app.seededSnapshotName]
+            : []),
+          ...(imageState === "active" ? [config.snapshotName] : []),
+        ];
+        if (sources.length === 0) {
+          throw new Error(
+            `No boot source for ${app.repoId}: no previous seeded snapshot and no base Image — run forceImageRebuild to bootstrap`,
+          );
+        }
+        for (const source of sources) {
+          try {
+            const created = await step.runAction(
+              internal.snapshotActions.createSeedPrepSandbox,
+              { repoId: app.repoId, imageSnapshot: source },
+              { retry: { maxAttempts: 4, initialBackoffMs: 15000, base: 2 } },
+            );
+            prepSandboxId = created.sandboxId;
+            console.log(
+              `[snapshot] booted seed sandbox for ${app.repoId} from ${source}`,
+            );
+            break;
+          } catch (e) {
+            console.error(
+              `[snapshot] boot from ${source} failed for ${app.repoId}: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
+            );
+          }
+        }
+        if (!prepSandboxId) {
+          throw new Error(
+            `Could not boot a seed sandbox for ${app.repoId} from any source`,
+          );
+        }
+        // Fresh refs for the detached script's hard reset (owns git auth).
+        await step.runAction(
+          internal.daytona.fetchBaseBranch,
+          {
+            sandboxId: prepSandboxId,
+            installationId: repo.installationId,
+            repoOwner: repo.owner,
+            repoName: repo.name,
+            baseBranch: branch,
+            repoId: app.repoId,
+          },
+          { retry: { maxAttempts: 3, initialBackoffMs: 10000, base: 2 } },
+        );
+        // Launch the whole pipeline detached; poll its outcome markers. The
+        // launch is idempotent (live-process guard), so retries can't race a
+        // second copy of the script.
+        await step.runAction(
+          internal.snapshotActions.launchSeedRun,
+          {
+            sandboxId: prepSandboxId,
+            repoId: app.repoId,
+            branch,
+            buildCommands: config.buildCommands ?? [],
+          },
+          { retry: { maxAttempts: 3, initialBackoffMs: 10000, base: 2 } },
+        );
+        let seedState = "running";
+        for (
+          let pollAttempt = 1;
+          pollAttempt <= MAX_SEED_RUN_POLLS && seedState === "running";
+          pollAttempt++
+        ) {
+          seedState = await step.runAction(
+            internal.snapshotActions.pollSeedRun,
+            { sandboxId: prepSandboxId, repoId: app.repoId },
+            { runAfter: SEED_RUN_POLL_DELAY_MS },
+          );
+        }
+        if (seedState !== "done") {
+          // Grab the seed-run + daemon logs into the build record BEFORE the
+          // catch tears the sandbox down — teardown destroys the evidence.
+          const diagnostics = await step.runAction(
+            internal.snapshotActions.fetchSeedDiagnostics,
+            { sandboxId: prepSandboxId, repoId: app.repoId },
+          );
+          await step.runMutation(internal.repoSnapshots.appendLogs, {
+            buildId: args.buildId,
+            chunk: `[seed ${app.repoId}] FAILED (${seedState}) — diagnostics:\n${diagnostics}\n`,
+          });
+          throw new Error(
+            `Seed run for ${app.repoId} did not complete (state: ${seedState})`,
+          );
+        }
+        // Capture the refreshed filesystem snapshot. Trigger fires the POST
+        // without blocking; poll across separate steps so a long DB capture
+        // never exceeds Convex's 600s per-action ceiling.
+        await step.runAction(internal.snapshotActions.triggerSeededSnapshot, {
+          repoId: app.repoId,
+          sandboxId: prepSandboxId,
+          seededName,
+        });
+        let snapState = "pending";
+        for (
+          let pollAttempt = 1;
+          pollAttempt <= MAX_SEED_SNAPSHOT_POLLS &&
+          !isTerminalSnapshotState(snapState);
+          pollAttempt++
+        ) {
+          snapState = await step.runAction(
+            internal.snapshotActions.pollSeededSnapshotState,
+            { repoId: app.repoId, seededName },
+            {
+              runAfter:
+                pollAttempt === 1 ? 10_000 : SEED_SNAPSHOT_POLL_DELAY_MS,
+            },
+          );
+        }
+        if (snapState !== "active") {
+          throw new Error(
+            `Seeded snapshot for ${app.repoId} did not reach active (last state: ${snapState})`,
+          );
+        }
+        await step.runAction(internal.daytona.deleteSandbox, {
+          sandboxId: prepSandboxId,
+          repoId: app.repoId,
+        });
+        prepSandboxId = null;
+        // SWAP: point the repo at the new snapshot, then (best-effort) delete
+        // the previous one. New sandboxes cut over atomically; a failed delete
+        // just leaves a stray snapshot that the next successful build removes.
+        await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
+          repoId: app.repoId,
+          seededSnapshotName: seededName,
+        });
+        await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+          buildId: args.buildId,
+          repoId: app.repoId,
+          status: "seeded",
+          seededSnapshotName: seededName,
+        });
+        try {
+          await step.runMutation(
+            internal.repoSnapshots.updateSeededAppWarmupStatus,
+            {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              status: "pending",
+            },
+          );
+          await step.runAction(
+            internal.snapshotActions.warmSeededSnapshotCache,
+            {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              seededName,
+            },
+          );
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          await step.runMutation(
+            internal.repoSnapshots.updateSeededAppWarmupStatus,
+            {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              status: "error",
+              error: message,
+            },
+          );
+          await step.runMutation(internal.repoSnapshots.appendLogs, {
+            buildId: args.buildId,
+            chunk: `[warm ${app.repoId}] skipped after error: ${message}\n`,
+          });
+        }
+        if (app.seededSnapshotName && app.seededSnapshotName !== seededName) {
+          try {
+            await step.runAction(
+              internal.snapshotActions.deleteDaytonaSnapshot,
+              {
+                snapshotName: app.seededSnapshotName,
+                repoId: app.repoId,
+              },
+            );
+          } catch (e) {
+            console.error(
+              `[snapshot] failed to delete previous seeded snapshot ${app.seededSnapshotName}: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
+            );
+          }
+        }
+        return true;
+      } catch (e) {
+        console.error(
+          `[snapshot] seeded build failed for ${app.repoId}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        // Tear down the prep sandbox so it doesn't linger.
+        if (prepSandboxId) {
+          await step.runAction(internal.daytona.deleteSandbox, {
+            sandboxId: prepSandboxId,
+            repoId: app.repoId,
+          });
+        }
+        // Best-effort: remove the partial/orphaned versioned capture if the
+        // trigger fired before the failure (no-op when it never registered).
+        try {
+          await step.runAction(internal.snapshotActions.deleteDaytonaSnapshot, {
+            snapshotName: seededName,
+            repoId: app.repoId,
+          });
+        } catch {
+          // ignore — snapshot may not exist
+        }
+        // The repo keeps its PREVIOUS seededSnapshotName (untouched above), so
+        // sandboxes continue booting from the last good seeded snapshot.
+        await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+          buildId: args.buildId,
+          repoId: app.repoId,
+          status: "fallback",
+          seededSnapshotName: app.seededSnapshotName,
+        });
+        return false;
+      }
+    };
+
+    const results = await Promise.all(apps.map((app) => runSeedChain(app)));
+
+    // Finalize the build record (the forceImageRebuild path already recorded
+    // the image outcome; per-app outcomes live in seededApps either way).
+    if (!args.forceImageRebuild) {
+      const succeeded = results.filter(Boolean).length;
+      await step.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: succeeded === apps.length ? "success" : "error",
+        logs: `Sandbox-native build finished: ${succeeded}/${apps.length} app snapshot(s) refreshed.\n`,
+        ...(succeeded === apps.length
+          ? {}
+          : {
+              error: `${apps.length - succeeded} app snapshot(s) fell back to their previous seeded snapshot — see per-app diagnostics in the logs`,
+            }),
       });
     }
   },


### PR DESCRIPTION
## Purpose

Reviewable archive of the **seeded running-sandbox** work reverted from `main` in 1a20b561. This branch re-applies that work as a single forward commit on top of the reverted `main`, so the full diff is browsable. Kept as **draft** — **do not merge as-is** (merging re-applies the whole experiment and undoes the revert).

The pre-revert tip is also preserved verbatim on branch `revisit/seeded-snapshots` (cb9da2f3).

## Why it was reverted

Unstable in prod:
- Build times regressed past 30m (declarative was ~15m).
- Sandboxes leaked from create-ready timeouts ("No available runners").
- eproc's local Convex backend failed to bind `127.0.0.1:3210` on warm boot from an old seeded snapshot (suspected Convex version drift) — sole unresolved functional blocker; web reached ~11m fresh.

## What's here (vs the reverted declarative base)

- Per-app seeded running-sandbox snapshots (`seeded-<repoId>-<buildId>`) baking the seeded DB into Daytona filesystem snapshots.
- Sandbox-native build model (boot previous seeded snapshot → reset → build → seed → capture); non-blocking trigger+poll capture.
- `stopCommands`, `seededFingerprint`, `imageFingerprint`, widened `seededApps` schema; warmup UI; seed-prep sandbox labelling + sweep.

## Before any future retry / deploy of the reverted main

Prod docs written during the experiment carry fields the reverted schema no longer declares (`seededFingerprint`, `imageFingerprint`, `stopCommands`, widened `seededApps`). A data-strip migration must run **before** `npx convex deploy`, or schema validation rejects.

Origin: PRs #402 (observability/reliability) + #403 (warmup removal) + follow-up sandbox-native rewrite. Branch `feat/seeded-running-snapshots` also retained.