### PR TITLE
[PRESERVED #403/2 · DO NOT MERGE] Drop warmup fields + seeded-snapshot refinements

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -36,7 +36,11 @@ import {
 import { formatDurationMs } from "@conductor/shared/duration";
 import { parseCommandLines, formatFileSize } from "./_utils";
 import { RebuildRequiredWarning } from "./_components/RebuildRequiredWarning";
-import { BuildRow, BuildStatusBadge } from "./_components/BuildRow";
+import {
+  BuildRow,
+  BuildStatusBadge,
+  WarmupStatusBadge,
+} from "./_components/BuildRow";
 
 export function SnapshotsClient({
   activeTab,
@@ -133,6 +137,16 @@ export function SnapshotsClient({
     (lastBuild?.seededApps ?? [])
       .filter((a) => a.status === "running")
       .map((a) => a.repoId),
+  );
+  const warmupByRepoId = new Map(
+    (lastBuild?.seededApps ?? []).map((app) => [
+      app.repoId,
+      {
+        seededSnapshotName: app.seededSnapshotName,
+        warmupStatus: app.warmupStatus,
+        warmupError: app.warmupError,
+      },
+    ]),
   );
 
   const handleSnapshotsTabChange = useCallback(
@@ -357,33 +371,50 @@ export function SnapshotsClient({
                   </p>
                 ) : (
                   <div className="space-y-2 text-xs">
-                    {seededApps.map((app) => (
-                      <div
-                        key={app.repoId}
-                        className="flex items-start justify-between gap-3"
-                      >
-                        <span className="font-medium shrink-0">
-                          {app.app ?? app.name}
-                        </span>
-                        {seedingRepoIds.has(app.repoId) ? (
-                          <span className="inline-flex shrink-0 items-center gap-1 text-blue-500">
-                            <Spinner size="sm" />
-                            Seeding…
+                    {seededApps.map((app) => {
+                      const warmup = warmupByRepoId.get(app.repoId);
+                      const warmupMatchesSnapshot =
+                        app.seededSnapshotName !== null &&
+                        warmup?.seededSnapshotName === app.seededSnapshotName;
+                      return (
+                        <div
+                          key={app.repoId}
+                          className="flex items-start justify-between gap-3"
+                        >
+                          <span className="font-medium shrink-0">
+                            {app.app ?? app.name}
                           </span>
-                        ) : app.seededSnapshotName ? (
-                          <span className="inline-flex min-w-0 items-start gap-1 text-green-500">
-                            <IconCheck size={12} className="mt-0.5 shrink-0" />
-                            <span className="min-w-0 font-mono break-all">
-                              {app.seededSnapshotName}
+                          {seedingRepoIds.has(app.repoId) ? (
+                            <span className="inline-flex shrink-0 items-center gap-1 text-blue-500">
+                              <Spinner size="sm" />
+                              Seeding…
                             </span>
-                          </span>
-                        ) : (
-                          <span className="shrink-0 text-muted-foreground">
-                            Using base Image
-                          </span>
-                        )}
-                      </div>
-                    ))}
+                          ) : app.seededSnapshotName ? (
+                            <span className="inline-flex min-w-0 items-start gap-1 text-green-500">
+                              <IconCheck
+                                size={12}
+                                className="mt-0.5 shrink-0"
+                              />
+                              <span className="min-w-0 space-y-1">
+                                <span className="block font-mono break-all">
+                                  {app.seededSnapshotName}
+                                </span>
+                                {warmupMatchesSnapshot && (
+                                  <WarmupStatusBadge
+                                    status={warmup.warmupStatus}
+                                    error={warmup.warmupError}
+                                  />
+                                )}
+                              </span>
+                            </span>
+                          ) : (
+                            <span className="shrink-0 text-muted-foreground">
+                              Using base Image
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>
@@ -415,6 +446,7 @@ export function SnapshotsClient({
                       </th>
                       <th className="px-2 py-2 font-medium sm:px-4">Trigger</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Status</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">Warmup</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Seeded</th>
                     </tr>
                   </thead>

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
@@ -13,6 +13,8 @@ type SeededAppResult = {
   app?: string;
   status?: "running" | "seeded" | "fallback";
   seededSnapshotName: string | null;
+  warmupStatus?: "pending" | "success" | "error";
+  warmupError?: string;
 };
 
 /** A per-app entry counts as seeded by explicit status, or (legacy rows) by name. */
@@ -34,6 +36,8 @@ export function BuildRow({
     error?: string;
     startedAt: number;
     completedAt?: number;
+    warmupStatus?: "pending" | "success" | "error";
+    warmupError?: string;
     seededApps?: SeededAppResult[];
   };
   isExpanded: boolean;
@@ -64,12 +68,18 @@ export function BuildRow({
           <BuildStatusBadge status={build.status} />
         </td>
         <td className="px-2 py-2 sm:px-4">
+          <WarmupStatusBadge
+            status={build.warmupStatus}
+            error={build.warmupError}
+          />
+        </td>
+        <td className="px-2 py-2 sm:px-4">
           <SeededSummary seededApps={build.seededApps} />
         </td>
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={6} className="px-4 py-3">
+          <td colSpan={7} className="px-4 py-3">
             {build.error && (
               <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 {build.error}
@@ -93,8 +103,14 @@ export function BuildRow({
                           <IconCheck size={12} className="shrink-0" />
                           {a.app ?? a.repoId}
                         </span>
-                        <span className="min-w-0 font-mono break-all text-muted-foreground">
-                          {a.seededSnapshotName}
+                        <span className="min-w-0 space-y-1">
+                          <span className="block font-mono break-all text-muted-foreground">
+                            {a.seededSnapshotName}
+                          </span>
+                          <WarmupStatusBadge
+                            status={a.warmupStatus}
+                            error={a.warmupError}
+                          />
                         </span>
                       </>
                     ) : (
@@ -122,6 +138,42 @@ export function BuildRow({
         </tr>
       )}
     </>
+  );
+}
+
+export function WarmupStatusBadge({
+  status,
+  error,
+}: {
+  status?: "pending" | "success" | "error";
+  error?: string;
+}) {
+  if (!status) {
+    return null;
+  }
+  if (status === "pending") {
+    return (
+      <span className="inline-flex items-center gap-1 text-blue-500">
+        <IconLoader2 size={12} className="shrink-0 animate-spin" />
+        warming snapshot cache
+      </span>
+    );
+  }
+  if (status === "success") {
+    return (
+      <span className="inline-flex items-center gap-1 text-green-500">
+        <IconCheck size={12} className="shrink-0" />
+        cache warmed
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-start gap-1 text-amber-500">
+      <IconX size={12} className="mt-0.5 shrink-0" />
+      <span className="break-words">
+        cache warm failed{error ? `: ${error}` : ""}
+      </span>
+    </span>
   );
 }
 

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Seeded snapshot database restore artifact - 2026-07-05
+
+- Captured a compressed Supabase Postgres dump into the seeded snapshot filesystem after seed commands complete, then restored it once when fresh sandboxes boot from that snapshot.
+- Restored the dump before preview dev servers and workflow background commands start, while leaving non-Supabase and non-seeded snapshots as no-ops.
+- Reason for change: Daytona snapshot creation did not preserve the Supabase Docker volume for fresh sandboxes, so a warmed seeded snapshot could still start with an empty local DB unless the database state was exported as ordinary filesystem data.
+
+## Preserve seeded snapshot runtime state - 2026-07-05
+
+- Preserved untracked runtime state when booting from a seeded snapshot marker so post-create repo cleanup does not remove stopped local database restore files while still skipping seed commands.
+- Started session background services before running startup/seed commands, and made background command launches return immediately after detaching the daemon script.
+- Reason for change: fresh sandboxes could boot from the correct seeded snapshot but start an empty Supabase DB if `git clean -fd` removed the snapshot's untracked local-service state before background services restarted; repair/retry paths also need Supabase and Convex local daemons running before seed/import commands wait on them.
+
+## Seeded snapshot config restore and warm-up fix - 2026-07-05
+
+- Force-restored baked sandbox config files when creating fresh session/task/project sandboxes from seeded snapshots so the app keeps the DB connection and seed files captured during the snapshot build.
+- Reintroduced per-app seeded snapshot cache warming during snapshot builds so the first slow Daytona create-from-snapshot happens before a user creates a sandbox, with build-level warmup status staying pending until every app has settled.
+- Reason for change: seeded snapshots carry the startup-complete marker by design, but that marker was also preventing config restore after checkout, and fresh seeded snapshots still need an explicit warm-up pass before normal sandbox creation is fast.
+
+## Snapshot seed bootstrap and leak guard - 2026-07-05
+
+- Added an explicit base-Image seeding mode for snapshot builds so stale per-app seeded snapshots can be refreshed without triggering cron retry cascades.
+- Label new seed-prep sandboxes and sweep unreferenced labelled prep sandboxes at build start to prevent future runner-pool leaks.
+- Reason for change: eprocurement needed a safe bootstrap path out of a stale seeded snapshot while preserving keep-last-good behavior for normal builds.
+
 ## Seeded-snapshot capture polling fix - 2026-05-31
 
 - Fixed seeded-snapshot filesystem capture timeouts by switching from a blocking SDK call to non-blocking trigger-and-poll, preventing silent fallback to the base image when DB volumes exceed the 600s Convex action ceiling.

--- a/packages/backend/convex/_daytona/devServer.ts
+++ b/packages/backend/convex/_daytona/devServer.ts
@@ -1,7 +1,11 @@
 "use node";
 
 import type { Sandbox } from "@daytonaio/sdk";
-import { exec, workspaceDirShell } from "./helpers";
+import { ensureDockerDaemon, exec, workspaceDirShell } from "./helpers";
+
+const SUPABASE_DUMP_PATH =
+  "/home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz";
+const SUPABASE_RESTORE_MARKER = "/tmp/.eva-supabase-db-web-restored";
 
 /** Detects the package manager (pnpm, yarn, or npm) by checking lock files. */
 export async function detectPackageManager(
@@ -87,6 +91,8 @@ export async function startSessionServices(
   rootDir: string,
   overrides?: { devPort?: number; devCommand?: string },
 ): Promise<{ port: number; devCommand: string }> {
+  await restoreSeededRuntimeState(sandbox);
+
   const port =
     overrides?.devPort !== undefined
       ? overrides.devPort
@@ -102,6 +108,52 @@ export async function startSessionServices(
     : workspaceDirShell();
   const devCommand = `cd ${dir} && PORT=${port} ${pm} run dev`;
   return { port, devCommand };
+}
+
+/** Restores service state that was exported into a seeded snapshot filesystem. */
+export async function restoreSeededRuntimeState(
+  sandbox: Sandbox,
+): Promise<void> {
+  try {
+    await exec(sandbox, `test -f ${SUPABASE_DUMP_PATH}`, 5);
+  } catch {
+    return;
+  }
+
+  try {
+    await exec(sandbox, `test -f ${SUPABASE_RESTORE_MARKER}`, 5);
+    return;
+  } catch {
+    // No marker means this fresh sandbox still needs its local service state.
+  }
+
+  await ensureDockerDaemon(sandbox);
+  await exec(
+    sandbox,
+    [
+      "set -e",
+      "set -o pipefail",
+      "cd /tmp/repo",
+      "if docker ps --filter name=supabase_db_web --filter status=running -q | grep -q .; then",
+      '  echo "supabase_db_web already running"',
+      "elif docker ps -a --filter name=supabase_db_web -q | grep -q .; then",
+      "  docker start supabase_db_web >/dev/null",
+      '  echo "started existing supabase_db_web"',
+      "else",
+      "  pnpm start-db",
+      "fi",
+      "for i in $(seq 1 240); do",
+      "  if docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1; then break; fi",
+      "  sleep 1",
+      "done",
+      "docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1",
+      `docker exec supabase_db_web psql -U postgres -d postgres -v ON_ERROR_STOP=1 -c "DO \\$\\$ DECLARE tables text; BEGIN SELECT string_agg(format('%I.%I', schemaname, tablename), ', ') INTO tables FROM pg_tables WHERE schemaname = 'public'; IF tables IS NOT NULL THEN EXECUTE 'TRUNCATE TABLE ' || tables || ' CASCADE'; END IF; END \\$\\$;" >/tmp/eva-supabase-db-web-truncate.log 2>&1 || { tail -120 /tmp/eva-supabase-db-web-truncate.log; exit 1; }`,
+      `gzip -dc ${SUPABASE_DUMP_PATH} | docker exec -i supabase_db_web psql -U postgres -d postgres -v ON_ERROR_STOP=1 >/tmp/eva-supabase-db-web-restore.log 2>&1 || { tail -120 /tmp/eva-supabase-db-web-restore.log; exit 1; }`,
+      `touch ${SUPABASE_RESTORE_MARKER}`,
+      'echo "restored supabase_db_web from seeded snapshot dump"',
+    ].join("; "),
+    600,
+  );
 }
 
 /** Stable default terminal pane id — must match `sandboxPanes.defaultPane`. */

--- a/packages/backend/convex/_daytona/execution.ts
+++ b/packages/backend/convex/_daytona/execution.ts
@@ -32,6 +32,7 @@ import { startDesktopWithChrome } from "./desktop";
 import { ensurePreviewNavigationProxy } from "./previewProxy";
 import { getPreviewGrantPublicJwk, signPreviewGrant } from "../previewGrant";
 import { PREVIEW_GRANT_PARAM } from "../previewGrantConfig";
+import { restoreSeededRuntimeState as restoreSeededRuntimeStateInSandbox } from "./devServer";
 
 const sessionPersistenceKindValidator = v.union(
   v.literal("sessions"),
@@ -104,6 +105,20 @@ export const startupCommandsMarkerExists = internalAction({
   },
 });
 
+/** Restores service state exported into a seeded snapshot before services boot. */
+export const restoreSeededRuntimeState = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    await restoreSeededRuntimeStateInSandbox(sandbox);
+    return null;
+  },
+});
+
 /** Runs startup commands on a sandbox if configured. Returns success status. */
 export const runStartupCommands = internalAction({
   args: {
@@ -170,11 +185,20 @@ export const runStartupCommands = internalAction({
       }
     }
 
-    // Create marker file to prevent re-running on sandbox resume
-    try {
-      await exec(sandbox, "touch /tmp/.startup-commands-done", 5);
-    } catch {
-      // Non-fatal
+    // Create the marker only when every command succeeded. Writing it after a
+    // failed run permanently branded the sandbox as seeded: every resume then
+    // marker-skipped the seed and the DB stayed empty forever. Leaving the
+    // marker absent lets the next resume retry the full startup sequence.
+    if (errors.length === 0) {
+      try {
+        await exec(sandbox, "touch /tmp/.startup-commands-done", 5);
+      } catch {
+        // Non-fatal
+      }
+    } else {
+      console.error(
+        `[daytona] runStartupCommands: ${errors.length}/${commands.length} command(s) failed — NOT writing marker so the next resume retries`,
+      );
     }
 
     return { ran: true, commandCount: commands.length, errors };
@@ -224,13 +248,20 @@ export const runBackgroundCommands = internalAction({
       const command = commands[i];
       const logPath = `/tmp/bg-${i}.log`;
       // Escape single quotes for the bash -lc payload.
-      const escaped = command.replace(/'/g, "'\\''");
+      // Write the command to a script file and launch THAT, rather than
+      // inlining it via `bash -lc '<command>'`: the inline form puts the whole
+      // command text into the wrapper shell's cmdline, so a user guard like
+      // `pgrep -f "[c]onvex dev" || npx convex dev` matches its own wrapper
+      // (the unguarded "npx convex dev" launch text) and silently never starts
+      // the daemon. With a script file the cmdline is just the file path.
+      // Base64 transport also makes user quoting unbreakable.
+      const cb64 = Buffer.from(command, "utf8").toString("base64");
       // setsid + </dev/null fully detaches the daemon into its own session, so
       // it survives the exec session teardown even when the user's command
       // self-backgrounds. A trailing `&` would otherwise let bash -lc exit
       // immediately, letting a process-group SIGTERM reach the daemon (nohup
       // only blocks SIGHUP).
-      const launchCmd = `setsid nohup bash -lc '${escaped}' </dev/null > ${logPath} 2>&1 &`;
+      const launchCmd = `echo ${cb64} | base64 -d > /tmp/bg-cmd-${i}.sh && chmod +x /tmp/bg-cmd-${i}.sh && (setsid nohup bash -l /tmp/bg-cmd-${i}.sh </dev/null > ${logPath} 2>&1 & echo $! > /tmp/bg-${i}.pid) && echo LAUNCHED`;
       console.log(
         `[daytona] runBackgroundCommands: launching: ${command} (log: ${logPath})`,
       );

--- a/packages/backend/convex/_daytona/git.ts
+++ b/packages/backend/convex/_daytona/git.ts
@@ -36,6 +36,7 @@ export type SandboxLifecycle = {
   autoArchiveInterval?: number;
   autoDeleteInterval?: number;
   ephemeral?: boolean;
+  labels?: Record<string, string>;
 };
 
 export type RepoSyncStrategy =
@@ -311,6 +312,7 @@ export async function createSandbox(
 
     const commonParams = {
       ...(volumes ? { volumes } : {}),
+      ...(lifecycle.labels ? { labels: lifecycle.labels } : {}),
       envVars: {
         // VNC_RESOLUTION is read by the snapshot's ComputerUse plugin at startup
         // (Xvfb + x11vnc). Setting it here makes the desktop start at 1920x1080
@@ -686,7 +688,14 @@ export async function checkoutFetchedBaseBranch(
   });
 }
 
-/** Resets the snapshot worktree to a clean state via hard reset and clean. */
+/**
+ * Resets tracked files from a snapshot worktree.
+ *
+ * Seeded runtime snapshots carry /tmp/.startup-commands-done and may also carry
+ * untracked local-service state used to restore stopped databases. In that case
+ * preserve untracked files; deleting them makes the sandbox skip seeding while
+ * starting from an empty DB.
+ */
 export async function normalizeSnapshotWorktree(
   sandbox: Sandbox,
 ): Promise<void> {
@@ -697,7 +706,7 @@ export async function normalizeSnapshotWorktree(
     async () => {
       await execGitCommand(
         sandbox,
-        `cd ${workspaceDir} && git reset --hard HEAD && git clean -fd`,
+        `cd ${workspaceDir} && git reset --hard HEAD && if [ -f /tmp/.startup-commands-done ]; then echo "seeded snapshot marker found; preserving untracked runtime state"; else git clean -fd; fi`,
         60,
       );
     },
@@ -707,15 +716,20 @@ export async function normalizeSnapshotWorktree(
 /** Copies baked sandbox config files into the codebase root after git cleanup. */
 export async function copySandboxConfigFilesToWorkspace(
   sandbox: Sandbox,
+  options?: { force?: boolean },
 ): Promise<void> {
   const workspaceDir = workspaceDirShell();
+  const markerGuard =
+    options?.force === true
+      ? ""
+      : 'if [ -f /tmp/.startup-commands-done ]; then echo "startup commands already ran; skipping sandbox-config copy"; exit 0; fi; ';
   await runLoggedGitStep(
     "copySandboxConfigFilesToWorkspace",
     WORKSPACE_DIR,
     async () => {
       await execGitCommand(
         sandbox,
-        `if [ -f /tmp/.startup-commands-done ]; then echo "startup commands already ran; skipping sandbox-config copy"; exit 0; fi; if [ -d /home/eva/sandbox-config ] && find /home/eva/sandbox-config -mindepth 1 -maxdepth 1 | read first; then cp -a /home/eva/sandbox-config/. ${workspaceDir}/; fi`,
+        `${markerGuard}if [ -d /home/eva/sandbox-config ] && find /home/eva/sandbox-config -mindepth 1 -maxdepth 1 | read first; then cp -a /home/eva/sandbox-config/. ${workspaceDir}/; fi`,
         30,
       );
     },
@@ -927,6 +941,11 @@ export async function createSandboxAndPrepareRepo(
   onSandboxAcquired?: (sandbox: Sandbox) => Promise<void>,
   onProgress?: (label: string) => Promise<void>,
   syncStrategy: RepoSyncStrategy = { mode: "all" },
+  // Override the SDK create-ready wait. Large seeded snapshots (~10GB) take
+  // well over the 30s default to start, so callers that boot from them (seeded
+  // snapshot builds) pass a longer value to avoid spurious create timeouts +
+  // the orphaned sandboxes they leave server-side.
+  readyTimeoutSeconds?: number,
 ): Promise<{ sandbox: Sandbox; usedSnapshot: boolean }> {
   let sandbox: Sandbox | undefined;
   try {
@@ -945,6 +964,7 @@ export async function createSandboxAndPrepareRepo(
             lifecycle,
             effectiveSnapshot,
             volumes,
+            readyTimeoutSeconds,
           );
         } catch (err) {
           if (effectiveSnapshot && isSnapshotUnusableError(err)) {
@@ -961,6 +981,7 @@ export async function createSandboxAndPrepareRepo(
               lifecycle,
               undefined,
               volumes,
+              readyTimeoutSeconds,
             );
           } else {
             throw err;
@@ -979,7 +1000,7 @@ export async function createSandboxAndPrepareRepo(
             if (onProgress) await onProgress("Syncing repository...");
             await syncRepo(sandbox, owner, name, syncStrategy);
           }
-          await copySandboxConfigFilesToWorkspace(sandbox);
+          await copySandboxConfigFilesToWorkspace(sandbox, { force: true });
           return { sandbox, usedSnapshot: true };
         }
         if (lifecycle.ephemeral && syncStrategy.mode === "none") {

--- a/packages/backend/convex/_daytona/prepareSandboxSteps.ts
+++ b/packages/backend/convex/_daytona/prepareSandboxSteps.ts
@@ -198,7 +198,30 @@ export async function prepareSandboxSteps(
     );
   }
 
-  // Step 4: Launch background commands (long-running daemons / services) FIRST,
+  // Step 4: Restore service state baked into seeded snapshots before daemons
+  // or startup commands touch local dependencies. No-ops for ordinary snapshots.
+  if (!args.skipStartupCommands) {
+    await emitSteps(step, args.streamingEntityId, [
+      ...completedSteps,
+      {
+        type: "tool",
+        label: "Restoring seeded runtime...",
+        status: "active",
+      },
+    ]);
+    await step.runAction(
+      internal.daytona.restoreSeededRuntimeState,
+      { sandboxId, repoId: args.repoId },
+      { retry: { maxAttempts: 1, initialBackoffMs: 1000, base: 2 } },
+    );
+    completedSteps.push({
+      type: "tool",
+      label: "Restoring seeded runtime...",
+      status: "complete",
+    });
+  }
+
+  // Step 5: Launch background commands (long-running daemons / services) FIRST,
   // before startup commands, so one-time startup/seed work can depend on services
   // being up (e.g. `supabase start`, `npx convex dev`). Skipped together with
   // startup for read-only ephemeral flows (PR recap, interview). Non-fatal.
@@ -242,7 +265,7 @@ export async function prepareSandboxSteps(
     }
   }
 
-  // Step 5: Run startup commands once per sandbox (marker file). Skipped for
+  // Step 6: Run startup commands once per sandbox (marker file). Skipped for
   // read-only ephemeral flows (PR recap) and when a reused project sandbox
   // already paid this cost on the first task. Startup commands that depend on
   // services should wait for readiness themselves, since background daemons

--- a/packages/backend/convex/_daytona/sessions.ts
+++ b/packages/backend/convex/_daytona/sessions.ts
@@ -546,25 +546,6 @@ async function prepareSessionSandboxInternal(
             () => startDesktopWithChrome(sandbox),
           );
         }
-        // Note: runStartupCommands is intentionally not surfaced as a UI step
-        // on the reuse path — the marker file (`/tmp/.startup-commands-done`)
-        // makes it a no-op once the sandbox has been initialised, so showing
-        // "Running startup commands..." would be misleading on resume.
-        await runLoggedSessionStep(
-          "reuseSessionSandbox.runStartupCommands",
-          sandboxDetails,
-          async () => {
-            const result = await ctx.runAction(
-              internal.daytona.runStartupCommands,
-              { sandboxId: sandbox.id, repoId: args.repoId },
-            );
-            if (result.ran && result.commandCount > 0) {
-              logSession(
-                `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
-              );
-            }
-          },
-        );
         await emitSessionProgress(
           ctx,
           args.sessionId,
@@ -595,6 +576,25 @@ async function prepareSessionSandboxInternal(
             status: "complete",
           });
         }
+        // Note: runStartupCommands is intentionally not surfaced as a UI step
+        // on the reuse path — the marker file (`/tmp/.startup-commands-done`)
+        // makes it a no-op once the sandbox has been initialised, so showing
+        // "Running startup commands..." would be misleading on resume.
+        await runLoggedSessionStep(
+          "reuseSessionSandbox.runStartupCommands",
+          sandboxDetails,
+          async () => {
+            const result = await ctx.runAction(
+              internal.daytona.runStartupCommands,
+              { sandboxId: sandbox.id, repoId: args.repoId },
+            );
+            if (result.ran && result.commandCount > 0) {
+              logSession(
+                `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+              );
+            }
+          },
+        );
         reusedResult = {
           sandbox,
           isNew: false,
@@ -742,7 +742,7 @@ async function prepareSessionSandboxInternal(
   await runLoggedSessionStep(
     "newSessionSandbox.copyConfigFiles",
     sandboxDetails,
-    () => copySandboxConfigFilesToWorkspace(sandbox),
+    () => copySandboxConfigFilesToWorkspace(sandbox, { force: true }),
   );
   completedSteps.push({
     type: "tool",
@@ -790,33 +790,6 @@ async function prepareSessionSandboxInternal(
     ctx,
     args.sessionId,
     completedSteps,
-    "Running startup commands...",
-  );
-  await runLoggedSessionStep(
-    "newSessionSandbox.runStartupCommands",
-    sandboxDetails,
-    async () => {
-      const result = await ctx.runAction(internal.daytona.runStartupCommands, {
-        sandboxId: sandbox.id,
-        repoId: args.repoId,
-      });
-      if (result.ran && result.commandCount > 0) {
-        logSession(
-          `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
-        );
-      }
-    },
-  );
-  completedSteps.push({
-    type: "tool",
-    label: "Running startup commands...",
-    status: "complete",
-  });
-
-  await emitSessionProgress(
-    ctx,
-    args.sessionId,
-    completedSteps,
     "Launching background commands...",
   );
   let bgRan = false;
@@ -843,6 +816,33 @@ async function prepareSessionSandboxInternal(
       status: "complete",
     });
   }
+
+  await emitSessionProgress(
+    ctx,
+    args.sessionId,
+    completedSteps,
+    "Running startup commands...",
+  );
+  await runLoggedSessionStep(
+    "newSessionSandbox.runStartupCommands",
+    sandboxDetails,
+    async () => {
+      const result = await ctx.runAction(internal.daytona.runStartupCommands, {
+        sandboxId: sandbox.id,
+        repoId: args.repoId,
+      });
+      if (result.ran && result.commandCount > 0) {
+        logSession(
+          `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+        );
+      }
+    },
+  );
+  completedSteps.push({
+    type: "tool",
+    label: "Running startup commands...",
+    status: "complete",
+  });
 
   await completeSessionProgress(ctx, args.sessionId);
   return {
@@ -1418,7 +1418,7 @@ async function prepareTaskPreviewSandboxInternal(
   await runLoggedSessionStep(
     "newTaskSandbox.copyConfigFiles",
     sandboxDetails,
-    () => copySandboxConfigFilesToWorkspace(sandbox),
+    () => copySandboxConfigFilesToWorkspace(sandbox, { force: true }),
   );
   completedSteps.push({
     type: "tool",
@@ -1847,7 +1847,7 @@ async function prepareProjectPreviewSandboxInternal(
   await runLoggedSessionStep(
     "newProjectSandbox.copyConfigFiles",
     sandboxDetails,
-    () => copySandboxConfigFilesToWorkspace(sandbox),
+    () => copySandboxConfigFilesToWorkspace(sandbox, { force: true }),
   );
   completedSteps.push({
     type: "tool",

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -80,7 +80,6 @@ import type * as _migrations_backfillTaskSubscribers from "../_migrations/backfi
 import type * as _migrations_cleanup from "../_migrations/cleanup.js";
 import type * as _migrations_deleteRepos from "../_migrations/deleteRepos.js";
 import type * as _migrations_deploymentUrl from "../_migrations/deploymentUrl.js";
-import type * as _migrations_dropWarmupFields from "../_migrations/dropWarmupFields.js";
 import type * as _migrations_logProjectIds from "../_migrations/logProjectIds.js";
 import type * as _migrations_projectInterview from "../_migrations/projectInterview.js";
 import type * as _migrations_projectPhases from "../_migrations/projectPhases.js";
@@ -332,7 +331,6 @@ declare const fullApi: ApiFromModules<{
   "_migrations/cleanup": typeof _migrations_cleanup;
   "_migrations/deleteRepos": typeof _migrations_deleteRepos;
   "_migrations/deploymentUrl": typeof _migrations_deploymentUrl;
-  "_migrations/dropWarmupFields": typeof _migrations_dropWarmupFields;
   "_migrations/logProjectIds": typeof _migrations_logProjectIds;
   "_migrations/projectInterview": typeof _migrations_projectInterview;
   "_migrations/projectPhases": typeof _migrations_projectPhases;

--- a/packages/backend/convex/_githubRepos/mutations.ts
+++ b/packages/backend/convex/_githubRepos/mutations.ts
@@ -356,6 +356,48 @@ export const updateMcpRootPrompt = authMutation({
   },
 });
 
+/**
+ * Sets an app repo's command config directly (internal, CLI/ops use). Stop
+ * commands gate seeded-snapshot builds (findSeedableAppRepos), and updateConfig
+ * is auth+ownership-checked so it cannot be driven from `npx convex run` when a
+ * deployment's config needs backfilling or repair (e.g. prod after a dev-only
+ * setup). Each array is optional; an empty array clears the field.
+ */
+export const setRepoCommandsInternal = internalMutation({
+  args: {
+    repoId: v.id("githubRepos"),
+    startupCommands: v.optional(v.array(v.string())),
+    backgroundCommands: v.optional(v.array(v.string())),
+    stopCommands: v.optional(v.array(v.string())),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const repo = await ctx.db.get(args.repoId);
+    if (!repo) throw new Error("Repository not found");
+    if (args.startupCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        startupCommands:
+          args.startupCommands.length > 0 ? args.startupCommands : undefined,
+      });
+    }
+    if (args.backgroundCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        backgroundCommands:
+          args.backgroundCommands.length > 0
+            ? args.backgroundCommands
+            : undefined,
+      });
+    }
+    if (args.stopCommands !== undefined) {
+      await ctx.db.patch(args.repoId, {
+        stopCommands:
+          args.stopCommands.length > 0 ? args.stopCommands : undefined,
+      });
+    }
+    return null;
+  },
+});
+
 /** Deletes a GitHub repo entry by ID (internal use only). */
 export const deleteInternal = internalMutation({
   args: { id: v.id("githubRepos") },

--- a/packages/backend/convex/_repoSnapshots/builds.ts
+++ b/packages/backend/convex/_repoSnapshots/builds.ts
@@ -87,7 +87,14 @@ export const getBuildStatus = internalQuery({
 
 /** Cron-triggered handler that starts a new snapshot build if none is currently running. */
 export const triggerScheduledBuild = internalMutation({
-  args: { repoSnapshotId: v.id("repoSnapshots") },
+  args: {
+    repoSnapshotId: v.id("repoSnapshots"),
+    // For operational debugging: keep the existing cron entry point but record
+    // the build as manual so completeBuild does not enqueue cron retries.
+    disableRetries: v.optional(v.boolean()),
+    forceImageRebuild: v.optional(v.boolean()),
+    forceBaseSeed: v.optional(v.boolean()),
+  },
   returns: v.null(),
   handler: async (ctx, args) => {
     const config = await ctx.db.get(args.repoSnapshotId);
@@ -117,7 +124,7 @@ export const triggerScheduledBuild = internalMutation({
     const buildId = await ctx.db.insert("snapshotBuilds", {
       repoSnapshotId: args.repoSnapshotId,
       status: "running",
-      triggeredBy: "cron",
+      triggeredBy: args.disableRetries === true ? "manual" : "cron",
       logs: "",
       startedAt: now,
     });
@@ -125,9 +132,50 @@ export const triggerScheduledBuild = internalMutation({
     await workflow.start(ctx, internal.snapshotWorkflow.snapshotBuildWorkflow, {
       buildId,
       repoSnapshotId: args.repoSnapshotId,
+      forceImageRebuild: args.forceImageRebuild,
+      forceBaseSeed: args.forceBaseSeed,
     });
 
     return null;
+  },
+});
+
+/**
+ * Internal: all sandbox ids with a real product owner. Credential-helper rows
+ * are intentionally excluded: they are implementation detail rows created for
+ * every sandbox, including leaked seed-prep sandboxes.
+ */
+export const listReferencedSandboxIds = internalQuery({
+  args: {},
+  returns: v.array(v.string()),
+  handler: async (ctx) => {
+    const ids: string[] = [];
+    const add = (sandboxId: string | undefined): void => {
+      if (sandboxId && !ids.includes(sandboxId)) ids.push(sandboxId);
+    };
+
+    const tasks = await ctx.db.query("agentTasks").collect();
+    for (const task of tasks) add(task.sandboxId);
+
+    const runs = await ctx.db.query("agentRuns").collect();
+    for (const run of runs) add(run.sandboxId);
+
+    const sessions = await ctx.db.query("sessions").collect();
+    for (const session of sessions) add(session.sandboxId);
+
+    const projects = await ctx.db.query("projects").collect();
+    for (const project of projects) add(project.sandboxId);
+
+    const designSessions = await ctx.db.query("designSessions").collect();
+    for (const session of designSessions) add(session.sandboxId);
+
+    const docs = await ctx.db.query("docs").collect();
+    for (const doc of docs) add(doc.sandboxId);
+
+    const automationRuns = await ctx.db.query("automationRuns").collect();
+    for (const run of automationRuns) add(run.sandboxId);
+
+    return ids;
   },
 });
 
@@ -272,6 +320,54 @@ export const recordSeededApp = internalMutation({
       },
     ];
     await ctx.db.patch(args.buildId, { seededApps });
+    return null;
+  },
+});
+
+/** Updates a seeded app's cache-warm status without changing its seed outcome. */
+export const updateSeededAppWarmupStatus = internalMutation({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoId: v.id("githubRepos"),
+    status: snapshotWarmupStatusValidator,
+    error: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const build = await ctx.db.get(args.buildId);
+    if (!build) return null;
+    const seededApps = (build.seededApps ?? []).map((app) => {
+      if (app.repoId !== args.repoId) return app;
+      return {
+        repoId: app.repoId,
+        app: app.app,
+        status: app.status,
+        seededSnapshotName: app.seededSnapshotName,
+        warmupStatus: args.status,
+        warmupError: args.error,
+      };
+    });
+    const seededEntries = seededApps.filter((app) => app.status === "seeded");
+    const warmupStatus: "pending" | "success" | "error" | undefined =
+      seededApps.some((app) => app.status === "running")
+        ? "pending"
+        : seededEntries.some((app) => app.warmupStatus === "error")
+          ? "error"
+          : seededEntries.some(
+                (app) => !app.warmupStatus || app.warmupStatus === "pending",
+              )
+            ? "pending"
+            : seededEntries.length > 0
+              ? "success"
+              : undefined;
+    const warmupError = seededEntries.find(
+      (app) => app.warmupStatus === "error" && app.warmupError,
+    )?.warmupError;
+    await ctx.db.patch(args.buildId, {
+      seededApps,
+      warmupStatus,
+      warmupError,
+    });
     return null;
   },
 });

--- a/packages/backend/convex/_repoSnapshots/config.ts
+++ b/packages/backend/convex/_repoSnapshots/config.ts
@@ -60,6 +60,7 @@ export const getRepoSnapshot = authQuery({
       cronJobId: v.optional(v.string()),
       workflowRef: v.optional(v.string()),
       buildCommands: v.optional(v.array(v.string())),
+      imageFingerprint: v.optional(v.string()),
       createdAt: v.number(),
       updatedAt: v.number(),
     }),
@@ -141,10 +142,25 @@ export async function findSeedableAppRepos(
 
 export const getSeedableAppRepos = internalQuery({
   args: { repoSnapshotId: v.id("repoSnapshots") },
-  returns: v.array(v.object({ repoId: v.id("githubRepos") })),
+  returns: v.array(
+    v.object({
+      repoId: v.id("githubRepos"),
+      // Current live seeded snapshot (null when falling back to the Image).
+      // The build workflow warm-boots the seed-prep sandbox from this and
+      // deletes it only after the replacement capture succeeds.
+      seededSnapshotName: v.union(v.string(), v.null()),
+      // Seed-input fingerprint stored at the last successful capture — when it
+      // still matches the current inputs the workflow skips re-seeding.
+      seededFingerprint: v.union(v.string(), v.null()),
+    }),
+  ),
   handler: async (ctx, args) => {
     const apps = await findSeedableAppRepos(ctx.db, args.repoSnapshotId);
-    return apps.map((r) => ({ repoId: r._id }));
+    return apps.map((r) => ({
+      repoId: r._id,
+      seededSnapshotName: r.seededSnapshotName ?? null,
+      seededFingerprint: r.seededFingerprint ?? null,
+    }));
   },
 });
 
@@ -222,18 +238,69 @@ export const getSeededAppStatus = authQuery({
   },
 });
 
-/** Sets (or clears) an app repo's seeded snapshot name. */
+/** Sets (or clears) an app repo's seeded snapshot name (+ input fingerprint). */
 export const setSeededSnapshotName = internalMutation({
   args: {
     repoId: v.id("githubRepos"),
     seededSnapshotName: v.union(v.string(), v.null()),
+    seededFingerprint: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.patch(args.repoId, {
       seededSnapshotName: args.seededSnapshotName ?? undefined,
+      ...(args.seededFingerprint !== undefined
+        ? { seededFingerprint: args.seededFingerprint ?? undefined }
+        : {}),
     });
     return null;
+  },
+});
+
+/**
+ * Fingerprint of an app's seed inputs: its startup/background/stop commands
+ * plus the config-file blobs of the app repo and the snapshot config's repo
+ * (data.sql / backup zips live on the parent). When this matches the value
+ * stored at the last successful seeded capture, the build workflow skips
+ * re-seeding: the resulting snapshot's data would be identical, and rebuilding
+ * it only contends with the concurrent base-image build on Daytona.
+ */
+export const getSeedFingerprint = internalQuery({
+  args: {
+    repoSnapshotId: v.id("repoSnapshots"),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const app = await ctx.db.get(args.repoId);
+    if (!app) return "missing-repo";
+    const config = await ctx.db.get(args.repoSnapshotId);
+    const fileKeys = async (repoId: Id<"githubRepos">): Promise<string[]> => {
+      const files = await ctx.db
+        .query("sandboxConfigFiles")
+        .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+        .collect();
+      return files
+        .map(
+          (f) =>
+            `${f.fileName}:${f.fileSize}:${(f.chunks ?? (f.storageId ? [f.storageId] : [])).join(",")}`,
+        )
+        .sort();
+    };
+    const payload = JSON.stringify({
+      startup: app.startupCommands ?? [],
+      background: app.backgroundCommands ?? [],
+      stop: app.stopCommands ?? [],
+      appFiles: await fileKeys(args.repoId),
+      parentFiles: config ? await fileKeys(config.repoId) : [],
+    });
+    // djb2 — cheap, deterministic, collision-resistant enough for a
+    // change-detection fingerprint (a false match only skips a re-seed).
+    let hash = 5381;
+    for (let i = 0; i < payload.length; i++) {
+      hash = (hash * 33) ^ payload.charCodeAt(i);
+    }
+    return `fp-${(hash >>> 0).toString(36)}-${payload.length}`;
   },
 });
 
@@ -246,6 +313,7 @@ export const getRepoSnapshotInternal = internalQuery({
       snapshotName: v.string(),
       workflowRef: v.optional(v.string()),
       buildCommands: v.optional(v.array(v.string())),
+      imageFingerprint: v.optional(v.string()),
     }),
     v.null(),
   ),
@@ -257,7 +325,23 @@ export const getRepoSnapshotInternal = internalQuery({
       snapshotName: doc.snapshotName,
       workflowRef: doc.workflowRef,
       buildCommands: doc.buildCommands,
+      imageFingerprint: doc.imageFingerprint,
     };
+  },
+});
+
+/** Stores the image-input fingerprint after a successful Image build. */
+export const setImageFingerprint = internalMutation({
+  args: {
+    repoSnapshotId: v.id("repoSnapshots"),
+    imageFingerprint: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.repoSnapshotId, {
+      imageFingerprint: args.imageFingerprint ?? undefined,
+    });
+    return null;
   },
 });
 

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -17,6 +17,7 @@ import {
   runStatusValidator,
   sessionModeValidator,
   sessionStatusValidator,
+  snapshotWarmupStatusValidator,
   taskActivityFieldValidator,
   taskSandboxEventValidator,
   taskSandboxStatusValidator,
@@ -198,6 +199,8 @@ export const seededAppResultValidator = v.object({
   app: v.optional(v.string()),
   status: v.optional(seededAppStatusValidator),
   seededSnapshotName: v.union(v.string(), v.null()),
+  warmupStatus: v.optional(snapshotWarmupStatusValidator),
+  warmupError: v.optional(v.string()),
 });
 
 export const githubRepoFields = {
@@ -232,6 +235,11 @@ export const githubRepoFields = {
   // the DB already seeded), set by the seeded-snapshot build when it succeeds.
   // Preferred over the base Image snapshot at sandbox-create time for fast starts.
   seededSnapshotName: v.optional(v.string()),
+  // Fingerprint of the seed inputs (startup/background/stop commands + config
+  // file blobs) captured when seededSnapshotName was built. When unchanged, the
+  // build workflow skips re-seeding — the existing snapshot's data is identical
+  // and re-capturing it would only contend with the image build.
+  seededFingerprint: v.optional(v.string()),
   devPort: v.optional(v.number()),
   devCommand: v.optional(v.string()),
   systemPrompt: v.optional(v.string()),

--- a/packages/backend/convex/daytona.ts
+++ b/packages/backend/convex/daytona.ts
@@ -13,6 +13,7 @@ export {
 
 export {
   runSandboxCommand,
+  restoreSeededRuntimeState,
   runStartupCommands,
   startupCommandsMarkerExists,
   runBackgroundCommands,

--- a/packages/backend/convex/githubRepos.ts
+++ b/packages/backend/convex/githubRepos.ts
@@ -20,6 +20,7 @@ export {
   updateConfig,
   updateMcpRootPrompt,
   toggleHidden,
+  setRepoCommandsInternal,
   deleteInternal,
 } from "./_githubRepos/mutations";
 

--- a/packages/backend/convex/repoSnapshots.ts
+++ b/packages/backend/convex/repoSnapshots.ts
@@ -9,6 +9,8 @@ export {
   getOrphanedSeededApps,
   getSeededAppStatus,
   setSeededSnapshotName,
+  getSeedFingerprint,
+  setImageFingerprint,
 } from "./_repoSnapshots/config";
 
 export {
@@ -20,6 +22,8 @@ export {
   completeBuild,
   appendLogs,
   recordSeededApp,
+  updateSeededAppWarmupStatus,
+  listReferencedSandboxIds,
 } from "./_repoSnapshots/builds";
 
 export {

--- a/packages/backend/convex/sandboxConfigFiles.ts
+++ b/packages/backend/convex/sandboxConfigFiles.ts
@@ -192,3 +192,40 @@ export const getConfigFilesForSnapshot = internalQuery({
     return Array.from(filesByName.values());
   },
 });
+
+/**
+ * Stable identity keys for the config files baked into a snapshot — same
+ * sibling aggregation as getConfigFilesForSnapshot but returns
+ * `fileName:fileSize:chunkIds` strings (storage ids are immutable, unlike the
+ * signed chunk URLs). Used to fingerprint image/seed inputs for skip decisions.
+ */
+export const getConfigFileKeys = internalQuery({
+  args: { repoId: v.id("githubRepos") },
+  returns: v.array(v.string()),
+  handler: async (ctx, args) => {
+    const anchorRepo = await ctx.db.get(args.repoId);
+    if (!anchorRepo) return [];
+    const siblings = await ctx.db
+      .query("githubRepos")
+      .withIndex("by_owner_and_name", (q) =>
+        q.eq("owner", anchorRepo.owner).eq("name", anchorRepo.name),
+      )
+      .collect();
+    const keysByName = new Map<string, string>();
+    for (const sibling of siblings) {
+      const files = await ctx.db
+        .query("sandboxConfigFiles")
+        .withIndex("by_repo", (q) => q.eq("repoId", sibling._id))
+        .collect();
+      for (const file of files) {
+        const chunkIds =
+          file.chunks ?? (file.storageId ? [file.storageId] : []);
+        keysByName.set(
+          file.fileName,
+          `${file.fileName}:${file.fileSize}:${chunkIds.join(",")}`,
+        );
+      }
+    }
+    return Array.from(keysByName.values()).sort();
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -10,8 +10,8 @@ import {
   snapshotScheduleValidator,
   snapshotBuildStatusValidator,
   snapshotBuildTriggerValidator,
-  snapshotWarmupStatusValidator,
   seededAppResultValidator,
+  snapshotWarmupStatusValidator,
   teamMemberRoleValidator,
   webhookEventStatusValidator,
   messageFields,
@@ -265,6 +265,11 @@ const schema = defineSchema({
     cronJobId: v.optional(v.string()),
     workflowRef: v.optional(v.string()),
     buildCommands: v.optional(v.array(v.string())),
+    // Fingerprint of the image inputs (lockfile sha on the build branch,
+    // buildCommands, config-file blobs, image definition version) stored at the
+    // last successful Image build. When unchanged, the build workflow skips the
+    // ~11-15m image rebuild — its output would be byte-identical.
+    imageFingerprint: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
   }).index("by_repo", ["repoId"]),

--- a/packages/backend/convex/snapshotActions.ts
+++ b/packages/backend/convex/snapshotActions.ts
@@ -9,7 +9,8 @@ import {
   getDaytona,
   buildConfigFileDownloadCommands,
   filterDownloadableConfigFiles,
-  WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
+  exec,
+  getSandbox,
   type SandboxConfigFile,
 } from "./_daytona/helpers";
 import {
@@ -29,6 +30,57 @@ import { Image } from "@daytonaio/sdk";
 import type { Id } from "./_generated/dataModel";
 
 const DAYTONA_API_URL = "https://app.daytona.io/api";
+const SEED_PREP_LABEL_KEY = "eva.purpose";
+const SEED_PREP_LABEL_VALUE = "snapshot-seed-prep";
+const SEEDED_SNAPSHOT_WARM_READY_TIMEOUT_SECONDS = 300;
+
+function shouldCaptureSupabaseState(commands: string[]): boolean {
+  return commands.some((command) => {
+    const lower = command.toLowerCase();
+    return (
+      lower.includes("supabase") ||
+      lower.includes("start-db") ||
+      lower.includes("seed:sql")
+    );
+  });
+}
+
+function seededRuntimeStateCaptureLines(
+  requireSupabaseDump: boolean,
+): string[] {
+  return [
+    'echo "SEEDRUN-STAGE:capture-runtime-state"',
+    `REQUIRE_SUPABASE_DUMP=${requireSupabaseDump ? "1" : "0"}`,
+    "mkdir -p /home/eva/.eva-snapshot-state",
+    "rm -f /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz",
+    'if [ "$REQUIRE_SUPABASE_DUMP" != "1" ]; then',
+    '  echo "repo does not require Supabase state capture; skipping"',
+    "elif ! docker ps --filter name=supabase_db_web --filter status=running -q | grep -q .; then",
+    "  if docker ps -a --filter name=supabase_db_web -q | grep -q .; then",
+    "    docker start supabase_db_web >/dev/null",
+    "  else",
+    "    ( cd /tmp/repo && pnpm start-db ) || true",
+    "  fi",
+    "fi",
+    'if [ "$REQUIRE_SUPABASE_DUMP" = "1" ]; then',
+    "  for i in $(seq 1 240); do docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done",
+    '  docker exec supabase_db_web pg_isready -U postgres >/dev/null 2>&1 || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }',
+    "  dump_supabase_public_data() { ( set -o pipefail; docker exec supabase_db_web pg_dump -U postgres -d postgres --schema=public --data-only --no-owner --no-privileges | gzip -1 > /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz ); }",
+    "  count_supabase_dump_rows() { gzip -dc /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz | awk 'BEGIN{in_copy=0;c=0} /^COPY public\\./{in_copy=1;next} /^\\\\\\.$/{in_copy=0;next} in_copy{c++} END{print c}'; }",
+    '  dump_supabase_public_data || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }',
+    "  SUPABASE_DUMP_ROWS=$(count_supabase_dump_rows)",
+    '  if [ "$SUPABASE_DUMP_ROWS" = "0" ] && [ -f packages/db/data.sql ]; then echo "Supabase dump was empty; rerunning pnpm seed:sql before capture"; pnpm seed:sql || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }; dump_supabase_public_data || { echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; }; SUPABASE_DUMP_ROWS=$(count_supabase_dump_rows); fi',
+    '  if [ "$SUPABASE_DUMP_ROWS" = "0" ]; then echo "SEEDRUN-FAILED:capture-runtime-state"; exit 1; fi',
+    '  echo "supabase_dump_rows=$SUPABASE_DUMP_ROWS"',
+    "  ls -lh /home/eva/.eva-snapshot-state/supabase-db-web.pg_dump.sql.gz",
+    "fi",
+  ];
+}
+
+// Bump when buildSnapshotImage's content changes (new tools, base image, or
+// layer commands) so existing image fingerprints invalidate and the next build
+// rebuilds the Image even though repo/config inputs are unchanged.
+const IMAGE_DEF_VERSION = 1;
 
 // "eva ALL=(ALL) NOPASSWD: ALL\n" — base64-encoded to avoid parentheses breaking Dockerfile RUN
 const EVA_SUDOERS_B64 = "ZXZhIEFMTD0oQUxMKSBOT1BBU1NXRDogQUxMCg==";
@@ -517,49 +569,341 @@ export const deleteDaytonaSnapshot = internalAction({
 });
 
 /**
- * Propagation probe: boots ONE cheap ephemeral sandbox from the base Image
- * snapshot, then deletes it. A freshly-built snapshot is not immediately
- * available on Daytona runners (propagation lag), so `daytona.create` returns
- * "No available runners" until propagation completes. The seeded-snapshot
- * workflow calls this in a poll loop BEFORE fanning out per-app seed-prep
- * sandboxes, so the expensive seed work only starts once the snapshot is
- * actually bootable. Returns "available" on a successful create+delete, or
- * "unavailable" on any create failure (never throws on the create itself — the
- * workflow owns the retry loop). A successful probe also warms the cache.
+ * Deletes seed-prep sandboxes that were created by the snapshot workflow and
+ * no longer have a product owner in Convex. This is intentionally label-gated:
+ * older unlabelled leaks still need a one-off guarded audit, while the workflow
+ * can safely self-heal everything it creates after this change.
  */
-export const probeSnapshotAvailability = internalAction({
-  args: { repoId: v.id("githubRepos"), imageSnapshot: v.string() },
-  returns: v.union(v.literal("available"), v.literal("unavailable")),
-  handler: async (ctx, args): Promise<"available" | "unavailable"> => {
-    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
-      ctx,
-      args.repoId,
-    );
+export const sweepSeedPrepSandboxes = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    scopedRepoIds: v.optional(v.array(v.id("githubRepos"))),
+    buildId: v.optional(v.id("snapshotBuilds")),
+  },
+  returns: v.object({
+    scanned: v.number(),
+    matched: v.number(),
+    deleted: v.number(),
+    skippedReferenced: v.number(),
+    failed: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
     const daytona = getDaytona(daytonaApiKey);
+    const referenced = new Set(
+      await ctx.runQuery(internal.repoSnapshots.listReferencedSandboxIds, {}),
+    );
+    const scopedRepoIds = args.scopedRepoIds ?? [];
+    const scopedRepoIdStrings: string[] = [];
+    for (const repoId of scopedRepoIds) {
+      scopedRepoIdStrings.push(repoId);
+    }
+
+    let scanned = 0;
+    let matched = 0;
+    let deleted = 0;
+    let skippedReferenced = 0;
+    let failed = 0;
+    let page = 1;
+    const limit = 100;
+
+    while (true) {
+      const result = await daytona.list({
+        page: String(page),
+        limit: String(limit),
+      });
+      const items = result.items;
+      scanned += items.length;
+
+      for (const sandbox of items) {
+        if (sandbox.labels[SEED_PREP_LABEL_KEY] !== SEED_PREP_LABEL_VALUE) {
+          continue;
+        }
+        const sandboxRepoId = sandbox.labels["eva.repoId"];
+        if (
+          scopedRepoIdStrings.length > 0 &&
+          (sandboxRepoId === undefined ||
+            !scopedRepoIdStrings.includes(sandboxRepoId))
+        ) {
+          continue;
+        }
+        matched += 1;
+        if (referenced.has(sandbox.id)) {
+          skippedReferenced += 1;
+          continue;
+        }
+        try {
+          await sandbox.delete();
+          deleted += 1;
+          await ctx.runMutation(
+            internal.sandboxGitCredentials.deleteBySandboxId,
+            { sandboxId: sandbox.id },
+          );
+        } catch (e) {
+          failed += 1;
+          console.warn(
+            `[snapshot] failed to delete seed-prep sandbox ${sandbox.id}: ${
+              e instanceof Error ? e.message : String(e)
+            }`,
+          );
+        }
+      }
+
+      if (items.length < limit) break;
+      page += 1;
+    }
+
+    if (args.buildId) {
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk:
+          `[seed-prep sweep] scanned=${scanned}, matched=${matched}, deleted=${deleted}, ` +
+          `referenced=${skippedReferenced}, failed=${failed}\n`,
+      });
+    }
+
+    return { scanned, matched, deleted, skippedReferenced, failed };
+  },
+});
+
+/**
+ * Fingerprint of the Image inputs: the dependency lockfile's blob sha on the
+ * build branch, the build commands, the config-file blobs baked into the image,
+ * and IMAGE_DEF_VERSION. When this matches the value stored at the last
+ * successful Image build, the workflow skips the ~11-15m rebuild — the output
+ * would be byte-identical (sandboxes fetch fresh branches at boot, so a repo
+ * checkout that is a few commits stale costs nothing; node_modules only drift
+ * when the lockfile changes, which changes this fingerprint). Returns null when
+ * the inputs cannot be determined (e.g. lockfile lookup fails) — callers must
+ * treat null as "always rebuild".
+ */
+export const getImageFingerprint = internalAction({
+  args: { repoSnapshotId: v.id("repoSnapshots") },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args): Promise<string | null> => {
+    const config = await ctx.runQuery(
+      internal.repoSnapshots.getRepoSnapshotInternal,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+    if (!config) return null;
     const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
-      repoId: args.repoId,
+      repoId: config.repoId,
     });
-    if (!repo) throw new Error("Repo not found");
+    if (!repo) return null;
+    const branch = config.workflowRef ?? "main";
+    let lockfileSha: string | null = null;
     try {
-      const sandbox = await createSandbox(
-        daytona,
-        repo.installationId,
-        sandboxEnvVars,
-        WARMING_LIFECYCLE,
-        args.imageSnapshot,
-        undefined,
-        WARMING_SANDBOX_READY_TIMEOUT_SECONDS,
-      );
-      await sandbox.delete();
-      return "available";
-    } catch (err) {
-      console.log(
-        `[snapshot] propagation probe for ${args.imageSnapshot} not ready: ${
-          err instanceof Error ? err.message : String(err)
+      const token = await getInstallationToken(repo.installationId);
+      for (const lockfile of [
+        "pnpm-lock.yaml",
+        "package-lock.json",
+        "yarn.lock",
+      ]) {
+        const resp = await fetch(
+          `https://api.github.com/repos/${repo.owner}/${repo.name}/contents/${lockfile}?ref=${encodeURIComponent(branch)}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/vnd.github+json",
+            },
+          },
+        );
+        if (resp.ok) {
+          const data: unknown = await resp.json();
+          if (isRecord(data) && typeof data["sha"] === "string") {
+            lockfileSha = data["sha"];
+            break;
+          }
+        }
+      }
+    } catch (e) {
+      console.error(
+        `[snapshot] image fingerprint: lockfile lookup failed: ${
+          e instanceof Error ? e.message : String(e)
         }`,
       );
-      return "unavailable";
+      return null;
     }
+    if (!lockfileSha) return null;
+    const fileKeys: string[] = await ctx.runQuery(
+      internal.sandboxConfigFiles.getConfigFileKeys,
+      { repoId: config.repoId },
+    );
+    const payload = JSON.stringify({
+      v: IMAGE_DEF_VERSION,
+      branch,
+      lockfileSha,
+      buildCommands: config.buildCommands ?? [],
+      files: fileKeys,
+    });
+    let hash = 5381;
+    for (let i = 0; i < payload.length; i++) {
+      hash = (hash * 33) ^ payload.charCodeAt(i);
+    }
+    return `img-${(hash >>> 0).toString(36)}-${payload.length}`;
+  },
+});
+
+/**
+ * Seeded-snapshot build — LAUNCH step. Composes the app's whole seed sequence
+ * (startup commands → marker → stop commands) into one bash script and launches
+ * it DETACHED on the prep sandbox (setsid nohup), returning immediately.
+ *
+ * Convex actions have a hard 600s ceiling, so running seed commands
+ * synchronously inside actions caps every command at ~9 minutes — cold docker
+ * pulls and slow readiness waits blew through it repeatedly on prod. Detached,
+ * the script takes as long as it needs; the workflow polls pollSeedRun for the
+ * outcome markers, mirroring the trigger+poll pattern used for captures.
+ */
+export const launchSeedRun = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+    // Branch to hard-reset /tmp/repo to (refs must already be fetched — the
+    // workflow runs daytona.fetchBaseBranch first, which owns git auth).
+    branch: v.string(),
+    // Repo build commands (pnpm install / codegen etc), run after the reset so
+    // the captured snapshot carries fresh node_modules and build artifacts.
+    buildCommands: v.array(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const startupCommands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getStartupCommands,
+      { repoId: args.repoId },
+    );
+    const backgroundCommands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getBackgroundCommands,
+      { repoId: args.repoId },
+    );
+    const stopCommands: string[] | null = await ctx.runQuery(
+      internal.repoSnapshots.getStopCommands,
+      { repoId: args.repoId },
+    );
+    const requireSupabaseDump = shouldCaptureSupabaseState([
+      ...(startupCommands ?? []),
+      ...(backgroundCommands ?? []),
+      ...(stopCommands ?? []),
+    ]);
+    const lines: string[] = [
+      "#!/bin/bash",
+      "exec > /tmp/seedrun.log 2>&1",
+      "set -x",
+      "rm -f /tmp/.seedrun-done",
+      // ---- update: latest code + fresh deps/artifacts ----
+      'echo "SEEDRUN-STAGE:update"',
+      'cd /tmp/repo || { echo "SEEDRUN-FAILED:no-repo"; exit 1; }',
+      `( git checkout -f ${args.branch} 2>/dev/null || git checkout -fb ${args.branch} origin/${args.branch} ) && git reset --hard origin/${args.branch} || { echo "SEEDRUN-FAILED:git-reset"; exit 1; }`,
+    ];
+    args.buildCommands.forEach((command, i) => {
+      lines.push(
+        `( ${command} ) || { echo "SEEDRUN-FAILED:build-${i}"; exit 1; }`,
+      );
+    });
+    // ---- daemons: launch each background command detached (b64 per command
+    // so quoting inside user commands can never break the script) ----
+    lines.push('echo "SEEDRUN-STAGE:daemons"');
+    (backgroundCommands ?? []).forEach((command, i) => {
+      const cb64 = Buffer.from(command, "utf8").toString("base64");
+      lines.push(
+        `echo ${cb64} | base64 -d > /tmp/bg-cmd-${i}.sh && chmod +x /tmp/bg-cmd-${i}.sh && setsid nohup bash -l /tmp/bg-cmd-${i}.sh </dev/null > /tmp/bg-${i}.log 2>&1 &`,
+      );
+    });
+    // ---- seed ----
+    lines.push('echo "SEEDRUN-STAGE:startup"');
+    (startupCommands ?? []).forEach((command, i) => {
+      // Subshell so `cd`/env in one command can't leak into the next, matching
+      // how runSandboxCommand executed them as separate execs.
+      lines.push(
+        `( ${command} ) || { echo "SEEDRUN-FAILED:startup-${i}"; exit 1; }`,
+      );
+    });
+    lines.push(...seededRuntimeStateCaptureLines(requireSupabaseDump));
+    // Marker so a sandbox booting from the captured snapshot skips the seed.
+    lines.push("touch /tmp/.startup-commands-done");
+    (stopCommands ?? []).forEach((command, i) => {
+      lines.push(
+        `( ${command} ) || { echo "SEEDRUN-FAILED:stop-${i}"; exit 1; }`,
+      );
+    });
+    lines.push('echo "SEEDRUN-DONE"', "touch /tmp/.seedrun-done");
+    const script = lines.join("\n");
+    const b64 = Buffer.from(script, "utf8").toString("base64");
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    // Process-based guard makes the launch idempotent so the workflow can
+    // retry a timed-out launch exec without racing a second copy. It must be
+    // the LIVE process (pgrep, self-match-proof bracket pattern), not a
+    // lockfile: a prep sandbox warm-booted from a previously captured seeded
+    // snapshot carries that capture's marker files baked into /tmp, and a
+    // file-based guard would skip the launch and instantly report the baked
+    // "done" — capturing without ever re-seeding. Stale markers are scrubbed
+    // before every fresh launch for the same reason.
+    await exec(
+      sandbox,
+      `if pgrep -f "[s]eedrun.sh" >/dev/null; then echo ALREADY-RUNNING; else rm -f /tmp/.seedrun-done /tmp/seedrun.log && echo ${b64} | base64 -d > /tmp/seedrun.sh && chmod +x /tmp/seedrun.sh && setsid nohup /tmp/seedrun.sh </dev/null >/dev/null 2>&1 & echo LAUNCHED; fi`,
+      120,
+    );
+    return null;
+  },
+});
+
+/**
+ * Seeded-snapshot build — DIAGNOSTICS step. Returns the tail of the seed-run
+ * log and background daemon logs so a failed seed can be appended to the build
+ * record BEFORE the prep sandbox is torn down (teardown destroys the evidence).
+ */
+export const fetchSeedDiagnostics = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    try {
+      return await exec(
+        sandbox,
+        [
+          'echo "== git state =="',
+          "( cd /tmp/repo && git rev-parse --short HEAD 2>&1; git status -s 2>&1 | head -5 )",
+          'echo "== convex versions =="',
+          "( cd /tmp/repo && npx convex --version 2>&1; ls -la ~/.convex/ 2>&1 | head; ls -la ~/.cache/convex/ 2>&1 | head )",
+          'echo "== 3210 listening? =="',
+          "curl -s -o /dev/null -w 'backend http:%{http_code}\\n' http://127.0.0.1:3210 2>&1 || echo '3210 unreachable'",
+          'echo "== seedrun.log (tail) =="; tail -c 4000 /tmp/seedrun.log 2>/dev/null',
+          'for f in /tmp/bg-*.log; do echo; echo "== $f =="; tail -c 3000 "$f" 2>/dev/null; done',
+          "true",
+        ].join("; "),
+        90,
+      );
+    } catch (e) {
+      return `diagnostics unavailable: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  },
+});
+
+/**
+ * Seeded-snapshot build — SEED POLL step. Returns "done" when the detached
+ * seed script finished cleanly, "failed:<stage>" when it aborted (stage names
+ * the command index, e.g. startup-3), and "running" otherwise.
+ */
+export const pollSeedRun = internalAction({
+  args: {
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.string(),
+  handler: async (ctx, args): Promise<string> => {
+    const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+    const out = await exec(
+      sandbox,
+      'test -f /tmp/.seedrun-done && echo DONE; grep -aoE "SEEDRUN-FAILED:[a-z0-9-]+" /tmp/seedrun.log 2>/dev/null | tail -1; true',
+      30,
+    );
+    if (out.includes("DONE")) return "done";
+    const failed = out.match(/SEEDRUN-FAILED:([a-z0-9-]+)/);
+    if (failed) return `failed:${failed[1]}`;
+    return "running";
   },
 });
 
@@ -581,6 +925,14 @@ export const createSeedPrepSandbox = internalAction({
       repoId: args.repoId,
     });
     if (!repo) throw new Error("Repo not found");
+    const seedPrepLifecycle = {
+      ...SESSION_LIFECYCLE,
+      labels: {
+        "eva.managed": "true",
+        [SEED_PREP_LABEL_KEY]: SEED_PREP_LABEL_VALUE,
+        "eva.repoId": args.repoId,
+      },
+    };
     const { sandbox } = await createSandboxAndPrepareRepo(
       ctx,
       daytona,
@@ -588,8 +940,15 @@ export const createSeedPrepSandbox = internalAction({
       repo.owner,
       repo.name,
       { ...sandboxEnvVars, REPO_ID: args.repoId },
-      SESSION_LIFECYCLE,
+      seedPrepLifecycle,
       args.imageSnapshot,
+      undefined, // volumes
+      undefined, // onSandboxAcquired
+      undefined, // onProgress
+      { mode: "all" }, // syncStrategy
+      // Large seeded snapshots take well over the 30s default to boot; 180s
+      // avoids the spurious create timeout + orphaned sandbox on warm boots.
+      180,
     );
     return { sandboxId: sandbox.id };
   },
@@ -661,5 +1020,101 @@ export const pollSeededSnapshotState = internalAction({
     // Not registered yet (or a transient lookup miss) → treat as still pending.
     const snapshot = await getSnapshot(daytona, args.seededName);
     return snapshot ? snapshot.state : "pending";
+  },
+});
+
+/**
+ * Warms Daytona's create-from-snapshot cache for a newly active seeded snapshot.
+ * The first sandbox from a large seeded filesystem can take several minutes;
+ * paying that cost inside the build makes the next user-created sandbox fast.
+ */
+export const warmSeededSnapshotCache = internalAction({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoId: v.id("githubRepos"),
+    seededName: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) {
+      await ctx.runMutation(
+        internal.repoSnapshots.updateSeededAppWarmupStatus,
+        {
+          buildId: args.buildId,
+          repoId: args.repoId,
+          status: "error",
+          error: "Repo not found",
+        },
+      );
+      return null;
+    }
+
+    const daytona = getDaytona(daytonaApiKey);
+    let sandboxId: string | null = null;
+    try {
+      const sandbox = await createSandbox(
+        daytona,
+        repo.installationId,
+        { ...sandboxEnvVars, REPO_ID: args.repoId },
+        {
+          ...WARMING_LIFECYCLE,
+          labels: {
+            "eva.managed": "true",
+            "eva.purpose": "snapshot-warmup",
+            "eva.repoId": args.repoId,
+            "eva.snapshotName": args.seededName,
+          },
+        },
+        args.seededName,
+        undefined,
+        SEEDED_SNAPSHOT_WARM_READY_TIMEOUT_SECONDS,
+      );
+      sandboxId = sandbox.id;
+      await sandbox.delete();
+      sandboxId = null;
+      await ctx.runMutation(
+        internal.repoSnapshots.updateSeededAppWarmupStatus,
+        {
+          buildId: args.buildId,
+          repoId: args.repoId,
+          status: "success",
+        },
+      );
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[warm ${args.repoId}] warmed ${args.seededName}\n`,
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      await ctx.runMutation(
+        internal.repoSnapshots.updateSeededAppWarmupStatus,
+        {
+          buildId: args.buildId,
+          repoId: args.repoId,
+          status: "error",
+          error: message,
+        },
+      );
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[warm ${args.repoId}] failed for ${args.seededName}: ${message}\n`,
+      });
+      if (sandboxId) {
+        try {
+          const sandbox = await daytona.get(sandboxId);
+          await sandbox.delete();
+        } catch {
+          // Best-effort cleanup only; the warming lifecycle is ephemeral.
+        }
+      }
+    }
+    return null;
   },
 });

--- a/packages/backend/convex/snapshotWorkflow.ts
+++ b/packages/backend/convex/snapshotWorkflow.ts
@@ -6,41 +6,66 @@ import { isTerminalSnapshotState } from "./_daytona/snapshotStates";
 const POLL_DELAY_MS = 30_000;
 const MAX_POLLS = 60; // ~30 minutes at 30s intervals
 
-// Propagation-probe loop (Step 5 gate). A freshly-built base snapshot is not
-// immediately bootable on Daytona runners; creating a sandbox from it returns
-// "No available runners" until propagation completes. We probe with one cheap
-// ephemeral sandbox until it succeeds, THEN seed — so seed-prep creates don't
-// race the lag.
-const PROBE_DELAY_MS = 30_000;
-const MAX_PROBE_ATTEMPTS = 20; // ~10 minutes at 30s intervals
+// Detached seed-run poll loop (per app). The whole per-app pipeline (git
+// update, deps/build, daemons, seed, clean stop) runs as ONE detached script on
+// the sandbox (launchSeedRun) so no Convex action ever waits on a slow command
+// — cold docker pulls or readiness waits can take as long as they need. The
+// workflow just polls the script's outcome markers.
+const SEED_RUN_POLL_DELAY_MS = 20_000;
+const MAX_SEED_RUN_POLLS = 150; // ~50 minutes at 20s intervals
 
-// Seeded-snapshot capture poll loop (Step 5, per app). The capture is triggered
+// Seeded-snapshot capture poll loop (per app). The capture is triggered
 // without blocking (triggerSeededSnapshot) then polled here across separate
 // steps, so a long DB-volume capture never exceeds Convex's 600s per-action
 // ceiling. We poll the snapshot entity until it reaches "active" (success) or a
 // failure state — see pollSeededSnapshotState for why the sandbox state is not
 // a reliable completion signal.
-const SEED_SNAPSHOT_POLL_DELAY_MS = 30_000;
-const MAX_SEED_SNAPSHOT_POLLS = 60; // ~30 minutes at 30s intervals
+const SEED_SNAPSHOT_POLL_DELAY_MS = 15_000;
+const MAX_SEED_SNAPSHOT_POLLS = 240; // ~60 minutes at 15s intervals — captures
+// normally finish in ~6m but have been observed taking 40m+ when the Daytona
+// builder/runner fleet is degraded; the window must outlast a bad day because
+// exhausting it costs the app its seeded refresh for this build.
 
 /**
- * Workflow that orchestrates a full Daytona snapshot build:
- *   0. Delete existing snapshot and wait for removal
- *   1. Kick off the build (non-blocking POST to Daytona API)
- *   2. Poll snapshot state + stream build logs until terminal
- *   3. Complete the build record
+ * Snapshot build workflow — sandbox-native model.
  *
- * Each step is a separate action with its own timeout, so builds
- * that take 15–20 minutes don't hit Convex action limits.
+ * Each app's snapshot is refreshed INSIDE a sandbox booted from its previous
+ * seeded snapshot (warm: toolchain, service docker images, node_modules and
+ * local backends all present), rather than via a separate declarative Image
+ * build:
+ *
+ *   per app, in parallel:
+ *     1. boot a sandbox from the app's previous seeded snapshot
+ *        (fallback: the base Image snapshot when no seeded exists yet)
+ *     2. fetch latest refs (fetchBaseBranch owns git auth)
+ *     3. run ONE detached script: git reset to the build branch → repo build
+ *        commands (fresh deps/artifacts) → launch background daemons → seed
+ *        commands → marker → clean stop; the workflow polls its markers
+ *     4. capture a versioned snapshot (seeded-<repoId>-<buildId>), poll to
+ *        active, swap the repo pointer, then delete the previous snapshot
+ *        (keep-last-good: a failure at any point leaves the old snapshot live)
+ *
+ * Everything a sandbox boot needs is refreshed every build — code, deps, build
+ * artifacts, seeded data — with no separate Image rebuild (~11-15m serial, and
+ * observed 2-4x slower when captures ran concurrently against Daytona's
+ * builder). The declarative Image build remains ONLY as the bootstrap /
+ * toolchain-change path, behind forceImageRebuild (run it when an app has no
+ * seeded snapshot yet, or buildSnapshotImage's tool layers change).
  */
 export const snapshotBuildWorkflow = workflow.define({
   args: {
     buildId: v.id("snapshotBuilds"),
     repoSnapshotId: v.id("repoSnapshots"),
+    // Rebuild the declarative base Image first (bootstrap / toolchain
+    // changes). The nightly cron and Rebuild Now leave this unset.
+    forceImageRebuild: v.optional(v.boolean()),
+    // Operational bootstrap path: seed app snapshots from the base Image
+    // instead of their previous seeded snapshots. Use once when a seeded app
+    // snapshot is too stale to boot its local services cleanly.
+    forceBaseSeed: v.optional(v.boolean()),
   },
   handler: async (step, args) => {
-    // Step 0: Resolve config to get snapshotName/repoId for the delete step.
-    // kickOffSnapshotBuild also resolves config, but we need the names up front.
+    // Resolve config + repo (owner/name/installation drive git fetch auth).
     const config = await step.runQuery(
       internal.repoSnapshots.getRepoSnapshotInternal,
       { repoSnapshotId: args.repoSnapshotId },
@@ -54,282 +79,389 @@ export const snapshotBuildWorkflow = workflow.define({
       });
       return;
     }
-
-    // Step 1: Delete existing snapshot and wait for removal to finish
-    await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
-      snapshotName: config.snapshotName,
+    const repo = await step.runQuery(internal.repoSnapshots.getRepo, {
       repoId: config.repoId,
-      buildId: args.buildId,
     });
-
-    // Step 2: Resolve config, POST to Daytona to start the build
-    const kickOffResult = await step.runAction(
-      internal.snapshotActions.kickOffSnapshotBuild,
-      {
-        buildId: args.buildId,
-        repoSnapshotId: args.repoSnapshotId,
-      },
-    );
-
-    // If kick-off failed, it already called completeBuild with error — stop
-    if (!kickOffResult) return;
-
-    const { snapshotName, repoId } = kickOffResult;
-
-    // Step 3: Poll snapshot state + stream logs until terminal state
-    let attempt = 0;
-    let state = "";
-    while (attempt < MAX_POLLS) {
-      attempt++;
-
-      const pollResult = await step.runAction(
-        internal.snapshotActions.pollSnapshotProgress,
-        {
-          buildId: args.buildId,
-          snapshotName,
-          repoId,
-          attempt,
-        },
-        { runAfter: attempt === 1 ? 10_000 : POLL_DELAY_MS },
-      );
-
-      state = pollResult;
-
-      if (isTerminalSnapshotState(state)) break;
-    }
-
-    // Step 4: Finalize — if we exhausted polls without terminal state, mark timeout
-    if (!isTerminalSnapshotState(state)) {
+    if (!repo) {
       await step.runMutation(internal.repoSnapshots.completeBuild, {
         buildId: args.buildId,
         status: "error",
-        logs: `Max poll attempts (${MAX_POLLS}) reached.\n`,
-        error:
-          "Snapshot build did not complete within polling window (~30 minutes)",
+        logs: "",
+        error: "GitHub repo not found",
+      });
+      return;
+    }
+    const branch = config.workflowRef ?? "main";
+
+    const apps = await step.runQuery(
+      internal.repoSnapshots.getSeedableAppRepos,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+
+    try {
+      await step.runAction(internal.snapshotActions.sweepSeedPrepSandboxes, {
+        repoId: config.repoId,
+        scopedRepoIds: apps.map((app) => app.repoId),
+        buildId: args.buildId,
+      });
+    } catch (e) {
+      await step.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[seed-prep sweep] skipped after error: ${e instanceof Error ? e.message : String(e)}\n`,
       });
     }
 
-    // Step 5: Per-app seeded snapshots (best-effort). Only once the base Image is
-    // active. For each app repo with stopCommands, boot a sandbox from the Image,
-    // bring services up, run the one-time seed, clean-stop so volumes flush, then
-    // capture a filesystem snapshot with the DB baked in. A sandbox for that app
-    // then boots from `seeded-<repoId>` (see getRepoSnapshotName) and skips the
-    // ~10-min seed. Failures fall back to the Image (seededSnapshotName left clear).
-    if (state === "active") {
-      // Gate: wait until the freshly-built base snapshot is actually bootable on
-      // a runner before seeding. One cheap ephemeral probe sandbox per attempt;
-      // proceed on the first success. If propagation never completes within the
-      // window, skip seeding entirely — apps keep the base-Image fallback
-      // (seededSnapshotName stays clear), matching the per-app catch below.
-      let propagated = false;
-      for (
-        let attempt = 1;
-        attempt <= MAX_PROBE_ATTEMPTS && !propagated;
-        attempt++
-      ) {
-        const probe = await step.runAction(
-          internal.snapshotActions.probeSnapshotAvailability,
-          { repoId: config.repoId, imageSnapshot: config.snapshotName },
-          { runAfter: attempt === 1 ? 10_000 : PROBE_DELAY_MS },
+    // Best-effort cleanup: delete seeded snapshots for siblings that are no
+    // longer seedable (e.g. dropped stopCommands) and clear their stale name.
+    // The per-app chains below only manage snapshots for CURRENTLY seedable
+    // apps, so without this an ex-seedable app's seeded-<repoId> would linger
+    // in Daytona forever. A failed cleanup must not fail the build.
+    const orphans = await step.runQuery(
+      internal.repoSnapshots.getOrphanedSeededApps,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+    for (const orphan of orphans) {
+      try {
+        await step.runAction(internal.snapshotActions.deleteDaytonaSnapshot, {
+          snapshotName: orphan.seededSnapshotName,
+          repoId: orphan.repoId,
+        });
+        await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
+          repoId: orphan.repoId,
+          seededSnapshotName: null,
+        });
+        console.log(
+          `[snapshot] cleaned up orphaned seeded snapshot ${orphan.seededSnapshotName} (repo ${orphan.repoId} no longer seedable)`,
         );
-        propagated = probe === "available";
-      }
-      if (!propagated) {
+      } catch (e) {
         console.error(
-          `[snapshot] base snapshot ${config.snapshotName} not bootable after ${MAX_PROBE_ATTEMPTS} probes — skipping seeding (apps fall back to base Image)`,
+          `[snapshot] failed to clean up orphaned seeded snapshot ${orphan.seededSnapshotName}: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
         );
+      }
+    }
+
+    // Bootstrap / toolchain path: rebuild the declarative base Image first
+    // (serial — captures contending with the Image builder slow both down).
+    if (args.forceImageRebuild) {
+      await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
+        snapshotName: config.snapshotName,
+        repoId: config.repoId,
+        buildId: args.buildId,
+      });
+      const kickOffResult = await step.runAction(
+        internal.snapshotActions.kickOffSnapshotBuild,
+        { buildId: args.buildId, repoSnapshotId: args.repoSnapshotId },
+      );
+      // Kick-off failure already recorded completeBuild(error).
+      if (!kickOffResult) return;
+      let attempt = 0;
+      let state = "";
+      while (attempt < MAX_POLLS) {
+        attempt++;
+        state = await step.runAction(
+          internal.snapshotActions.pollSnapshotProgress,
+          {
+            buildId: args.buildId,
+            snapshotName: kickOffResult.snapshotName,
+            repoId: kickOffResult.repoId,
+            attempt,
+          },
+          { runAfter: attempt === 1 ? 10_000 : POLL_DELAY_MS },
+        );
+        if (isTerminalSnapshotState(state)) break;
+      }
+      if (state !== "active") {
+        // pollSnapshotProgress recorded the error terminal states; timeouts
+        // need recording here. Either way there is no bootable image to seed
+        // from, so stop.
+        if (!isTerminalSnapshotState(state)) {
+          await step.runMutation(internal.repoSnapshots.completeBuild, {
+            buildId: args.buildId,
+            status: "error",
+            logs: `Max poll attempts (${MAX_POLLS}) reached.\n`,
+            error:
+              "Snapshot build did not complete within polling window (~30 minutes)",
+          });
+        }
         return;
       }
+    } else {
+      await step.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: args.forceBaseSeed
+          ? `Sandbox-native build: updating + reseeding ${apps.length} app(s) from the base Image (branch: ${branch}).\n`
+          : `Sandbox-native build: updating + reseeding ${apps.length} app(s) from their previous seeded snapshots (branch: ${branch}).\n`,
+      });
+    }
 
-      const apps = await step.runQuery(
-        internal.repoSnapshots.getSeedableAppRepos,
-        { repoSnapshotId: args.repoSnapshotId },
-      );
+    // Whether the base Image exists (fallback boot source for apps that have
+    // no seeded snapshot yet).
+    const imageState = await step.runAction(
+      internal.snapshotActions.pollSeededSnapshotState,
+      { repoId: config.repoId, seededName: config.snapshotName },
+    );
 
-      // Best-effort cleanup: delete seeded snapshots for siblings that are no
-      // longer seedable (e.g. dropped stopCommands) and clear their stale name.
-      // The per-app loop below only deletes snapshots for CURRENTLY seedable
-      // apps, so without this an ex-seedable app's seeded-<repoId> would linger
-      // in Daytona forever. A failed cleanup must not fail the build.
-      const orphans = await step.runQuery(
-        internal.repoSnapshots.getOrphanedSeededApps,
-        { repoSnapshotId: args.repoSnapshotId },
-      );
-      for (const orphan of orphans) {
-        try {
-          await step.runAction(internal.snapshotActions.deleteDaytonaSnapshot, {
-            snapshotName: orphan.seededSnapshotName,
-            repoId: orphan.repoId,
-          });
-          await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
-            repoId: orphan.repoId,
-            seededSnapshotName: null,
-          });
-          console.log(
-            `[snapshot] cleaned up orphaned seeded snapshot ${orphan.seededSnapshotName} (repo ${orphan.repoId} no longer seedable)`,
-          );
-        } catch (e) {
-          console.error(
-            `[snapshot] failed to clean up orphaned seeded snapshot ${orphan.seededSnapshotName}: ${
-              e instanceof Error ? e.message : String(e)
-            }`,
+    // Per-app pipeline. Versioned capture name (buildId is unique per build):
+    // the previous seeded snapshot stays LIVE and untouched until the
+    // replacement is active, so a failed build never costs an app its warm
+    // snapshot — sandboxes keep booting from the old one and the next build
+    // warm-boots from it. Only after a successful swap is the old snapshot
+    // deleted (keep-last-good).
+    const runSeedChain = async (
+      app: (typeof apps)[number],
+    ): Promise<boolean> => {
+      const seededName = `seeded-${app.repoId}-${args.buildId}`;
+      let prepSandboxId: string | null = null;
+      try {
+        // Mark this app as actively seeding so the UI shows a spinner until
+        // it resolves to seeded/fallback below.
+        await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+          buildId: args.buildId,
+          repoId: app.repoId,
+          status: "running",
+          seededSnapshotName: null,
+        });
+        // Boot source cascade: previous seeded snapshot (warm: toolchain +
+        // service images + deps all present) → base Image (bootstrap). The
+        // retry/backoff absorbs runner propagation lag on fresh snapshots.
+        const sources = [
+          ...(app.seededSnapshotName && args.forceBaseSeed !== true
+            ? [app.seededSnapshotName]
+            : []),
+          ...(imageState === "active" ? [config.snapshotName] : []),
+        ];
+        if (sources.length === 0) {
+          throw new Error(
+            `No boot source for ${app.repoId}: no previous seeded snapshot and no base Image — run forceImageRebuild to bootstrap`,
           );
         }
-      }
-
-      // Build all apps' seeded snapshots in PARALLEL (each chain is independent).
-      // Trade-off: more concurrent Daytona runner demand — the createSeedPrepSandbox
-      // retry/backoff above absorbs transient "No available runners".
-      await Promise.all(
-        apps.map(async (app) => {
-          const seededName = `seeded-${app.repoId}`;
-          let prepSandboxId: string | null = null;
+        for (const source of sources) {
           try {
-            // Mark this app as actively seeding so the UI shows a spinner until
-            // it resolves to seeded/fallback below.
-            await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+            const created = await step.runAction(
+              internal.snapshotActions.createSeedPrepSandbox,
+              { repoId: app.repoId, imageSnapshot: source },
+              { retry: { maxAttempts: 4, initialBackoffMs: 15000, base: 2 } },
+            );
+            prepSandboxId = created.sandboxId;
+            console.log(
+              `[snapshot] booted seed sandbox for ${app.repoId} from ${source}`,
+            );
+            break;
+          } catch (e) {
+            console.error(
+              `[snapshot] boot from ${source} failed for ${app.repoId}: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
+            );
+          }
+        }
+        if (!prepSandboxId) {
+          throw new Error(
+            `Could not boot a seed sandbox for ${app.repoId} from any source`,
+          );
+        }
+        // Fresh refs for the detached script's hard reset (owns git auth).
+        await step.runAction(
+          internal.daytona.fetchBaseBranch,
+          {
+            sandboxId: prepSandboxId,
+            installationId: repo.installationId,
+            repoOwner: repo.owner,
+            repoName: repo.name,
+            baseBranch: branch,
+            repoId: app.repoId,
+          },
+          { retry: { maxAttempts: 3, initialBackoffMs: 10000, base: 2 } },
+        );
+        // Launch the whole pipeline detached; poll its outcome markers. The
+        // launch is idempotent (live-process guard), so retries can't race a
+        // second copy of the script.
+        await step.runAction(
+          internal.snapshotActions.launchSeedRun,
+          {
+            sandboxId: prepSandboxId,
+            repoId: app.repoId,
+            branch,
+            buildCommands: config.buildCommands ?? [],
+          },
+          { retry: { maxAttempts: 3, initialBackoffMs: 10000, base: 2 } },
+        );
+        let seedState = "running";
+        for (
+          let pollAttempt = 1;
+          pollAttempt <= MAX_SEED_RUN_POLLS && seedState === "running";
+          pollAttempt++
+        ) {
+          seedState = await step.runAction(
+            internal.snapshotActions.pollSeedRun,
+            { sandboxId: prepSandboxId, repoId: app.repoId },
+            { runAfter: SEED_RUN_POLL_DELAY_MS },
+          );
+        }
+        if (seedState !== "done") {
+          // Grab the seed-run + daemon logs into the build record BEFORE the
+          // catch tears the sandbox down — teardown destroys the evidence.
+          const diagnostics = await step.runAction(
+            internal.snapshotActions.fetchSeedDiagnostics,
+            { sandboxId: prepSandboxId, repoId: app.repoId },
+          );
+          await step.runMutation(internal.repoSnapshots.appendLogs, {
+            buildId: args.buildId,
+            chunk: `[seed ${app.repoId}] FAILED (${seedState}) — diagnostics:\n${diagnostics}\n`,
+          });
+          throw new Error(
+            `Seed run for ${app.repoId} did not complete (state: ${seedState})`,
+          );
+        }
+        // Capture the refreshed filesystem snapshot. Trigger fires the POST
+        // without blocking; poll across separate steps so a long DB capture
+        // never exceeds Convex's 600s per-action ceiling.
+        await step.runAction(internal.snapshotActions.triggerSeededSnapshot, {
+          repoId: app.repoId,
+          sandboxId: prepSandboxId,
+          seededName,
+        });
+        let snapState = "pending";
+        for (
+          let pollAttempt = 1;
+          pollAttempt <= MAX_SEED_SNAPSHOT_POLLS &&
+          !isTerminalSnapshotState(snapState);
+          pollAttempt++
+        ) {
+          snapState = await step.runAction(
+            internal.snapshotActions.pollSeededSnapshotState,
+            { repoId: app.repoId, seededName },
+            {
+              runAfter:
+                pollAttempt === 1 ? 10_000 : SEED_SNAPSHOT_POLL_DELAY_MS,
+            },
+          );
+        }
+        if (snapState !== "active") {
+          throw new Error(
+            `Seeded snapshot for ${app.repoId} did not reach active (last state: ${snapState})`,
+          );
+        }
+        await step.runAction(internal.daytona.deleteSandbox, {
+          sandboxId: prepSandboxId,
+          repoId: app.repoId,
+        });
+        prepSandboxId = null;
+        // SWAP: point the repo at the new snapshot, then (best-effort) delete
+        // the previous one. New sandboxes cut over atomically; a failed delete
+        // just leaves a stray snapshot that the next successful build removes.
+        await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
+          repoId: app.repoId,
+          seededSnapshotName: seededName,
+        });
+        await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+          buildId: args.buildId,
+          repoId: app.repoId,
+          status: "seeded",
+          seededSnapshotName: seededName,
+        });
+        try {
+          await step.runMutation(
+            internal.repoSnapshots.updateSeededAppWarmupStatus,
+            {
               buildId: args.buildId,
               repoId: app.repoId,
-              status: "running",
-              seededSnapshotName: null,
-            });
-            // Clear first so live sandboxes fall back to the Image during rebuild.
-            await step.runMutation(
-              internal.repoSnapshots.setSeededSnapshotName,
-              {
-                repoId: app.repoId,
-                seededSnapshotName: null,
-              },
-            );
-            // Delete the previous seeded snapshot (name reuse would 409).
+              status: "pending",
+            },
+          );
+          await step.runAction(
+            internal.snapshotActions.warmSeededSnapshotCache,
+            {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              seededName,
+            },
+          );
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          await step.runMutation(
+            internal.repoSnapshots.updateSeededAppWarmupStatus,
+            {
+              buildId: args.buildId,
+              repoId: app.repoId,
+              status: "error",
+              error: message,
+            },
+          );
+          await step.runMutation(internal.repoSnapshots.appendLogs, {
+            buildId: args.buildId,
+            chunk: `[warm ${app.repoId}] skipped after error: ${message}\n`,
+          });
+        }
+        if (app.seededSnapshotName && app.seededSnapshotName !== seededName) {
+          try {
             await step.runAction(
               internal.snapshotActions.deleteDaytonaSnapshot,
               {
-                snapshotName: seededName,
+                snapshotName: app.seededSnapshotName,
                 repoId: app.repoId,
               },
             );
-            // Retry with backoff: creating the prep sandbox can transiently hit
-            // Daytona "No available runners" when the Image build + per-app prep
-            // sandboxes contend for capacity. Backoff (15s/30s/60s/120s) rides out
-            // a brief saturation; if it still fails, the catch below falls back to
-            // the Image for this app.
-            const created = await step.runAction(
-              internal.snapshotActions.createSeedPrepSandbox,
-              { repoId: app.repoId, imageSnapshot: config.snapshotName },
-              { retry: { maxAttempts: 5, initialBackoffMs: 15000, base: 2 } },
-            );
-            prepSandboxId = created.sandboxId;
-            // services (every-start, launched detached in one quick action)
-            await step.runAction(internal.daytona.runBackgroundCommands, {
-              sandboxId: prepSandboxId,
-              repoId: app.repoId,
-            });
-            // Seed: run each command as its OWN workflow step. A single action
-            // running the whole seed (readiness wait + many env sets + import) can
-            // overrun Convex's ~10-min action limit; per-command steps each get
-            // their own budget. Any failure throws -> caught below -> Image fallback
-            // (we never snapshot a half-seeded DB).
-            const seedCommands = await step.runQuery(
-              internal.repoSnapshots.getStartupCommands,
-              { repoId: app.repoId },
-            );
-            for (const command of seedCommands ?? []) {
-              await step.runAction(internal.daytona.runSandboxCommand, {
-                sandboxId: prepSandboxId,
-                repoId: app.repoId,
-                command,
-                timeoutSeconds: 600,
-              });
-            }
-            // Marker so a sandbox booting from the seeded snapshot skips the seed.
-            await step.runAction(internal.daytona.runSandboxCommand, {
-              sandboxId: prepSandboxId,
-              repoId: app.repoId,
-              command: "touch /tmp/.startup-commands-done",
-              timeoutSeconds: 10,
-            });
-            // clean stop so volumes flush before the snapshot
-            await step.runAction(internal.daytona.runStopCommands, {
-              sandboxId: prepSandboxId,
-              repoId: app.repoId,
-            });
-            // Capture the seeded filesystem snapshot. Trigger fires the POST
-            // without blocking; poll the sandbox state across separate steps so
-            // a long DB capture never exceeds Convex's 600s per-action ceiling.
-            await step.runAction(
-              internal.snapshotActions.triggerSeededSnapshot,
-              {
-                repoId: app.repoId,
-                sandboxId: prepSandboxId,
-                seededName,
-              },
-            );
-            let snapState = "pending";
-            for (
-              let pollAttempt = 1;
-              pollAttempt <= MAX_SEED_SNAPSHOT_POLLS &&
-              !isTerminalSnapshotState(snapState);
-              pollAttempt++
-            ) {
-              snapState = await step.runAction(
-                internal.snapshotActions.pollSeededSnapshotState,
-                { repoId: app.repoId, seededName },
-                {
-                  runAfter:
-                    pollAttempt === 1 ? 10_000 : SEED_SNAPSHOT_POLL_DELAY_MS,
-                },
-              );
-            }
-            // Anything but "active" (failure state or window exhausted) throws
-            // into the per-app catch below → prep sandbox torn down + fallback
-            // (null) recorded → app keeps the base-Image snapshot.
-            if (snapState !== "active") {
-              throw new Error(
-                `Seeded snapshot for ${app.repoId} did not reach active (last state: ${snapState})`,
-              );
-            }
-            await step.runAction(internal.daytona.deleteSandbox, {
-              sandboxId: prepSandboxId,
-              repoId: app.repoId,
-            });
-            prepSandboxId = null;
-            await step.runMutation(
-              internal.repoSnapshots.setSeededSnapshotName,
-              {
-                repoId: app.repoId,
-                seededSnapshotName: seededName,
-              },
-            );
-            // Record the success on the build record for the history view.
-            await step.runMutation(internal.repoSnapshots.recordSeededApp, {
-              buildId: args.buildId,
-              repoId: app.repoId,
-              status: "seeded",
-              seededSnapshotName: seededName,
-            });
           } catch (e) {
             console.error(
-              `[snapshot] seeded build failed for ${app.repoId}: ${e instanceof Error ? e.message : String(e)}`,
+              `[snapshot] failed to delete previous seeded snapshot ${app.seededSnapshotName}: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
             );
-            // Tear down the prep sandbox so it doesn't linger.
-            if (prepSandboxId) {
-              await step.runAction(internal.daytona.deleteSandbox, {
-                sandboxId: prepSandboxId,
-                repoId: app.repoId,
-              });
-            }
-            // seededSnapshotName stays cleared → app uses the base Image snapshot.
-            // Record the fallback on the build record for the history view.
-            await step.runMutation(internal.repoSnapshots.recordSeededApp, {
-              buildId: args.buildId,
-              repoId: app.repoId,
-              status: "fallback",
-              seededSnapshotName: null,
-            });
           }
-        }),
-      );
+        }
+        return true;
+      } catch (e) {
+        console.error(
+          `[snapshot] seeded build failed for ${app.repoId}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        // Tear down the prep sandbox so it doesn't linger.
+        if (prepSandboxId) {
+          await step.runAction(internal.daytona.deleteSandbox, {
+            sandboxId: prepSandboxId,
+            repoId: app.repoId,
+          });
+        }
+        // Best-effort: remove the partial/orphaned versioned capture if the
+        // trigger fired before the failure (no-op when it never registered).
+        try {
+          await step.runAction(internal.snapshotActions.deleteDaytonaSnapshot, {
+            snapshotName: seededName,
+            repoId: app.repoId,
+          });
+        } catch {
+          // ignore — snapshot may not exist
+        }
+        // The repo keeps its PREVIOUS seededSnapshotName (untouched above), so
+        // sandboxes continue booting from the last good seeded snapshot.
+        await step.runMutation(internal.repoSnapshots.recordSeededApp, {
+          buildId: args.buildId,
+          repoId: app.repoId,
+          status: "fallback",
+          seededSnapshotName: app.seededSnapshotName,
+        });
+        return false;
+      }
+    };
+
+    const results = await Promise.all(apps.map((app) => runSeedChain(app)));
+
+    // Finalize the build record (the forceImageRebuild path already recorded
+    // the image outcome; per-app outcomes live in seededApps either way).
+    if (!args.forceImageRebuild) {
+      const succeeded = results.filter(Boolean).length;
+      await step.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: succeeded === apps.length ? "success" : "error",
+        logs: `Sandbox-native build finished: ${succeeded}/${apps.length} app snapshot(s) refreshed.\n`,
+        ...(succeeded === apps.length
+          ? {}
+          : {
+              error: `${apps.length - succeeded} app snapshot(s) fell back to their previous seeded snapshot — see per-app diagnostics in the logs`,
+            }),
+      });
     }
   },
 });


### PR DESCRIPTION
## Purpose — archive, do not merge

**Part 2 of 2**, stacked on the PR #402 reconstruction. Together they reproduce the full pre-revert state (cb9da2f3). Reverted from `main` in 1a20b561.

## Scope here
- **PR #403**: drop warmup schema fields (phase B).
- **Follow-up refinements** made after #402/#403 landed: sandbox-native build model (build inside the seeded sandbox), keep-last-good versioned snapshots, seed-from-old-image concurrently with rebuild, richer seed diagnostics, 180s create-ready timeout for seed-prep, idempotent/retryable seed-run launch.

Base is `revisit/402-seeded-pipeline` so the diff shows only this delta. Review #402 first.

⚠️ Same prod data-strip migration caveat as part 1.