### PR TITLE
[PRESERVED #402/2 · DO NOT MERGE] Seeded running-sandbox snapshots — pipeline

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/settings/AppClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/AppClient.tsx
@@ -30,6 +30,7 @@ export function AppClient() {
 
   const startupCommands = repo.startupCommands?.join("\n") ?? "";
   const backgroundCommands = repo.backgroundCommands?.join("\n") ?? "";
+  const stopCommands = repo.stopCommands?.join("\n") ?? "";
 
   const handleDevPortBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const raw = e.target.value.trim();
@@ -67,6 +68,12 @@ export function AppClient() {
     const next = e.target.value;
     if (next === backgroundCommands) return;
     updateConfig({ repoId, backgroundCommands: parseCommandLines(next) });
+  };
+
+  const handleStopCommandsBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    const next = e.target.value;
+    if (next === stopCommands) return;
+    updateConfig({ repoId, stopCommands: parseCommandLines(next) });
   };
 
   const handleSystemPromptBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
@@ -154,9 +161,11 @@ export function AppClient() {
               placeholder="npx supabase start&#10;psql -h localhost -p 54322 -U postgres -d postgres < /home/eva/sandbox-config/seed.sql"
             />
             <p className="mt-1 text-[11px] text-muted-foreground">
-              One command per line. Runs once when sandbox first starts (after
-              snapshot loads). Use for services like <code>supabase start</code>{" "}
-              or database seeding. Commands have a 10-minute timeout each.
+              One command per line. Runs <strong>once</strong> per sandbox (a
+              marker is left, so it is skipped on resume and baked into a seeded
+              snapshot). Use for one-time data <strong>seeding</strong> that
+              depends on services being up — put the services themselves in
+              Background Commands. Commands have a 10-minute timeout each.
             </p>
           </div>
         </div>
@@ -182,6 +191,27 @@ export function AppClient() {
               redirect. Commands respawn every time the sandbox starts or
               resumes. Use for daemons like <code>npx convex dev</code>. Output
               is written to <code>/tmp/bg-&lt;index&gt;.log</code>.
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
+          <h3 className="text-sm font-medium">Stop Commands</h3>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Clean-shutdown commands run before snapshotting a seeded sandbox
+            </label>
+            <textarea
+              key={`stop-${repoId}`}
+              defaultValue={stopCommands}
+              onBlur={handleStopCommandsBlur}
+              className="w-full h-32 rounded-md bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="pkill -TERM -f 'convex dev'&#10;pnpm stop-db"
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              One command per line. Run by the seeded-snapshot build before the
+              filesystem snapshot is taken, so on-disk volumes (e.g. local
+              Postgres) flush consistently. Not run on normal sandbox starts.
             </p>
           </div>
         </div>

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/components/CronScheduleCard";
 import {
   IconCamera,
+  IconCheck,
   IconPlayerPlay,
   IconTrash,
   IconUpload,
@@ -35,11 +36,7 @@ import {
 import { formatDurationMs } from "@conductor/shared/duration";
 import { parseCommandLines, formatFileSize } from "./_utils";
 import { RebuildRequiredWarning } from "./_components/RebuildRequiredWarning";
-import {
-  BuildRow,
-  BuildStatusBadge,
-  WarmupStatusBadge,
-} from "./_components/BuildRow";
+import { BuildRow, BuildStatusBadge } from "./_components/BuildRow";
 
 export function SnapshotsClient({
   activeTab,
@@ -51,6 +48,10 @@ export function SnapshotsClient({
   const snapshot = useQuery(api.repoSnapshots.getRepoSnapshot, { repoId });
   const builds = useQuery(
     api.repoSnapshots.listBuilds,
+    snapshot ? { repoSnapshotId: snapshot._id } : "skip",
+  );
+  const seededApps = useQuery(
+    api.repoSnapshots.getSeededAppStatus,
     snapshot ? { repoSnapshotId: snapshot._id } : "skip",
   );
   const saveRepoSnapshot = useMutation(api.repoSnapshots.saveRepoSnapshot);
@@ -123,6 +124,16 @@ export function SnapshotsClient({
   const isRunning =
     builds && builds.length > 0 && builds[0].status === "running";
   const lastBuild = builds && builds.length > 0 ? builds[0] : null;
+  // Base image is marked success before Step 5 seeding runs, so "in progress"
+  // must also cover an ongoing seed (any app still in the "running" state).
+  const isSeeding = (lastBuild?.seededApps ?? []).some(
+    (a) => a.status === "running",
+  );
+  const seedingRepoIds = new Set(
+    (lastBuild?.seededApps ?? [])
+      .filter((a) => a.status === "running")
+      .map((a) => a.repoId),
+  );
 
   const handleSnapshotsTabChange = useCallback(
     (value: string) => {
@@ -259,75 +270,124 @@ export function SnapshotsClient({
 
         <TabsContent value="status" className="space-y-6">
           {snapshot ? (
-            <div className="rounded-surface border border-border bg-card p-4 space-y-3">
-              <h3 className="text-sm font-medium">Current Status</h3>
-              <div className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2 sm:gap-4">
-                <div>
-                  <span className="text-muted-foreground">Snapshot Name</span>
-                  <p className="font-mono mt-0.5">{snapshot.snapshotName}</p>
+            <>
+              <div className="rounded-surface border border-border bg-card p-4 space-y-3">
+                <h3 className="text-sm font-medium">Current Status</h3>
+                <div className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2 sm:gap-4">
+                  <div>
+                    <span className="text-muted-foreground">Snapshot Name</span>
+                    <p className="font-mono mt-0.5">{snapshot.snapshotName}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Schedule</span>
+                    <p className="mt-0.5">
+                      {snapshot.schedule === "manual"
+                        ? "Manual"
+                        : (() => {
+                            const result = describeCron(snapshot.schedule);
+                            return result.valid
+                              ? result.text
+                              : snapshot.schedule;
+                          })()}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Clone Branch</span>
+                    <p className="font-mono mt-0.5">
+                      {snapshot.workflowRef ?? "main"}
+                    </p>
+                  </div>
+                  {lastBuild && (
+                    <>
+                      <div>
+                        <span className="text-muted-foreground">
+                          Last Build
+                        </span>
+                        <p className="mt-0.5">
+                          {new Date(lastBuild.startedAt).toLocaleDateString(
+                            "en-GB",
+                            {
+                              day: "numeric",
+                              month: "short",
+                              year: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                            },
+                          )}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Status</span>
+                        <p className="mt-0.5">
+                          <BuildStatusBadge status={lastBuild.status} />
+                        </p>
+                      </div>
+                    </>
+                  )}
                 </div>
-                <div>
-                  <span className="text-muted-foreground">Schedule</span>
-                  <p className="mt-0.5">
-                    {snapshot.schedule === "manual"
-                      ? "Manual"
-                      : (() => {
-                          const result = describeCron(snapshot.schedule);
-                          return result.valid ? result.text : snapshot.schedule;
-                        })()}
+                <Button
+                  size="sm"
+                  onClick={handleRebuild}
+                  disabled={building || isRunning || isSeeding}
+                >
+                  {building || isRunning || isSeeding ? (
+                    <Spinner size="sm" className="mr-1.5" />
+                  ) : (
+                    <IconPlayerPlay size={14} className="mr-1.5" />
+                  )}
+                  {building || isRunning
+                    ? "Building..."
+                    : isSeeding
+                      ? "Seeding..."
+                      : "Rebuild Now"}
+                </Button>
+              </div>
+              <div className="rounded-lg bg-muted/40 p-4 space-y-3">
+                <h3 className="text-sm font-medium">Seeded Snapshots</h3>
+                <p className="text-xs text-muted-foreground">
+                  Per-app running-sandbox snapshots with the DB already seeded.
+                  Apps without one fall back to the base Image (slower cold
+                  start).
+                </p>
+                {seededApps === undefined ? (
+                  <p className="text-xs text-muted-foreground">Loading…</p>
+                ) : seededApps.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No seedable apps for this snapshot.
                   </p>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Clone Branch</span>
-                  <p className="font-mono mt-0.5">
-                    {snapshot.workflowRef ?? "main"}
-                  </p>
-                </div>
-                {lastBuild && (
-                  <>
-                    <div>
-                      <span className="text-muted-foreground">Last Build</span>
-                      <p className="mt-0.5">
-                        {new Date(lastBuild.startedAt).toLocaleDateString(
-                          "en-GB",
-                          {
-                            day: "numeric",
-                            month: "short",
-                            year: "numeric",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          },
+                ) : (
+                  <div className="space-y-2 text-xs">
+                    {seededApps.map((app) => (
+                      <div
+                        key={app.repoId}
+                        className="flex items-start justify-between gap-3"
+                      >
+                        <span className="font-medium shrink-0">
+                          {app.app ?? app.name}
+                        </span>
+                        {seedingRepoIds.has(app.repoId) ? (
+                          <span className="inline-flex shrink-0 items-center gap-1 text-blue-500">
+                            <Spinner size="sm" />
+                            Seeding…
+                          </span>
+                        ) : app.seededSnapshotName ? (
+                          <span className="inline-flex min-w-0 items-start gap-1 text-green-500">
+                            <IconCheck size={12} className="mt-0.5 shrink-0" />
+                            <span className="min-w-0 font-mono break-all">
+                              {app.seededSnapshotName}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className="shrink-0 text-muted-foreground">
+                            Using base Image
+                          </span>
                         )}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Status</span>
-                      <p className="mt-0.5">
-                        <BuildStatusBadge status={lastBuild.status} />
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Warmup</span>
-                      <p className="mt-0.5">
-                        <WarmupStatusBadge status={lastBuild.warmupStatus} />
-                      </p>
-                    </div>
-                  </>
+                      </div>
+                    ))}
+                  </div>
                 )}
               </div>
-              <Button
-                size="sm"
-                onClick={handleRebuild}
-                disabled={building || isRunning}
-              >
-                {isRunning ? (
-                  <Spinner size="sm" className="mr-1.5" />
-                ) : (
-                  <IconPlayerPlay size={14} className="mr-1.5" />
-                )}
-                {isRunning ? "Building..." : "Rebuild Now"}
-              </Button>
-            </div>
+            </>
           ) : (
             <div className="rounded-surface border border-border bg-card p-8 text-center">
               <p className="text-sm text-muted-foreground">
@@ -355,7 +415,7 @@ export function SnapshotsClient({
                       </th>
                       <th className="px-2 py-2 font-medium sm:px-4">Trigger</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Status</th>
-                      <th className="px-2 py-2 font-medium sm:px-4">Warmup</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">Seeded</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
@@ -4,8 +4,21 @@ import {
   IconChevronDown,
   IconChevronRight,
   IconClock,
+  IconLoader2,
   IconX,
 } from "@tabler/icons-react";
+
+type SeededAppResult = {
+  repoId: Id<"githubRepos">;
+  app?: string;
+  status?: "running" | "seeded" | "fallback";
+  seededSnapshotName: string | null;
+};
+
+/** A per-app entry counts as seeded by explicit status, or (legacy rows) by name. */
+function isSeededEntry(a: SeededAppResult): boolean {
+  return a.status ? a.status === "seeded" : a.seededSnapshotName !== null;
+}
 
 export function BuildRow({
   build,
@@ -21,8 +34,7 @@ export function BuildRow({
     error?: string;
     startedAt: number;
     completedAt?: number;
-    warmupStatus?: "pending" | "success" | "error";
-    warmupError?: string;
+    seededApps?: SeededAppResult[];
   };
   isExpanded: boolean;
   duration: string;
@@ -52,7 +64,7 @@ export function BuildRow({
           <BuildStatusBadge status={build.status} />
         </td>
         <td className="px-2 py-2 sm:px-4">
-          <WarmupStatusBadge status={build.warmupStatus} />
+          <SeededSummary seededApps={build.seededApps} />
         </td>
       </tr>
       {isExpanded && (
@@ -63,13 +75,42 @@ export function BuildRow({
                 {build.error}
               </div>
             )}
-            {build.warmupError && (
-              <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                Warmup failed: {build.warmupError}
+            {build.seededApps && build.seededApps.length > 0 && (
+              <div className="mb-2 space-y-1 text-xs">
+                {build.seededApps.map((a) => (
+                  <div key={a.repoId} className="flex items-start gap-2">
+                    {a.status === "running" ? (
+                      <span className="inline-flex items-center gap-1 text-blue-500">
+                        <IconLoader2
+                          size={12}
+                          className="shrink-0 animate-spin"
+                        />
+                        {a.app ?? a.repoId} — seeding…
+                      </span>
+                    ) : a.seededSnapshotName ? (
+                      <>
+                        <span className="inline-flex shrink-0 items-center gap-1 text-green-500">
+                          <IconCheck size={12} className="shrink-0" />
+                          {a.app ?? a.repoId}
+                        </span>
+                        <span className="min-w-0 font-mono break-all text-muted-foreground">
+                          {a.seededSnapshotName}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="inline-flex items-start gap-1 text-muted-foreground">
+                        <IconX size={12} className="mt-0.5 shrink-0" />
+                        <span className="break-words">
+                          {a.app ?? a.repoId} — fell back to base Image
+                        </span>
+                      </span>
+                    )}
+                  </div>
+                ))}
               </div>
             )}
             {build.logs ? (
-              <pre className="max-h-64 overflow-auto rounded bg-muted/50 p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap sm:p-3 sm:text-[11px]">
+              <pre className="max-h-64 overflow-y-auto overflow-x-hidden rounded bg-muted/50 p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap break-all sm:p-3 sm:text-[11px]">
                 {build.logs}
               </pre>
             ) : (
@@ -113,34 +154,31 @@ export function BuildStatusBadge({
   );
 }
 
-export function WarmupStatusBadge({
-  status,
-}: {
-  status?: "pending" | "success" | "error";
-}) {
-  if (!status) {
+/** Compact per-build seeding summary: seeded/total, coloured by completeness. */
+function SeededSummary({ seededApps }: { seededApps?: SeededAppResult[] }) {
+  if (!seededApps || seededApps.length === 0) {
     return <span className="text-muted-foreground">&mdash;</span>;
   }
-  if (status === "pending") {
+  const total = seededApps.length;
+  const seeded = seededApps.filter(isSeededEntry).length;
+  // Still seeding: show a spinner with progress so far.
+  if (seededApps.some((a) => a.status === "running")) {
     return (
       <span className="inline-flex items-center gap-1 text-blue-500">
-        <IconClock size={12} />
-        Pending
+        <IconLoader2 size={12} className="animate-spin" />
+        {seeded}/{total}
       </span>
     );
   }
-  if (status === "success") {
-    return (
-      <span className="inline-flex items-center gap-1 text-success">
-        <IconCheck size={12} />
-        Warmed
-      </span>
-    );
-  }
+  const color =
+    seeded === total
+      ? "text-green-500"
+      : seeded === 0
+        ? "text-destructive"
+        : "text-amber-500";
   return (
-    <span className="inline-flex items-center gap-1 text-destructive">
-      <IconX size={12} />
-      Failed
+    <span className={`inline-flex items-center gap-1 ${color}`}>
+      {seeded}/{total}
     </span>
   );
 }

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Seeded-snapshot capture polling fix - 2026-05-31
+
+- Fixed seeded-snapshot filesystem capture timeouts by switching from a blocking SDK call to non-blocking trigger-and-poll, preventing silent fallback to the base image when DB volumes exceed the 600s Convex action ceiling.
+
+## Seeded running-sandbox snapshots for fast cold starts - 2026-05-31
+
+- Bake the seeded local database into per-app Daytona filesystem snapshots so new sandboxes skip the ~10-minute Supabase and Convex seed on every start.
+- Added per-app Stop Commands to app settings, and clarified Startup commands (seed, run once) versus Background commands (services, run every start).
+- Sandbox prep now runs background services before startup commands so seeding has its dependencies available; sandboxes prefer the app's seeded snapshot when one exists.
+
+## Seeded-snapshot reliability and observability - 2026-05-31
+
+- Gate per-app seeding on a base-image propagation probe so seeding only starts once the freshly built snapshot is actually bootable, fixing "No available runners" failures and silent fallbacks to the base image.
+- Surface per-app seeding outcomes in snapshot settings: the status tab shows each app's current state (seeded with snapshot name, or using the base image), and build history shows per-build results as a seeded/total count with per-app detail on expand.
+- Removed the snapshot-cache warmup pass (now redundant with the propagation probe, which also warms the runner cache) and cleared its orphaned fields from existing build records.
+
 ## Sandbox chats surface in the sessions sidebar - 2026-07-02
 
 - Project sandbox chats and quick-task sandbox chats now appear in the sessions sidebar as virtual entries whenever they have at least one message, interleaved with real sessions by last activity, so ongoing conversations are reachable from one place instead of buried in project/task pages.

--- a/internal/plans/todo/running-sandbox-snapshot-seeded-db.md
+++ b/internal/plans/todo/running-sandbox-snapshot-seeded-db.md
@@ -1,0 +1,289 @@
+# Running-sandbox filesystem snapshots (seeded DB baked in)
+
+## Goal
+
+Cut ~10-min cold-start cost. Today the per-repo Daytona snapshot is a **Dockerfile/Image**
+build (clone + `pnpm install` + buildCommands). The DB setup + seed (local Supabase + Convex
+in Docker-in-Docker, migrate, seed) runs as **startup commands on every sandbox start** — that's
+the 10 min.
+
+New: daily cron produces a **filesystem snapshot of a fully-prepared, DB-seeded running sandbox**,
+so new sandboxes resume with seeded Docker volumes already on disk and skip the seed.
+
+## Key SDK facts (verified)
+
+- `sandbox._experimental_createSnapshot(name, timeout?)` → captures **filesystem only** (not
+  memory/processes). Sandbox enters `snapshotting` then returns to prior state. Returns `Promise<void>`.
+- `daytona.create({ snapshot: name })` consumes it — same call we use today.
+- Endpoints landed in `@daytonaio/sdk` 0.165.0 (14 Apr 2026). We are on **0.143.0** → upgrade required.
+- Method is `_experimental_`-prefixed (unstable name) but **docs show no region gating**. The
+  "experimental region" in the announcement is for _memory_ pause/resume — not needed here.
+
+## Why filesystem-only is the right fit
+
+Docker-in-Docker stores Postgres/Convex data under `/var/lib/docker`. A filesystem snapshot
+captures it **iff the data is flushed + consistent at snapshot time**. So: seed → **cleanly stop
+DB containers** (Postgres checkpoint/flush) → snapshot. Memory state is irrelevant; on resume we
+just restart containers against the existing volumes — no re-seed.
+
+## Architecture: AUGMENT the existing Image build (revised — simplest path)
+
+The existing per-repo Image already bakes a perfect boot base: toolchain (node, docker, chrome, VNC,
+CLIs, claude plugins, supabase/convex CLI) + clone + deps + buildCommands + uploaded config files
+(`/home/eva/sandbox-config/`, incl. `data.sql` / `carepulse-staging-backup.zip`). **Keep it as-is.**
+
+Add ONE new stage to the cron, after the Image is `active`:
+
+1. Boot a sandbox from the per-repo Image.
+2. Run `startupCommands` (services up) → `seedCommands` (the ~10-min seed, once).
+3. Run `stopCommands` (clean-stop) so volumes flush.
+4. `sandbox._experimental_createSnapshot(seededSnapshotName)` — captures the full filesystem incl.
+   seeded Docker volumes.
+5. Delete the prep sandbox.
+
+Sandboxes then `daytona.create({ snapshot: seededSnapshotName })` — a self-contained filesystem with
+the seeded DB on disk. The Image is only a build-time base.
+
+Why this over the earlier "replace / two-layer split": no separate global base-toolchain image to
+build or scope; reuses ALL existing code (Image build, config files, delete-existing, cron, UI);
+strictly smaller surface. The seeded snapshot uses a distinct name (e.g. `snapshot-<repoId>-seeded`)
+so it doesn't collide with the Image name it booted from; the cron deletes the prior seeded snapshot
+each run → latest-only (matches the daily 24 h retention).
+
+## Config model — split today's single startup-commands blob
+
+Today `settings/app` has ONE "Startup commands" list, run on every start. The seed steps depend on
+services being up, so they interleave — but they split into two **ordered phases** (startup brings
+services up; seed runs after). Introduce on `githubRepos` (settings/app UI):
+
+- **`startupCommands`** (repurpose existing) — bring services up. Run on EVERY start incl. warm
+  restore from a seeded snapshot.
+- **`seedCommands`** (new) — data load. Run ONCE during snapshot build, after startup. Baked in.
+- **`stopCommands`** (new) — clean shutdown before snapshot, so on-disk data is consistent.
+
+### carepulse-ts mapping (current commands, re-split)
+
+```
+# startupCommands (always; carepulse)
+pnpm start-db                                   # supabase start — reuses seeded volumes on warm restore
+cd apps/web && (nohup env CONVEX_AGENT_MODE=anonymous npx convex dev > /tmp/convex.log 2>&1 &) \
+  && for i in $(seq 1 120); do grep -q "Convex functions ready" /tmp/convex.log && break; sleep 2; done \
+  && (grep -q "Convex functions ready" /tmp/convex.log || (tail -80 /tmp/convex.log && exit 1))
+
+# seedCommands (once, during build, after startup)
+cp data.sql packages/db/data.sql
+cp carepulse-staging-backup.zip apps/web/carepulse-staging-backup.zip
+rm -f data.sql carepulse-staging-backup.zip
+pnpm seed:sql                                   # seeds postgres (volume captured by snapshot)
+cd apps/web && npx convex import carepulse-staging-backup.zip
+cd apps/web && npx convex env set BASE_APP_URL http://localhost:3000
+cd apps/web && npx convex env set NEXT_PUBLIC_API_URL https://staging.carepulse.co.uk
+touch /home/eva/.db-seeded
+
+# stopCommands (clean shutdown before _experimental_createSnapshot)
+pkill -TERM -f "convex dev" 2>/dev/null || true            # flush convex local backend (sqlite)
+pkill -TERM -f "convex-local-backend" 2>/dev/null || true
+sleep 3
+pnpm stop-db                                                # supabase stop — retains seeded volumes
+```
+
+Note: `convex env set` values persist in the local backend store (captured) → no re-run on resume.
+The `.db-seeded` marker (captured) lets cold/no-snapshot starts know whether to seed.
+
+## Build flow (cron — existing Image build, then a NEW seed-snapshot stage)
+
+Existing steps unchanged: delete old Image → `kickOffSnapshotBuild` (Dockerfile) → poll until
+`active`. Then add the new stage as further workflow steps:
+
+1. Delete prior seeded snapshot (`snapshot-<repoId>-seeded`) — reuse `deleteExistingSnapshot` logic.
+2. `daytona.create({ snapshot: <repo Image> })` (warming/ephemeral lifecycle, disk 10 GB).
+3. Start dockerd; run **`startupCommands`** (services up) then **`seedCommands`** (the ~10-min seed,
+   ONCE; ends with `touch /home/eva/.db-seeded`).
+4. Run **`stopCommands`** — clean-stop convex local backend + `supabase stop` so volumes flush
+   consistently. Keep volumes.
+5. `sandbox._experimental_createSnapshot("snapshot-<repoId>-seeded", timeout)`.
+6. `sandbox.delete()` the prep sandbox; record build success.
+7. `getRepoSnapshotName` returns the **seeded** name when its build succeeded, else falls back to the
+   Image name → `createSandbox` picks it up via `daytona.create({ snapshot })`.
+
+Reuse existing `repoSnapshots` / `snapshotBuilds` tables, cron schedule, logs, settings UI, config
+files — add only the seed-snapshot workflow steps + the `seeded` snapshot name + the three command
+fields.
+
+## Resume flow (sandbox created from seeded snapshot — warm-start path)
+
+`createSandboxAndPrepareRepo` already: normalize worktree, sync git, install cred helper, copy config.
+Then the startup path simply runs **`startupCommands` only** (NOT `seedCommands`), because the
+snapshot already carries `.db-seeded` + seeded volumes:
+
+- `pnpm start-db` (supabase start) re-attaches to the seeded Postgres volume.
+- Relaunch `convex dev` (anonymous) → reads the existing seeded local-backend store + env vars.
+- App dev server launches as today (`launchDevServerInBackground`).
+- `ensureDockerDaemon` + eva-entrypoint already restart dockerd on resume.
+
+Cold/no-snapshot fallback path runs `startupCommands` + `seedCommands` (full setup) as today.
+
+**Primary risks to validate in the spike:**
+
+1. `supabase start` re-attaches to existing on-disk volumes after a fresh snapshot create (container
+   IDs/networks gone, volumes remain) — and does NOT re-run migrations/seed over them.
+2. Anonymous `convex dev` reuses the existing local deployment + seeded data (deployment identity is
+   on the snapshotted filesystem) rather than spinning a fresh empty deployment.
+
+## Region decision — DECIDED: stay on default region
+
+No pool migration. Filesystem snapshot/fork are SDK methods available without the experimental
+region. Keep `getDaytona` on the default region; the only prerequisite is the SDK bump. Avoids the
+high blast radius of migrating every call site and orphaning existing default-region `sandboxId`s
+in the DB. (Phase 0 spike still empirically confirms the endpoints work on the default region.)
+
+## Phases
+
+- **Phase 0 — Spike (make-or-break, do first).** Target repo: `carepulse-ts`. Branch-bump SDK
+  ≥0.165.0; confirm `_experimental_createSnapshot`/`_experimental_fork` exist by reading
+  `node_modules/@daytonaio/sdk/dist/*.d.ts`. Manually: boot from base, run startup+seed, clean-stop,
+  `_experimental_createSnapshot`, create new sandbox from it. Verify: (a) seeded Postgres present &
+  `supabase start` does not re-migrate/seed; (b) anonymous `convex dev` reuses seeded deployment;
+  (c) services up in <~1 min vs ~10; (d) snapshot size + restore time acceptable; (e) endpoints work
+  on default region. Decide go/no-go.
+- **Phase 1 — SDK upgrade + breaking-change audit** across all `@daytonaio/sdk` call sites
+  (create/get/start/stop/archive/delete/refreshData, process.executeCommand, fs, git._, volume._,
+  snapshot.\*, Image). Typecheck via `cd packages/backend && npx convex codegen --typecheck enable`.
+- **Phase 2 — Config fields. ✅ DONE (Model A).** Reused existing `startupCommands` (run-once, seed) +
+  `backgroundCommands` (every-start, services); added ONE new field `stopCommands`. Files: schema
+  `_validators/tableFields.ts` (githubRepoFields), `updateConfig` mutation, settings/app `AppClient.tsx`
+  (new Stop Commands section + clarified Startup/Background copy). Also **reordered `prepareSandboxSteps`**
+  so `backgroundCommands` (services) run BEFORE `startupCommands` (seed) — safe because on resume startup
+  is marker-skipped, so background never depends on a same-boot startup. Seeds now self-wait for service
+  readiness (background launches detached). Backend + web typecheck clean.
+  **DB migrated on dev:evalucom (good-mule-506)** — carepulse-ts is a 3-repo monorepo; rebucketed each:
+  web `mh7fdbcr` (supabase+convex), eproc `mh78235g` (convex-only, secrets preserved in-DB), parent
+  `mh7ca667` (supabase-only). Migration done via throwaway `_spike/migrateCommands.ts` (read-transform-
+  write, so secrets never hit source). NOTE: convex-readiness wait greps `/tmp/bg-<index>.log` — index
+  depends on backgroundCommands order (web convex=bg-1, eproc convex=bg-0).
+- **Phase 3 — Seed-snapshot workflow stage. ✅ DONE (per-app model).** After the base Image goes
+  `active`, `snapshotWorkflow.ts` now builds a seeded snapshot for EACH app repo with stopCommands
+  (`getSeedableAppRepos`): boot prep sandbox from the Image (`createSeedPrepSandbox`, explicit Image
+  name to bypass the seeded preference) → `runBackgroundCommands`(services) → `runStartupCommands`(seed)
+  → `runStopCommands`(NEW, clean-stop) → `createSeededSnapshot`(NEW, `_experimental_createSnapshot`,
+  timeout 600) → `deleteSandbox` → `setSeededSnapshotName`. Best-effort: on failure the prep sandbox is
+  deleted and the app falls back to the Image (seededSnapshotName left clear). New schema field
+  `githubRepos.seededSnapshotName`; `getRepoSnapshotName` prefers it. New re-exports in `repoSnapshots.ts`.
+  Backend typechecks clean. Every new code path smoke-tested end-to-end on dev for the web app
+  (chain ran 0-error; getRepoSnapshotName flipped to the seeded name; smoke artifact then cleaned up).
+- **Phase 4 — Warm-start path. ✅ SATISFIED by Phase 2's reorder + the marker.** A sandbox created
+  from a seeded snapshot has the `/tmp/.startup-commands-done` marker baked in, so `runStartupCommands`
+  (seed) is skipped; `runBackgroundCommands` (services) runs every start (now before startup). No
+  separate code needed. Verified end-to-end in Phase 2's verification run.
+
+## Minimised surface
+
+- Schema: add `startupCommands` / `seedCommands` / `stopCommands` to `githubRepos`; seeded build
+  reuses `repoSnapshots` / `snapshotBuilds` (no new tables).
+- Existing Image build, config-files pipeline, cron trigger, delete-existing logic: unchanged —
+  new workflow steps appended, not rewritten.
+- `getRepoSnapshotName` returns the seeded name (fallback to Image) — consumers unchanged.
+- `getDaytona` unchanged (no region migration).
+
+## Unresolved questions
+
+1. ~~**Region**~~ — DECIDED: default region, SDK upgrade only.
+2. ~~**Seed/startup commands**~~ — RESOLVED: `startupCommands` / `seedCommands` / `stopCommands`
+   split (carepulse mapping above). Confirm `stopCommands` checkpoint convex cleanly in the spike.
+3. ~~**Disk size**~~ — DECIDED: keep at 10 GB max. ⚠ RISK: seeded Postgres + supabase/convex docker
+   images + node_modules may be tight in 10 GB — the spike MUST measure actual `/` + `/var/lib/docker`
+   usage; if it overflows, slim (prune unused docker images, drop dev deps) before proceeding.
+4. ~~**Base toolchain scope**~~ — DROPPED: augment approach reuses the existing per-repo Image; no
+   separate base image.
+5. ~~**Seed-data confidentiality**~~ — ACCEPTED by user (staging backup baked into snapshot is fine).
+6. ~~**Snapshot retention**~~ — DECIDED: latest-only, rebuilt daily (24 h); reuse delete-existing.
+
+## Phase 0 spike — runnable checklist (the gate)
+
+Goal: empirically answer the two make-or-break unknowns (fits in 10 GB? services re-attach to seeded
+volumes?) before any production code. Target repo: `carepulse-ts`. Throwaway only — delete after.
+
+### Setup
+
+- [ ] Branch off `main`.
+- [x] Bump `@daytonaio/sdk` → `^0.167.0` (the version Daytona's announcement validated; latest is
+      0.183 — Phase 1 can go latest with a full audit). `pnpm install` done; backend resolves 0.167.0.
+- [x] **Methods verified in installed source** (`node_modules/.pnpm/@daytonaio+sdk@0.167.0/.../Sandbox.d.ts`):
+      `_experimental_createSnapshot(name: string, timeout?: number): Promise<void>` (filesystem-only,
+      enters 'snapshotting' then restores state) and `_experimental_fork(params?, timeout?)`.
+- [x] Typecheck CLEAN: `npx convex codegen --typecheck enable` → exit 0. No breaking changes from
+      0.143→0.167 across any SDK call site; spike file typechecks (proves the method is on the type).
+
+### Harness (throwaway internalAction, triggered from Convex dashboard)
+
+Write a temporary `internalAction` (e.g. `convex/_spike/seededSnapshot.ts`) reusing `getDaytona`,
+`getSandbox`, `exec`. It should log timings + disk at each step. Steps:
+
+1. [ ] Create sandbox from carepulse's **existing Image** snapshot (`snapshot-<repoId>`), default
+       region. Log `sandbox.target` (confirm NOT experimental) + `sandbox.id`.
+2. [ ] Run `startupCommands` (start-db; launch + await `convex dev`). Log elapsed.
+3. [ ] Run `seedCommands` (cp's, `pnpm seed:sql`, `convex import`, `convex env set` ×2, `touch
+/home/eva/.db-seeded`). Log elapsed (expect ~10 min).
+4. [ ] **Measure disk BEFORE snapshot**: `df -h /`, `du -sh /var/lib/docker`, `du -sh ~`. Record
+       total vs 10 GB cap. ← gate (1).
+5. [ ] Run `stopCommands` (pkill convex (TERM), `supabase stop`). Confirm no errors; check the
+       supabase postgres volume still listed (`docker volume ls`).
+6. [ ] `sandbox._experimental_createSnapshot("spike-carepulse-seeded")`. Log elapsed + any state
+       transitions; confirm it returns and the call doesn't error.
+7. [ ] Create a NEW sandbox from `spike-carepulse-seeded`. Log create/restore elapsed.
+8. [ ] On the new sandbox, run `startupCommands` ONLY (no seed). Log elapsed. ← target ≪ 10 min.
+9. [ ] **Validate re-attach** ← gate (2):
+   - Postgres: query a seeded table row count via `supabase`/psql; matches step 3. Confirm
+     `supabase start` did NOT re-run migrations/seed (check its log output).
+   - Convex: query seeded data; `convex env get BASE_APP_URL` returns the seeded value (proves
+     deployment reuse, not a fresh empty one).
+   - App: dev server boots, page loads.
+10. [ ] Record: snapshot size, create-from-snapshot time, total warm-start time (create → app ready).
+11. [ ] Cleanup: delete both sandboxes + the `spike-carepulse-seeded` snapshot; remove the spike
+        action + revert the SDK bump if not proceeding.
+
+### RESULTS — 2026-05-30, dev:evalucom (good-mule-506), carepulse-ts — ✅ GREEN
+
+Ran end-to-end against real Daytona (default `eu` region). Both gates pass.
+
+- **GATE 2 (re-attach) — PASS.** Restored sandbox from the seeded snapshot:
+  Postgres `140 tables / ~1,603,273 live rows` survived; Convex env var `BASE_APP_URL=http://localhost:3000`
+  persisted (anonymous deployment + 54,112 imported docs re-attached); `.db-seeded` marker present.
+  **No re-seed ran** — only `pnpm start-db` + `convex dev`.
+- **GATE 1 (disk) — PASS / reframed.** `/var/lib/docker` = **12–13 G on a SEPARATE mount**, larger than
+  the 10 G root overlay (root only ~0.8 G used, 8%). The filesystem snapshot **captured + restored the
+  separate docker mount fully** — this was the key uncertainty, resolved positively. The 10 G "cap" is the
+  root disk param and is NOT the binding constraint; Daytona stores the full multi-mount state.
+- **Region — confirmed default.** Sandbox `target=eu`; `_experimental_createSnapshot` works without the
+  experimental region. No migration needed.
+- **Timings.** Seed (one-off): start-db 56 s + seed:sql 13 s + convex import 17 s. Snapshot create **~4.7 min**.
+  Warm restore: create 26 s + start-db 33 s + convex dev 14 s ≈ **73 s to a seeded, running stack** (vs ~10 min).
+
+Findings to fold into the real implementation (Phases 1–4):
+
+1. `_experimental_createSnapshot(name, timeout)` — `timeout` is the **HTTP request timeout** (timeout\*1000 ms).
+   `0` aborts immediately ("fetch failed"). Pass a positive value (used 600 s).
+2. Convex import must be **`--replace-all --yes`** — the anonymous deployment is non-empty after `convex dev`
+   boots the app, so a plain import hits an ID-space collision.
+3. `ensureDockerDaemon` logs "Docker not available" right after restore (race), but the snapshot's
+   entrypoint brings dockerd up — `supabase start` succeeded. Benign, but the warm-start path should
+   tolerate the race (it does).
+4. SDK 0.143→0.167 bump validated at runtime on dev (create/get/exec/git all worked). Phase 1 unblocked.
+
+### Pass criteria (go/no-go)
+
+- Total disk ≤ 10 GB with headroom. (else: slimming pass first)
+- `supabase start` + `convex dev` re-attach to seeded data with NO re-seed/re-migrate.
+- Warm start materially faster than ~10 min (target ≲ 2 min).
+- `_experimental_createSnapshot` works on the default region.
+
+### Gotchas to watch
+
+- `supabase start` may run `migration up` on boot — confirm it's a no-op against an already-migrated
+  volume and doesn't wipe data.
+- Anonymous `convex dev` deployment identity must live on the snapshotted filesystem (else it spins a
+  fresh empty deployment). Note WHERE it persists (project `.convex` vs `~/.cache`).
+- Postgres consistency: if `supabase stop` didn't flush cleanly, restored data may be corrupt — watch
+  postgres startup logs on the restored sandbox.
+- Snapshot may require a particular sandbox state; confirm whether containers must be stopped (we stop
+  them anyway for consistency).

--- a/packages/backend/convex/_daytona/execution.ts
+++ b/packages/backend/convex/_daytona/execution.ts
@@ -251,6 +251,58 @@ export const runBackgroundCommands = internalAction({
   },
 });
 
+/**
+ * Runs a repo's clean-stop commands (e.g. `supabase stop`, `pkill convex dev`)
+ * sequentially, foreground, so on-disk volumes flush before a filesystem
+ * snapshot. Used only by the seeded-snapshot build; never on normal starts.
+ * Non-fatal per command so a partial stop still lets the snapshot proceed.
+ */
+export const runStopCommands = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.object({
+    ran: v.boolean(),
+    commandCount: v.number(),
+    errors: v.array(v.string()),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ ran: boolean; commandCount: number; errors: string[] }> => {
+    const commands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getStopCommands,
+      { repoId: args.repoId },
+    );
+
+    if (!commands || commands.length === 0) {
+      return { ran: false, commandCount: 0, errors: [] };
+    }
+
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+
+    console.log(
+      `[daytona] runStopCommands: running ${commands.length} stop command(s)`,
+    );
+
+    const errors: string[] = [];
+    for (const command of commands) {
+      console.log(`[daytona] runStopCommands: running: ${command}`);
+      try {
+        await exec(sandbox, command, 300);
+        console.log(`[daytona] runStopCommands: completed: ${command}`);
+      } catch (e) {
+        const msg = errorMessage(e, "command failed");
+        console.error(`[daytona] runStopCommands: failed: ${command}`, msg);
+        errors.push(`${command}: ${msg}`);
+      }
+    }
+
+    return { ran: true, commandCount: commands.length, errors };
+  },
+});
+
 /** Returns a signed preview URL for a sandbox port, optionally checking readiness. */
 export const getPreviewUrl = action({
   args: {

--- a/packages/backend/convex/_daytona/lifecycle.ts
+++ b/packages/backend/convex/_daytona/lifecycle.ts
@@ -3,17 +3,7 @@
 import { v } from "convex/values";
 import { internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
-import {
-  exec,
-  resolveSandboxContext,
-  getSandbox,
-  sleep,
-  WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
-} from "./helpers";
-import { createSandbox, WARMING_LIFECYCLE } from "./git";
-
-const MAX_WARMUP_RETRIES = 2;
-const WARMUP_RETRY_DELAY_MS = 5_000;
+import { exec, getSandbox } from "./helpers";
 
 /**
  * Short wait window for the start kick-off. A stopped→started fast resume
@@ -35,67 +25,6 @@ const CALLBACK_LIVENESS_COMMAND = [
 /** Agent CLI still running even if callback PID bookkeeping is stale. */
 const AGENT_PROCESS_LIVENESS_COMMAND =
   "pgrep -f 'claude-code|cursor-agent|codex run|opencode run|/\\.claude/' >/dev/null 2>&1";
-
-/** Warms the Daytona snapshot cache for a repo by creating and immediately deleting a sandbox, with retries. */
-export const warmSnapshotCache = internalAction({
-  args: {
-    repoId: v.id("githubRepos"),
-    buildId: v.id("snapshotBuilds"),
-  },
-  returns: v.null(),
-  handler: async (ctx, args) => {
-    const { daytona, sandboxEnvVars, snapshotName } =
-      await resolveSandboxContext(ctx, args.repoId);
-    if (!snapshotName) return null;
-    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
-      repoId: args.repoId,
-    });
-    if (!repo) return null;
-
-    let lastError = "";
-    for (let attempt = 0; attempt <= MAX_WARMUP_RETRIES; attempt++) {
-      try {
-        if (attempt > 0) {
-          console.log(
-            `[daytona] Warmup retry ${attempt}/${MAX_WARMUP_RETRIES} for ${repo.owner}/${repo.name}`,
-          );
-          await sleep(WARMUP_RETRY_DELAY_MS);
-        }
-        const sandbox = await createSandbox(
-          daytona,
-          repo.installationId,
-          sandboxEnvVars,
-          WARMING_LIFECYCLE,
-          snapshotName,
-          undefined,
-          WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
-        );
-        await sandbox.delete();
-        console.log(
-          `[daytona] Warmed snapshot cache for ${repo.owner}/${repo.name}`,
-        );
-        await ctx.runMutation(internal.repoSnapshots.updateWarmupStatus, {
-          buildId: args.buildId,
-          status: "success",
-        });
-        return null;
-      } catch (err) {
-        lastError = err instanceof Error ? err.message : String(err);
-        console.error(
-          `[daytona] warmSnapshotCache attempt ${attempt + 1} failed:`,
-          lastError,
-        );
-      }
-    }
-
-    await ctx.runMutation(internal.repoSnapshots.updateWarmupStatus, {
-      buildId: args.buildId,
-      status: "error",
-      error: lastError,
-    });
-    return null;
-  },
-});
 
 /**
  * Verifies whether a sandbox and its callback runner are alive.

--- a/packages/backend/convex/_daytona/prepareSandboxSteps.ts
+++ b/packages/backend/convex/_daytona/prepareSandboxSteps.ts
@@ -198,9 +198,55 @@ export async function prepareSandboxSteps(
     );
   }
 
-  // Step 4: Run startup commands once per sandbox (marker file). Skipped for
+  // Step 4: Launch background commands (long-running daemons / services) FIRST,
+  // before startup commands, so one-time startup/seed work can depend on services
+  // being up (e.g. `supabase start`, `npx convex dev`). Skipped together with
+  // startup for read-only ephemeral flows (PR recap, interview). Non-fatal.
+  if (!args.skipStartupCommands) {
+    await emitSteps(step, args.streamingEntityId, [
+      ...completedSteps,
+      {
+        type: "tool",
+        label: "Launching background commands...",
+        status: "active",
+      },
+    ]);
+    try {
+      const result = await step.runAction(
+        internal.daytona.runBackgroundCommands,
+        { sandboxId, repoId: args.repoId },
+        { retry: { maxAttempts: 1, initialBackoffMs: 1000, base: 2 } },
+      );
+      if (result.ran) {
+        completedSteps.push({
+          type: "tool",
+          label: "Launching background commands...",
+          status: "complete",
+        });
+        if (result.commandCount > 0) {
+          console.log(
+            `[prepareSandbox] Launched ${result.commandCount} background command(s)`,
+          );
+          if (result.errors.length > 0) {
+            console.warn(
+              `[prepareSandbox] Background command errors: ${result.errors.join("; ")}`,
+            );
+          }
+        }
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(
+        `[prepareSandbox] Background commands failed — continuing: ${msg}`,
+      );
+    }
+  }
+
+  // Step 5: Run startup commands once per sandbox (marker file). Skipped for
   // read-only ephemeral flows (PR recap) and when a reused project sandbox
-  // already paid this cost on the first task.
+  // already paid this cost on the first task. Startup commands that depend on
+  // services should wait for readiness themselves, since background daemons
+  // above are launched detached.
   let shouldRunStartupCommands = !args.skipStartupCommands;
   if (shouldRunStartupCommands) {
     const markerExists = await step.runAction(
@@ -245,48 +291,6 @@ export async function prepareSandboxSteps(
       const msg = e instanceof Error ? e.message : String(e);
       console.warn(
         `[prepareSandbox] Startup commands failed — continuing: ${msg}`,
-      );
-    }
-  }
-
-  // Step 5: Launch background commands (long-running daemons). Skipped together
-  // with startup commands for read-only ephemeral flows (PR recap, interview).
-  if (!args.skipStartupCommands) {
-    await emitSteps(step, args.streamingEntityId, [
-      ...completedSteps,
-      {
-        type: "tool",
-        label: "Launching background commands...",
-        status: "active",
-      },
-    ]);
-    try {
-      const result = await step.runAction(
-        internal.daytona.runBackgroundCommands,
-        { sandboxId, repoId: args.repoId },
-        { retry: { maxAttempts: 1, initialBackoffMs: 1000, base: 2 } },
-      );
-      if (result.ran) {
-        completedSteps.push({
-          type: "tool",
-          label: "Launching background commands...",
-          status: "complete",
-        });
-        if (result.commandCount > 0) {
-          console.log(
-            `[prepareSandbox] Launched ${result.commandCount} background command(s)`,
-          );
-          if (result.errors.length > 0) {
-            console.warn(
-              `[prepareSandbox] Background command errors: ${result.errors.join("; ")}`,
-            );
-          }
-        }
-      }
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.warn(
-        `[prepareSandbox] Background commands failed — continuing: ${msg}`,
       );
     }
   }

--- a/packages/backend/convex/_daytona/snapshotStates.ts
+++ b/packages/backend/convex/_daytona/snapshotStates.ts
@@ -1,0 +1,18 @@
+/**
+ * Snapshot lifecycle states that end a build/capture poll loop: "active" is
+ * success; "error" / "build_failed" are failures.
+ *
+ * This module is intentionally dependency-free. The snapshot SDK service
+ * (snapshots.ts) is node-only and cannot be imported by the build workflow,
+ * which runs in the Convex isolate — so the shared terminal-state definition
+ * lives here where both sides can import it.
+ */
+export const TERMINAL_SNAPSHOT_STATES: readonly string[] = [
+  "active",
+  "error",
+  "build_failed",
+];
+
+export function isTerminalSnapshotState(state: string): boolean {
+  return TERMINAL_SNAPSHOT_STATES.includes(state);
+}

--- a/packages/backend/convex/_daytona/snapshots.ts
+++ b/packages/backend/convex/_daytona/snapshots.ts
@@ -1,0 +1,105 @@
+"use node";
+
+import type { Daytona } from "@daytonaio/sdk";
+import { DaytonaTimeoutError } from "@daytonaio/sdk";
+
+/**
+ * Daytona snapshot mechanics — the "how" of talking to the snapshot SDK,
+ * centralized so the action/workflow layers own only the "when/why" (poll
+ * cadence, retry policy, build-status transitions, per-app fallback).
+ *
+ * Every function takes an already-resolved `daytona` client as an explicit
+ * parameter and never touches Convex ctx/DB — callers resolve the client and
+ * apply their own domain policy (e.g. whether a missing API key fails the build
+ * or throws).
+ */
+
+/** Narrowed view of a Daytona snapshot — the fields callers actually read. */
+export type SnapshotInfo = {
+  id: string;
+  state: string;
+  errorReason: string | null;
+};
+
+/**
+ * Looks up a snapshot by name. Returns a narrowed SnapshotInfo, or null when the
+ * snapshot is not registered (the SDK throws on not-found). Callers decide what
+ * "missing" means — still building, already removed, etc.
+ */
+export async function getSnapshot(
+  daytona: Daytona,
+  name: string,
+): Promise<SnapshotInfo | null> {
+  try {
+    const snapshot = await daytona.snapshot.get(name);
+    return {
+      id: String(snapshot.id),
+      state: String(snapshot.state),
+      errorReason:
+        snapshot.errorReason != null ? String(snapshot.errorReason) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deletes a snapshot by name. Returns true if it existed and was deleted, false
+ * if it was not found. Never throws on a missing snapshot.
+ */
+export async function deleteSnapshotByName(
+  daytona: Daytona,
+  name: string,
+): Promise<boolean> {
+  try {
+    const snapshot = await daytona.snapshot.get(name);
+    await daytona.snapshot.delete(snapshot);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Polls until a snapshot name no longer resolves. snapshot.delete() returns
+ * immediately but the snapshot lingers in a "removing" state, and recreating the
+ * same name 409s until removal finishes. Best-effort and bounded: returns once
+ * the snapshot is gone or the attempts are exhausted.
+ */
+export async function waitForSnapshotRemoval(
+  daytona: Daytona,
+  name: string,
+  opts: { attempts?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const attempts = opts.attempts ?? 30;
+  const intervalMs = opts.intervalMs ?? 2000;
+  for (let i = 0; i < attempts; i++) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    if ((await getSnapshot(daytona, name)) === null) return;
+  }
+}
+
+/**
+ * Fires a sandbox→snapshot capture (the seeded-DB filesystem snapshot) and
+ * returns WITHOUT waiting for it to finish.
+ *
+ * The SDK helper blocks the caller polling the source sandbox's state for the
+ * entire capture, which for a seeded DB volume routinely exceeds Convex's 600s
+ * per-action ceiling. We pass a short timeout so the helper bails fast with a
+ * DaytonaTimeoutError (the capture keeps running server-side) and let the caller
+ * poll completion via getSnapshot. Any non-timeout error is a real failure and
+ * propagates.
+ */
+export async function triggerSandboxSnapshot(
+  daytona: Daytona,
+  sandboxId: string,
+  name: string,
+  timeoutSec: number,
+): Promise<void> {
+  const sandbox = await daytona.get(sandboxId);
+  try {
+    await sandbox._experimental_createSnapshot(name, timeoutSec);
+  } catch (e) {
+    if (!(e instanceof DaytonaTimeoutError)) throw e;
+  }
+}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -45,6 +45,8 @@ import type * as _daytona_resumeSandboxSteps from "../_daytona/resumeSandboxStep
 import type * as _daytona_runDevServer from "../_daytona/runDevServer.js";
 import type * as _daytona_services from "../_daytona/services.js";
 import type * as _daytona_sessions from "../_daytona/sessions.js";
+import type * as _daytona_snapshotStates from "../_daytona/snapshotStates.js";
+import type * as _daytona_snapshots from "../_daytona/snapshots.js";
 import type * as _daytona_volumes from "../_daytona/volumes.js";
 import type * as _deployment_vercel from "../_deployment/vercel.js";
 import type * as _designSessions_execution from "../_designSessions/execution.js";
@@ -78,6 +80,7 @@ import type * as _migrations_backfillTaskSubscribers from "../_migrations/backfi
 import type * as _migrations_cleanup from "../_migrations/cleanup.js";
 import type * as _migrations_deleteRepos from "../_migrations/deleteRepos.js";
 import type * as _migrations_deploymentUrl from "../_migrations/deploymentUrl.js";
+import type * as _migrations_dropWarmupFields from "../_migrations/dropWarmupFields.js";
 import type * as _migrations_logProjectIds from "../_migrations/logProjectIds.js";
 import type * as _migrations_projectInterview from "../_migrations/projectInterview.js";
 import type * as _migrations_projectPhases from "../_migrations/projectPhases.js";
@@ -294,6 +297,8 @@ declare const fullApi: ApiFromModules<{
   "_daytona/runDevServer": typeof _daytona_runDevServer;
   "_daytona/services": typeof _daytona_services;
   "_daytona/sessions": typeof _daytona_sessions;
+  "_daytona/snapshotStates": typeof _daytona_snapshotStates;
+  "_daytona/snapshots": typeof _daytona_snapshots;
   "_daytona/volumes": typeof _daytona_volumes;
   "_deployment/vercel": typeof _deployment_vercel;
   "_designSessions/execution": typeof _designSessions_execution;
@@ -327,6 +332,7 @@ declare const fullApi: ApiFromModules<{
   "_migrations/cleanup": typeof _migrations_cleanup;
   "_migrations/deleteRepos": typeof _migrations_deleteRepos;
   "_migrations/deploymentUrl": typeof _migrations_deploymentUrl;
+  "_migrations/dropWarmupFields": typeof _migrations_dropWarmupFields;
   "_migrations/logProjectIds": typeof _migrations_logProjectIds;
   "_migrations/projectInterview": typeof _migrations_projectInterview;
   "_migrations/projectPhases": typeof _migrations_projectPhases;

--- a/packages/backend/convex/_githubRepos/mutations.ts
+++ b/packages/backend/convex/_githubRepos/mutations.ts
@@ -174,6 +174,7 @@ export const updateConfig = authMutation({
     devCommand: v.optional(v.string()),
     startupCommands: v.optional(v.array(v.string())),
     backgroundCommands: v.optional(v.array(v.string())),
+    stopCommands: v.optional(v.array(v.string())),
     systemPrompt: v.optional(v.string()),
   },
   returns: v.null(),
@@ -265,6 +266,13 @@ export const updateConfig = authMutation({
           args.backgroundCommands.length > 0
             ? args.backgroundCommands
             : undefined,
+      });
+    }
+
+    if (args.stopCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        stopCommands:
+          args.stopCommands.length > 0 ? args.stopCommands : undefined,
       });
     }
 

--- a/packages/backend/convex/_repoSnapshots/builds.ts
+++ b/packages/backend/convex/_repoSnapshots/builds.ts
@@ -5,6 +5,8 @@ import {
   snapshotBuildStatusValidator,
   snapshotBuildTriggerValidator,
   snapshotWarmupStatusValidator,
+  seededAppResultValidator,
+  seededAppStatusValidator,
 } from "../validators";
 import { authQuery, authMutation } from "../functions";
 import { workflow } from "../workflowManager";
@@ -30,6 +32,7 @@ export const listBuilds = authQuery({
       retryCount: v.optional(v.number()),
       warmupStatus: v.optional(snapshotWarmupStatusValidator),
       warmupError: v.optional(v.string()),
+      seededApps: v.optional(v.array(seededAppResultValidator)),
     }),
   ),
   handler: async (ctx, args) => {
@@ -62,6 +65,7 @@ export const getBuild = authQuery({
       retryCount: v.optional(v.number()),
       warmupStatus: v.optional(snapshotWarmupStatusValidator),
       warmupError: v.optional(v.string()),
+      seededApps: v.optional(v.array(seededAppResultValidator)),
     }),
     v.null(),
   ),
@@ -173,7 +177,7 @@ export const startBuild = authMutation({
   },
 });
 
-/** Marks a build as complete (success/error), triggers warmup on success or retries on cron failure. */
+/** Marks a build as complete (success/error); retries on cron failure. */
 export const completeBuild = internalMutation({
   args: {
     buildId: v.id("snapshotBuilds"),
@@ -195,16 +199,6 @@ export const completeBuild = internalMutation({
       error: args.error,
       completedAt: Date.now(),
     });
-    if (args.status === "success") {
-      const snapshot = await ctx.db.get(build.repoSnapshotId);
-      if (snapshot) {
-        await ctx.db.patch(args.buildId, { warmupStatus: "pending" });
-        await ctx.scheduler.runAfter(0, internal.daytona.warmSnapshotCache, {
-          repoId: snapshot.repoId,
-          buildId: args.buildId,
-        });
-      }
-    }
     if (
       args.status === "error" &&
       build.triggeredBy === "cron" &&
@@ -233,25 +227,6 @@ export const completeBuild = internalMutation({
   },
 });
 
-/** Updates the warmup status and optional error for a snapshot build. */
-export const updateWarmupStatus = internalMutation({
-  args: {
-    buildId: v.id("snapshotBuilds"),
-    status: snapshotWarmupStatusValidator,
-    error: v.optional(v.string()),
-  },
-  returns: v.null(),
-  handler: async (ctx, args) => {
-    const build = await ctx.db.get(args.buildId);
-    if (!build) return null;
-    await ctx.db.patch(args.buildId, {
-      warmupStatus: args.status,
-      warmupError: args.error,
-    });
-    return null;
-  },
-});
-
 /** Appends a log chunk to an existing snapshot build record. */
 export const appendLogs = internalMutation({
   args: {
@@ -265,6 +240,38 @@ export const appendLogs = internalMutation({
     await ctx.db.patch(args.buildId, {
       logs: build.logs + args.chunk,
     });
+    return null;
+  },
+});
+
+/**
+ * Records a single app's seeding outcome on a build (called during Step 5).
+ * seededSnapshotName is the captured snapshot name on success, or null when the
+ * app fell back to the base Image. Replaces any prior entry for the same repo so
+ * the operation is idempotent under workflow retries.
+ */
+export const recordSeededApp = internalMutation({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoId: v.id("githubRepos"),
+    status: seededAppStatusValidator,
+    seededSnapshotName: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const build = await ctx.db.get(args.buildId);
+    if (!build) return null;
+    const repo = await ctx.db.get(args.repoId);
+    const seededApps = [
+      ...(build.seededApps ?? []).filter((a) => a.repoId !== args.repoId),
+      {
+        repoId: args.repoId,
+        app: repo?.rootDirectory,
+        status: args.status,
+        seededSnapshotName: args.seededSnapshotName,
+      },
+    ];
+    await ctx.db.patch(args.buildId, { seededApps });
     return null;
   },
 });

--- a/packages/backend/convex/_repoSnapshots/config.ts
+++ b/packages/backend/convex/_repoSnapshots/config.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { internalQuery } from "../_generated/server";
+import { internalQuery, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { GenericDatabaseReader } from "convex/server";
 import type { DataModel, Doc, Id } from "../_generated/dataModel";
@@ -70,11 +70,22 @@ export const getRepoSnapshot = authQuery({
   },
 });
 
-/** Returns the snapshot name for a repo, only if a successful build exists. */
+/**
+ * Returns the snapshot name a sandbox for this repo should boot from.
+ * Prefers the app's own seeded running-sandbox snapshot (DB already seeded) when
+ * present; otherwise falls back to the shared base Image snapshot, but only if a
+ * successful Image build exists.
+ */
 export const getRepoSnapshotName = internalQuery({
   args: { repoId: v.id("githubRepos") },
   returns: v.union(v.object({ snapshotName: v.string() }), v.null()),
   handler: async (ctx, args) => {
+    // Per-app seeded snapshot takes precedence (fast start with seeded DB).
+    const repo = await ctx.db.get(args.repoId);
+    if (repo?.seededSnapshotName) {
+      return { snapshotName: repo.seededSnapshotName };
+    }
+
     const snapshot = await findSnapshotForRepo(ctx.db, args.repoId);
     if (!snapshot) return null;
 
@@ -88,6 +99,141 @@ export const getRepoSnapshotName = internalQuery({
 
     if (!latestSuccessfulBuild) return null;
     return { snapshotName: snapshot.snapshotName };
+  },
+});
+
+/**
+ * Lists the app repos a seeded snapshot should be built for after the base Image
+ * build. Seeded snapshots are PER APP, not per monorepo: an app is a sibling
+ * (same owner/name) with stopCommands configured that is NOT the monorepo parent
+ * (i.e. no other sibling points to it via parentRepoId). For a single-app repo
+ * the lone repo qualifies (it parents nobody). For carepulse this yields web +
+ * eprocurement, excluding the parent root.
+ */
+/**
+ * Shared resolver for the seedable app repos of a snapshot config (see
+ * getSeedableAppRepos doc for the rule). Returns the full repo docs so callers
+ * can read display fields / seededSnapshotName.
+ */
+export async function findSeedableAppRepos(
+  db: GenericDatabaseReader<DataModel>,
+  repoSnapshotId: Id<"repoSnapshots">,
+): Promise<Doc<"githubRepos">[]> {
+  const config = await db.get(repoSnapshotId);
+  if (!config) return [];
+  const configRepo = await db.get(config.repoId);
+  if (!configRepo) return [];
+  const siblings = await db
+    .query("githubRepos")
+    .withIndex("by_owner_and_name", (q) =>
+      q.eq("owner", configRepo.owner).eq("name", configRepo.name),
+    )
+    .collect();
+  // Repos that are a monorepo parent of another sibling — skip these.
+  const parentIds = new Set<Id<"githubRepos">>();
+  for (const r of siblings) {
+    if (r.parentRepoId) parentIds.add(r.parentRepoId);
+  }
+  return siblings.filter(
+    (r) => (r.stopCommands?.length ?? 0) > 0 && !parentIds.has(r._id),
+  );
+}
+
+export const getSeedableAppRepos = internalQuery({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.array(v.object({ repoId: v.id("githubRepos") })),
+  handler: async (ctx, args) => {
+    const apps = await findSeedableAppRepos(ctx.db, args.repoSnapshotId);
+    return apps.map((r) => ({ repoId: r._id }));
+  },
+});
+
+/**
+ * Siblings that still carry a seededSnapshotName but are NO LONGER seedable
+ * (e.g. an app that dropped its stopCommands, or the monorepo parent). The
+ * per-app rebuild loop only deletes snapshots for CURRENTLY seedable apps, so
+ * without cleanup an ex-seedable app's seeded-<repoId> snapshot lingers in
+ * Daytona forever. The build workflow uses this to delete those snapshots and
+ * clear the stale name.
+ */
+export const getOrphanedSeededApps = internalQuery({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.array(
+    v.object({
+      repoId: v.id("githubRepos"),
+      seededSnapshotName: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const config = await ctx.db.get(args.repoSnapshotId);
+    if (!config) return [];
+    const configRepo = await ctx.db.get(config.repoId);
+    if (!configRepo) return [];
+    const siblings = await ctx.db
+      .query("githubRepos")
+      .withIndex("by_owner_and_name", (q) =>
+        q.eq("owner", configRepo.owner).eq("name", configRepo.name),
+      )
+      .collect();
+    const seedable = await findSeedableAppRepos(ctx.db, args.repoSnapshotId);
+    const seedableIds = new Set(seedable.map((r) => r._id));
+    const orphans: Array<{
+      repoId: Id<"githubRepos">;
+      seededSnapshotName: string;
+    }> = [];
+    for (const r of siblings) {
+      // The !== undefined guard narrows seededSnapshotName to string.
+      if (!seedableIds.has(r._id) && r.seededSnapshotName !== undefined) {
+        orphans.push({
+          repoId: r._id,
+          seededSnapshotName: r.seededSnapshotName,
+        });
+      }
+    }
+    return orphans;
+  },
+});
+
+/**
+ * Current per-app seeded-snapshot state for a snapshot config: each seedable app
+ * with its live seededSnapshotName (null = falling back to the base Image).
+ * Used by the snapshot status tab.
+ */
+export const getSeededAppStatus = authQuery({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.array(
+    v.object({
+      repoId: v.id("githubRepos"),
+      app: v.optional(v.string()),
+      owner: v.string(),
+      name: v.string(),
+      seededSnapshotName: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const apps = await findSeedableAppRepos(ctx.db, args.repoSnapshotId);
+    return apps.map((r) => ({
+      repoId: r._id,
+      app: r.rootDirectory,
+      owner: r.owner,
+      name: r.name,
+      seededSnapshotName: r.seededSnapshotName ?? null,
+    }));
+  },
+});
+
+/** Sets (or clears) an app repo's seeded snapshot name. */
+export const setSeededSnapshotName = internalMutation({
+  args: {
+    repoId: v.id("githubRepos"),
+    seededSnapshotName: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.repoId, {
+      seededSnapshotName: args.seededSnapshotName ?? undefined,
+    });
+    return null;
   },
 });
 

--- a/packages/backend/convex/_repoSnapshots/repoMetadata.ts
+++ b/packages/backend/convex/_repoSnapshots/repoMetadata.ts
@@ -23,6 +23,17 @@ export const getBackgroundCommands = internalQuery({
   },
 });
 
+/** Returns the clean-stop commands for a repo/app, if any. */
+export const getStopCommands = internalQuery({
+  args: { repoId: v.id("githubRepos") },
+  returns: v.union(v.array(v.string()), v.null()),
+  handler: async (ctx, args) => {
+    const repo = await ctx.db.get(args.repoId);
+    if (!repo) return null;
+    return repo.stopCommands ?? null;
+  },
+});
+
 /** Internal query to get GitHub repo metadata (owner, name, installationId). */
 export const getRepo = internalQuery({
   args: { repoId: v.id("githubRepos") },

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -180,6 +180,26 @@ export const repoSkillFields = {
   createdAt: v.number(),
 };
 
+// Lifecycle of a single app's seeded-snapshot build within Step 5: actively
+// seeding, captured successfully, or fell back to the base Image.
+export const seededAppStatusValidator = v.union(
+  v.literal("running"),
+  v.literal("seeded"),
+  v.literal("fallback"),
+);
+
+// Per-app outcome of a seeded-snapshot build (recorded per snapshotBuild during
+// Step 5). status tracks the lifecycle (running while in progress); is optional
+// for build records created before the field existed (treat absent as terminal,
+// inferred from seededSnapshotName). seededSnapshotName is the captured snapshot
+// name on success, or null while running / when it fell back to the base Image.
+export const seededAppResultValidator = v.object({
+  repoId: v.id("githubRepos"),
+  app: v.optional(v.string()),
+  status: v.optional(seededAppStatusValidator),
+  seededSnapshotName: v.union(v.string(), v.null()),
+});
+
 export const githubRepoFields = {
   owner: v.string(),
   name: v.string(),
@@ -204,7 +224,13 @@ export const githubRepoFields = {
   screenshotsVideosEnabled: v.optional(v.boolean()),
   startupCommands: v.optional(v.array(v.string())),
   backgroundCommands: v.optional(v.array(v.string())),
+  // Clean-shutdown commands run before snapshotting a seeded sandbox so on-disk
+  // volumes (e.g. local Postgres) flush consistently. Used by the seeded-snapshot
+  // build stage; not run on normal sandbox starts.
   stopCommands: v.optional(v.array(v.string())),
+  // Name of this app's seeded running-sandbox snapshot (filesystem snapshot with
+  // the DB already seeded), set by the seeded-snapshot build when it succeeds.
+  // Preferred over the base Image snapshot at sandbox-create time for fast starts.
   seededSnapshotName: v.optional(v.string()),
   devPort: v.optional(v.number()),
   devCommand: v.optional(v.string()),

--- a/packages/backend/convex/daytona.ts
+++ b/packages/backend/convex/daytona.ts
@@ -1,7 +1,6 @@
 "use node";
 
 export {
-  warmSnapshotCache,
   killSandboxProcess,
   stopSandbox,
   deleteSandbox,
@@ -17,6 +16,7 @@ export {
   runStartupCommands,
   startupCommandsMarkerExists,
   runBackgroundCommands,
+  runStopCommands,
   getPreviewUrl,
   prepareSandbox,
   createOrResumeSandbox,

--- a/packages/backend/convex/repoSnapshots.ts
+++ b/packages/backend/convex/repoSnapshots.ts
@@ -5,6 +5,10 @@ export {
   saveRepoSnapshot,
   setSnapshotEnabled,
   deleteRepoSnapshot,
+  getSeedableAppRepos,
+  getOrphanedSeededApps,
+  getSeededAppStatus,
+  setSeededSnapshotName,
 } from "./_repoSnapshots/config";
 
 export {
@@ -14,12 +18,13 @@ export {
   triggerScheduledBuild,
   startBuild,
   completeBuild,
-  updateWarmupStatus,
   appendLogs,
+  recordSeededApp,
 } from "./_repoSnapshots/builds";
 
 export {
   getStartupCommands,
   getBackgroundCommands,
+  getStopCommands,
   getRepo,
 } from "./_repoSnapshots/repoMetadata";

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -11,6 +11,7 @@ import {
   snapshotBuildStatusValidator,
   snapshotBuildTriggerValidator,
   snapshotWarmupStatusValidator,
+  seededAppResultValidator,
   teamMemberRoleValidator,
   webhookEventStatusValidator,
   messageFields,
@@ -279,16 +280,8 @@ const schema = defineSchema({
     retryCount: v.optional(v.number()),
     warmupStatus: v.optional(snapshotWarmupStatusValidator),
     warmupError: v.optional(v.string()),
-    seededApps: v.optional(
-      v.array(
-        v.object({
-          app: v.string(),
-          repoId: v.id("githubRepos"),
-          seededSnapshotName: v.union(v.string(), v.null()),
-          status: v.optional(v.string()),
-        }),
-      ),
-    ),
+    // Per-app seeding outcomes captured during Step 5 of the build workflow.
+    seededApps: v.optional(v.array(seededAppResultValidator)),
   })
     .index("by_repo_snapshot", ["repoSnapshotId"])
     .index("by_repo_snapshot_and_status", ["repoSnapshotId", "status"])

--- a/packages/backend/convex/snapshotActions.ts
+++ b/packages/backend/convex/snapshotActions.ts
@@ -3,14 +3,28 @@
 import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { resolveAllEnvVars } from "./envVarResolver";
+import { resolveAllEnvVars, resolveDaytonaApiKey } from "./envVarResolver";
 import { getInstallationToken } from "./githubAuth";
 import {
   getDaytona,
   buildConfigFileDownloadCommands,
   filterDownloadableConfigFiles,
+  WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
   type SandboxConfigFile,
 } from "./_daytona/helpers";
+import {
+  createSandbox,
+  createSandboxAndPrepareRepo,
+  SESSION_LIFECYCLE,
+  WARMING_LIFECYCLE,
+} from "./_daytona/git";
+import {
+  getSnapshot,
+  deleteSnapshotByName,
+  waitForSnapshotRemoval,
+  triggerSandboxSnapshot,
+} from "./_daytona/snapshots";
+import { isTerminalSnapshotState } from "./_daytona/snapshotStates";
 import { Image } from "@daytonaio/sdk";
 import type { Id } from "./_generated/dataModel";
 
@@ -373,11 +387,16 @@ export const pollSnapshotProgress = internalAction({
     }
 
     const daytona = getDaytona(daytonaApiKey);
-    const snapshot = await daytona.snapshot.get(args.snapshotName);
-    const state = String(snapshot.state);
+    const snapshot = await getSnapshot(daytona, args.snapshotName);
+    if (!snapshot) {
+      // The base snapshot was just kicked off, so a missing one is unexpected;
+      // throw so the workflow step fails (matches the prior get-throws path).
+      throw new Error(`Snapshot ${args.snapshotName} not found`);
+    }
+    const state = snapshot.state;
 
     // Terminal states: fetch build logs and complete the build
-    if (state === "active" || state === "error" || state === "build_failed") {
+    if (isTerminalSnapshotState(state)) {
       // Fetch full build logs from the Daytona API (only on terminal state to avoid wasted calls).
       // Both the URL endpoint AND the returned log-stream URL require Bearer auth.
       let logs = "";
@@ -415,9 +434,7 @@ export const pollSnapshotProgress = internalAction({
         return "active";
       }
 
-      const reason = snapshot.errorReason
-        ? String(snapshot.errorReason)
-        : "Unknown error";
+      const reason = snapshot.errorReason || "Unknown error";
       await ctx.runMutation(internal.repoSnapshots.completeBuild, {
         buildId: args.buildId,
         status: "error",
@@ -466,26 +483,13 @@ export const deleteExistingSnapshot = internalAction({
 
     const daytona = getDaytona(daytonaApiKey);
 
-    try {
-      const existing = await daytona.snapshot.get(args.snapshotName);
-      await daytona.snapshot.delete(existing);
-
+    const deleted = await deleteSnapshotByName(daytona, args.snapshotName);
+    if (deleted) {
       await ctx.runMutation(internal.repoSnapshots.appendLogs, {
         buildId: args.buildId,
         chunk: "Deleting existing snapshot, waiting for removal...\n",
       });
-
-      // Poll until the snapshot is fully removed (get throws on not-found)
-      for (let i = 0; i < 30; i++) {
-        await new Promise((r) => setTimeout(r, 2000));
-        try {
-          await daytona.snapshot.get(args.snapshotName);
-        } catch {
-          break;
-        }
-      }
-    } catch {
-      // Snapshot doesn't exist — nothing to delete
+      await waitForSnapshotRemoval(daytona, args.snapshotName);
     }
 
     return null;
@@ -507,12 +511,155 @@ export const deleteDaytonaSnapshot = internalAction({
     }
 
     const daytona = getDaytona(daytonaApiKey);
-    try {
-      const snapshot = await daytona.snapshot.get(args.snapshotName);
-      await daytona.snapshot.delete(snapshot);
-    } catch {
-      // Snapshot may not exist
-    }
+    await deleteSnapshotByName(daytona, args.snapshotName);
     return null;
+  },
+});
+
+/**
+ * Propagation probe: boots ONE cheap ephemeral sandbox from the base Image
+ * snapshot, then deletes it. A freshly-built snapshot is not immediately
+ * available on Daytona runners (propagation lag), so `daytona.create` returns
+ * "No available runners" until propagation completes. The seeded-snapshot
+ * workflow calls this in a poll loop BEFORE fanning out per-app seed-prep
+ * sandboxes, so the expensive seed work only starts once the snapshot is
+ * actually bootable. Returns "available" on a successful create+delete, or
+ * "unavailable" on any create failure (never throws on the create itself — the
+ * workflow owns the retry loop). A successful probe also warms the cache.
+ */
+export const probeSnapshotAvailability = internalAction({
+  args: { repoId: v.id("githubRepos"), imageSnapshot: v.string() },
+  returns: v.union(v.literal("available"), v.literal("unavailable")),
+  handler: async (ctx, args): Promise<"available" | "unavailable"> => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const daytona = getDaytona(daytonaApiKey);
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) throw new Error("Repo not found");
+    try {
+      const sandbox = await createSandbox(
+        daytona,
+        repo.installationId,
+        sandboxEnvVars,
+        WARMING_LIFECYCLE,
+        args.imageSnapshot,
+        undefined,
+        WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
+      );
+      await sandbox.delete();
+      return "available";
+    } catch (err) {
+      console.log(
+        `[snapshot] propagation probe for ${args.imageSnapshot} not ready: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return "unavailable";
+    }
+  },
+});
+
+/**
+ * Seeded-snapshot build step: creates + prepares a sandbox from the base Image
+ * snapshot (NOT a seeded one — passed explicitly to bypass the seeded preference
+ * in getRepoSnapshotName), ready to run the app's background/seed/stop commands.
+ */
+export const createSeedPrepSandbox = internalAction({
+  args: { repoId: v.id("githubRepos"), imageSnapshot: v.string() },
+  returns: v.object({ sandboxId: v.string() }),
+  handler: async (ctx, args): Promise<{ sandboxId: string }> => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const daytona = getDaytona(daytonaApiKey);
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) throw new Error("Repo not found");
+    const { sandbox } = await createSandboxAndPrepareRepo(
+      ctx,
+      daytona,
+      repo.installationId,
+      repo.owner,
+      repo.name,
+      { ...sandboxEnvVars, REPO_ID: args.repoId },
+      SESSION_LIFECYCLE,
+      args.imageSnapshot,
+    );
+    return { sandboxId: sandbox.id };
+  },
+});
+
+// Trigger timeout (seconds) for the seeded-snapshot capture. The SDK's
+// _experimental_createSnapshot fires the POST then blocks polling the sandbox
+// state until the capture finishes OR this timeout elapses. We keep it small so
+// the trigger action returns quickly (the snapshot keeps building server-side)
+// and the workflow polls completion across separate steps — see
+// triggerSeededSnapshot. Comfortable for the POST; short enough to never near
+// Convex's 600s per-action ceiling.
+const SEEDED_SNAPSHOT_TRIGGER_TIMEOUT_SEC = 30;
+
+/**
+ * Seeded-snapshot build — TRIGGER step. Captures the (clean-stopped) sandbox's
+ * filesystem — including the seeded Docker volumes — into a reusable snapshot.
+ *
+ * Non-blocking by design: a seeded snapshot carries the whole seeded DB volume
+ * and its capture routinely runs for many minutes. The SDK helper blocks the
+ * caller polling the sandbox state for the entire capture, which exceeds
+ * Convex's hard 600s action limit — the action gets killed mid-await (the
+ * "unawaited operation" warning) and the app silently drops to the base Image.
+ * Instead we fire the POST with a short timeout so the helper bails fast with a
+ * DaytonaTimeoutError (the snapshot keeps building server-side), then poll
+ * completion in separate workflow steps via pollSeededSnapshotState. Any
+ * non-timeout error is a real failure and propagates to the per-app fallback.
+ */
+export const triggerSeededSnapshot = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    sandboxId: v.string(),
+    seededName: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
+    const daytona = getDaytona(daytonaApiKey);
+    await triggerSandboxSnapshot(
+      daytona,
+      args.sandboxId,
+      args.seededName,
+      SEEDED_SNAPSHOT_TRIGGER_TIMEOUT_SEC,
+    );
+    return null;
+  },
+});
+
+/**
+ * Seeded-snapshot build — POLL step. Returns the snapshot entity's current state
+ * ("active" on success, "error"/"build_failed" on failure, otherwise still
+ * building; "pending" if it is not registered yet).
+ *
+ * We poll the SNAPSHOT entity, not the sandbox state: a sandbox snapshot can
+ * reach "active" while the source sandbox still reports "snapshotting", so a
+ * sandbox-state poll can wait out the whole window and wrongly record a fallback
+ * for a snapshot that actually succeeded. The snapshot's own state is the
+ * authoritative signal — the same one the base-Image build polls.
+ */
+export const pollSeededSnapshotState = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    seededName: v.string(),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
+    const daytona = getDaytona(daytonaApiKey);
+    // Not registered yet (or a transient lookup miss) → treat as still pending.
+    const snapshot = await getSnapshot(daytona, args.seededName);
+    return snapshot ? snapshot.state : "pending";
   },
 });

--- a/packages/backend/convex/snapshotWorkflow.ts
+++ b/packages/backend/convex/snapshotWorkflow.ts
@@ -1,12 +1,27 @@
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { workflow } from "./workflowManager";
+import { isTerminalSnapshotState } from "./_daytona/snapshotStates";
 
 const POLL_DELAY_MS = 30_000;
 const MAX_POLLS = 60; // ~30 minutes at 30s intervals
 
-/** Terminal snapshot states that end the poll loop. */
-const TERMINAL_STATES = ["active", "error", "build_failed"];
+// Propagation-probe loop (Step 5 gate). A freshly-built base snapshot is not
+// immediately bootable on Daytona runners; creating a sandbox from it returns
+// "No available runners" until propagation completes. We probe with one cheap
+// ephemeral sandbox until it succeeds, THEN seed — so seed-prep creates don't
+// race the lag.
+const PROBE_DELAY_MS = 30_000;
+const MAX_PROBE_ATTEMPTS = 20; // ~10 minutes at 30s intervals
+
+// Seeded-snapshot capture poll loop (Step 5, per app). The capture is triggered
+// without blocking (triggerSeededSnapshot) then polled here across separate
+// steps, so a long DB-volume capture never exceeds Convex's 600s per-action
+// ceiling. We poll the snapshot entity until it reaches "active" (success) or a
+// failure state — see pollSeededSnapshotState for why the sandbox state is not
+// a reliable completion signal.
+const SEED_SNAPSHOT_POLL_DELAY_MS = 30_000;
+const MAX_SEED_SNAPSHOT_POLLS = 60; // ~30 minutes at 30s intervals
 
 /**
  * Workflow that orchestrates a full Daytona snapshot build:
@@ -80,11 +95,11 @@ export const snapshotBuildWorkflow = workflow.define({
 
       state = pollResult;
 
-      if (TERMINAL_STATES.includes(state)) break;
+      if (isTerminalSnapshotState(state)) break;
     }
 
     // Step 4: Finalize — if we exhausted polls without terminal state, mark timeout
-    if (!TERMINAL_STATES.includes(state)) {
+    if (!isTerminalSnapshotState(state)) {
       await step.runMutation(internal.repoSnapshots.completeBuild, {
         buildId: args.buildId,
         status: "error",
@@ -92,6 +107,229 @@ export const snapshotBuildWorkflow = workflow.define({
         error:
           "Snapshot build did not complete within polling window (~30 minutes)",
       });
+    }
+
+    // Step 5: Per-app seeded snapshots (best-effort). Only once the base Image is
+    // active. For each app repo with stopCommands, boot a sandbox from the Image,
+    // bring services up, run the one-time seed, clean-stop so volumes flush, then
+    // capture a filesystem snapshot with the DB baked in. A sandbox for that app
+    // then boots from `seeded-<repoId>` (see getRepoSnapshotName) and skips the
+    // ~10-min seed. Failures fall back to the Image (seededSnapshotName left clear).
+    if (state === "active") {
+      // Gate: wait until the freshly-built base snapshot is actually bootable on
+      // a runner before seeding. One cheap ephemeral probe sandbox per attempt;
+      // proceed on the first success. If propagation never completes within the
+      // window, skip seeding entirely — apps keep the base-Image fallback
+      // (seededSnapshotName stays clear), matching the per-app catch below.
+      let propagated = false;
+      for (
+        let attempt = 1;
+        attempt <= MAX_PROBE_ATTEMPTS && !propagated;
+        attempt++
+      ) {
+        const probe = await step.runAction(
+          internal.snapshotActions.probeSnapshotAvailability,
+          { repoId: config.repoId, imageSnapshot: config.snapshotName },
+          { runAfter: attempt === 1 ? 10_000 : PROBE_DELAY_MS },
+        );
+        propagated = probe === "available";
+      }
+      if (!propagated) {
+        console.error(
+          `[snapshot] base snapshot ${config.snapshotName} not bootable after ${MAX_PROBE_ATTEMPTS} probes — skipping seeding (apps fall back to base Image)`,
+        );
+        return;
+      }
+
+      const apps = await step.runQuery(
+        internal.repoSnapshots.getSeedableAppRepos,
+        { repoSnapshotId: args.repoSnapshotId },
+      );
+
+      // Best-effort cleanup: delete seeded snapshots for siblings that are no
+      // longer seedable (e.g. dropped stopCommands) and clear their stale name.
+      // The per-app loop below only deletes snapshots for CURRENTLY seedable
+      // apps, so without this an ex-seedable app's seeded-<repoId> would linger
+      // in Daytona forever. A failed cleanup must not fail the build.
+      const orphans = await step.runQuery(
+        internal.repoSnapshots.getOrphanedSeededApps,
+        { repoSnapshotId: args.repoSnapshotId },
+      );
+      for (const orphan of orphans) {
+        try {
+          await step.runAction(internal.snapshotActions.deleteDaytonaSnapshot, {
+            snapshotName: orphan.seededSnapshotName,
+            repoId: orphan.repoId,
+          });
+          await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
+            repoId: orphan.repoId,
+            seededSnapshotName: null,
+          });
+          console.log(
+            `[snapshot] cleaned up orphaned seeded snapshot ${orphan.seededSnapshotName} (repo ${orphan.repoId} no longer seedable)`,
+          );
+        } catch (e) {
+          console.error(
+            `[snapshot] failed to clean up orphaned seeded snapshot ${orphan.seededSnapshotName}: ${
+              e instanceof Error ? e.message : String(e)
+            }`,
+          );
+        }
+      }
+
+      // Build all apps' seeded snapshots in PARALLEL (each chain is independent).
+      // Trade-off: more concurrent Daytona runner demand — the createSeedPrepSandbox
+      // retry/backoff above absorbs transient "No available runners".
+      await Promise.all(
+        apps.map(async (app) => {
+          const seededName = `seeded-${app.repoId}`;
+          let prepSandboxId: string | null = null;
+          try {
+            // Mark this app as actively seeding so the UI shows a spinner until
+            // it resolves to seeded/fallback below.
+            await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              status: "running",
+              seededSnapshotName: null,
+            });
+            // Clear first so live sandboxes fall back to the Image during rebuild.
+            await step.runMutation(
+              internal.repoSnapshots.setSeededSnapshotName,
+              {
+                repoId: app.repoId,
+                seededSnapshotName: null,
+              },
+            );
+            // Delete the previous seeded snapshot (name reuse would 409).
+            await step.runAction(
+              internal.snapshotActions.deleteDaytonaSnapshot,
+              {
+                snapshotName: seededName,
+                repoId: app.repoId,
+              },
+            );
+            // Retry with backoff: creating the prep sandbox can transiently hit
+            // Daytona "No available runners" when the Image build + per-app prep
+            // sandboxes contend for capacity. Backoff (15s/30s/60s/120s) rides out
+            // a brief saturation; if it still fails, the catch below falls back to
+            // the Image for this app.
+            const created = await step.runAction(
+              internal.snapshotActions.createSeedPrepSandbox,
+              { repoId: app.repoId, imageSnapshot: config.snapshotName },
+              { retry: { maxAttempts: 5, initialBackoffMs: 15000, base: 2 } },
+            );
+            prepSandboxId = created.sandboxId;
+            // services (every-start, launched detached in one quick action)
+            await step.runAction(internal.daytona.runBackgroundCommands, {
+              sandboxId: prepSandboxId,
+              repoId: app.repoId,
+            });
+            // Seed: run each command as its OWN workflow step. A single action
+            // running the whole seed (readiness wait + many env sets + import) can
+            // overrun Convex's ~10-min action limit; per-command steps each get
+            // their own budget. Any failure throws -> caught below -> Image fallback
+            // (we never snapshot a half-seeded DB).
+            const seedCommands = await step.runQuery(
+              internal.repoSnapshots.getStartupCommands,
+              { repoId: app.repoId },
+            );
+            for (const command of seedCommands ?? []) {
+              await step.runAction(internal.daytona.runSandboxCommand, {
+                sandboxId: prepSandboxId,
+                repoId: app.repoId,
+                command,
+                timeoutSeconds: 600,
+              });
+            }
+            // Marker so a sandbox booting from the seeded snapshot skips the seed.
+            await step.runAction(internal.daytona.runSandboxCommand, {
+              sandboxId: prepSandboxId,
+              repoId: app.repoId,
+              command: "touch /tmp/.startup-commands-done",
+              timeoutSeconds: 10,
+            });
+            // clean stop so volumes flush before the snapshot
+            await step.runAction(internal.daytona.runStopCommands, {
+              sandboxId: prepSandboxId,
+              repoId: app.repoId,
+            });
+            // Capture the seeded filesystem snapshot. Trigger fires the POST
+            // without blocking; poll the sandbox state across separate steps so
+            // a long DB capture never exceeds Convex's 600s per-action ceiling.
+            await step.runAction(
+              internal.snapshotActions.triggerSeededSnapshot,
+              {
+                repoId: app.repoId,
+                sandboxId: prepSandboxId,
+                seededName,
+              },
+            );
+            let snapState = "pending";
+            for (
+              let pollAttempt = 1;
+              pollAttempt <= MAX_SEED_SNAPSHOT_POLLS &&
+              !isTerminalSnapshotState(snapState);
+              pollAttempt++
+            ) {
+              snapState = await step.runAction(
+                internal.snapshotActions.pollSeededSnapshotState,
+                { repoId: app.repoId, seededName },
+                {
+                  runAfter:
+                    pollAttempt === 1 ? 10_000 : SEED_SNAPSHOT_POLL_DELAY_MS,
+                },
+              );
+            }
+            // Anything but "active" (failure state or window exhausted) throws
+            // into the per-app catch below → prep sandbox torn down + fallback
+            // (null) recorded → app keeps the base-Image snapshot.
+            if (snapState !== "active") {
+              throw new Error(
+                `Seeded snapshot for ${app.repoId} did not reach active (last state: ${snapState})`,
+              );
+            }
+            await step.runAction(internal.daytona.deleteSandbox, {
+              sandboxId: prepSandboxId,
+              repoId: app.repoId,
+            });
+            prepSandboxId = null;
+            await step.runMutation(
+              internal.repoSnapshots.setSeededSnapshotName,
+              {
+                repoId: app.repoId,
+                seededSnapshotName: seededName,
+              },
+            );
+            // Record the success on the build record for the history view.
+            await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              status: "seeded",
+              seededSnapshotName: seededName,
+            });
+          } catch (e) {
+            console.error(
+              `[snapshot] seeded build failed for ${app.repoId}: ${e instanceof Error ? e.message : String(e)}`,
+            );
+            // Tear down the prep sandbox so it doesn't linger.
+            if (prepSandboxId) {
+              await step.runAction(internal.daytona.deleteSandbox, {
+                sandboxId: prepSandboxId,
+                repoId: app.repoId,
+              });
+            }
+            // seededSnapshotName stays cleared → app uses the base Image snapshot.
+            // Record the fallback on the build record for the history view.
+            await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              status: "fallback",
+              seededSnapshotName: null,
+            });
+          }
+        }),
+      );
     }
   },
 });


### PR DESCRIPTION
## Purpose — archive, do not merge

Reconstruction of **PR #402** (seeded running-sandbox snapshots) on top of the reverted declarative `main`, so the work stays reviewable for a future, calmer attempt. Reverted from `main` in 1a20b561.

This is **part 1 of 2**. Part 2 (#403 warmup removal + follow-up refinements) is stacked on this branch.

## Why reverted
Unstable in prod: build times regressed past 30m (declarative ~15m); sandboxes leaked from create-ready timeouts; eproc's local Convex backend failed to bind `127.0.0.1:3210` on warm boot from an old seeded snapshot (unresolved). Web reached ~11m fresh.

## Scope here
Per-app seeded snapshots (`seeded-<repoId>-<buildId>`), the build pipeline, seed/stop-command plumbing, seed-prep sandbox labelling + sweep, settings UI, plan doc. Warmup schema fields are **still present** here — their removal is part 2.

⚠️ Reviving this needs a prod data-strip migration before deploying the reverted main (see revert commit 1a20b561).