### PR TITLE
feat(backend): VM hot seeded snapshots pilot (Path B)

### DIFF
--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## VM hot seeded snapshots pilot (Path B) - 2026-07-06
+
+- Pilot flag `vmHotSeededSnapshots` on carepulse `apps/web`: VM base via thin `ubuntu:22.04` pull in Daytona `experimental` region + sandbox bootstrap (declarative builder is container-only), hot capture (`includeMemory`), skip stopCommands at seed time, `seededSnapshotClass` tracking, and session startup logging.
+- Reason for change: container seeded snapshots cost ~30s on `daytona.create`; VM hot snapshots target sub-10s session boot while keeping daily versioned seeded builds.
+
 ## Seeded snapshot database restore artifact - 2026-07-05
 
 - Captured a compressed Supabase Postgres dump into the seeded snapshot filesystem after seed commands complete, then restored it once when fresh sandboxes boot from that snapshot.

--- a/internal/plans/implemented/vm-hot-seeded-snapshots-pilot.md
+++ b/internal/plans/implemented/vm-hot-seeded-snapshots-pilot.md
@@ -1,0 +1,151 @@
+# VM hot seeded snapshots pilot (Path B)
+
+**Date:** 2026-07-06  
+**Status:** Pilot infrastructure landed on dev (`good-mule-506`); carepulse `apps/web` flagged; seed chain in progress at time of writeup.  
+**Goal:** Sub-10s session `createSandbox` by booting from **hot memory snapshots** (`includeMemory: true`) instead of cold container filesystem snapshots (~30s).
+
+---
+
+## Problem
+
+Container seeded snapshots in EU work but every new session pays a cold boot: Docker, Supabase, Convex local, etc. must start from a **stopped** filesystem capture. Daily seeded rebuilds keep data fresh but not startup latency.
+
+**Path B (vm-hot):** capture **running** sandbox state (memory + disk) into a VM-class snapshot so the next boot resumes warm processes.
+
+---
+
+## Architecture
+
+```
+experimental region (linux-vm, 12 GiB cap)
+  │
+  ├─ Thin VM snapshot     ubuntu:22.04 pull  (…-vm-thin)
+  ├─ Bootstrap via toolbox  apt/node/docker/chrome/…  (execScript, no SSH)
+  ├─ Cold VM base         stop → capture (…-vm)
+  ├─ Seed prep sandbox    boot from …-vm → clone repo → seed commands
+  └─ Hot seeded snapshot  includeMemory: true → seeded-<repoId>-<buildId>
+                              seededSnapshotClass: "vm-hot"
+```
+
+**Container path (unchanged for non-pilot apps):** EU, 16 GiB, declarative Dockerfile build, cold filesystem seeded snapshots.
+
+---
+
+## Key code changes
+
+| Area                   | What                                                                                                                             |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `vmHotSeededSnapshots` | Per-repo pilot flag (`githubRepos`)                                                                                              |
+| `seededSnapshotClass`  | `"container"` \| `"vm-hot"` on repo + build records                                                                              |
+| `vmSnapshotNames.ts`   | `-vm-thin`, `-vm` suffixes; `isVmRegionSnapshotName`, `isVmToolingBaseSnapshot`                                                  |
+| `snapshots.ts`         | `VM_SNAPSHOT_REGION = "experimental"`, `kickOffVmBaseSnapshot`, REST hot capture                                                 |
+| `helpers.ts`           | Toolbox-only `exec` / `execScript` (chunked b64 upload); VM cwd `/` when `/tmp/repo` missing                                     |
+| `git.ts`               | VM thin skip post-create; **VM tooling base clones repo** (no baked `/tmp/repo`); pnpm install skips global reinstall if present |
+| `snapshotWorkflow.ts`  | Parallel VM thin → bootstrap → `-vm` base; vm-hot seed chain; `skipStopCommands` for hot capture                                 |
+| `snapshotActions.ts`   | `bootstrapVmBaseTooling`, debug ops actions, `pollSeededSnapshotState` with `vmHot`                                              |
+| `sessions.ts`          | Route `vm-hot` sandboxes to `experimental`; `[sessionStartup][timing]` logs                                                      |
+
+**Removed:** SSH/`ssh2` workaround — Daytona confirmed toolbox exec works on VM sandboxes when cwd/region/script delivery are correct.
+
+---
+
+## Toolbox exec on VM (Option A)
+
+Earlier failures (`fork/exec /usr/bin/bash`) were misconfiguration, not platform:
+
+1. Use **`experimental`** target for create/get/exec.
+2. Use cwd **`/`** on thin VM images (no `/tmp/repo` yet).
+3. Deliver scripts via **chunked base64** → `/tmp/eva-script.sh` → `/bin/bash /tmp/eva-script.sh` (avoid `| bash` pipe — toolbox parses badly).
+4. **Stop** sandbox before cold capture; **start** before hot capture.
+
+Smoke test: `debugVmBootstrapCapture` → snapshot **active**. Full bootstrap script ~3.5 min via toolbox.
+
+---
+
+## VM bootstrap script
+
+Mirrors container Dockerfile tooling layers inside `ubuntu:22.04` VM (no repo clone — that happens at seed prep).
+
+Notable fix: `build-essential` must install **before** `rm -rf /var/lib/apt/lists/*`, not after.
+
+---
+
+## Region / memory limits (Daytona API probes, 2026-07-06)
+
+| Request                            | Result                            |
+| ---------------------------------- | --------------------------------- |
+| EU + `linux-vm` + 16 GiB           | `400` — no VM runners in `eu`     |
+| EU + `linux-vm` + 12 GiB           | `400` — no VM runners in `eu`     |
+| US + `linux-vm` + 16 GiB           | `400` — no VM runners in `us`     |
+| experimental + `linux-vm` + 16 GiB | `400` — max 12 GiB per VM sandbox |
+| experimental + `linux-vm` + 12 GiB | **Works**                         |
+
+**Conclusion:** vm-hot pilot must stay **experimental + 12 GiB** until Daytona adds EU VM runners and/or raises VM memory quota (`support@daytona.io`).
+
+---
+
+## Carepulse pilot (dev `good-mule-506`)
+
+| Resource                      | ID / name                                                                  |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| Carepulse web repo            | `mh7fdbcrhbt6wbwqkdxr0xe4c182502a`                                         |
+| Monorepo parent (Daytona ops) | `mh7ca667pjd7fjaqtw6n86vxex82jev6`                                         |
+| Repo snapshot config          | `rh74g8w7mczaf7m7kg0vhnj1y181tyh2`                                         |
+| Container base                | `snapshot-mh796tpcm1h0a0amat46r27wms81gwz3` (EU, active)                   |
+| VM thin                       | `snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-thin` (experimental, active) |
+| VM tooling base               | `snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm` (experimental, **active**)  |
+
+### Bootstrap carepulse dev
+
+```powershell
+$env:CONVEX_DEPLOYMENT="dev:good-mule-506"
+cd packages/backend
+node scripts/vm-hot-carepulse-pilot-bootstrap.mjs   # sync commands, enable flag, forceImageRebuild
+```
+
+### Ops scripts (`packages/backend/scripts/`)
+
+- `run-debug-vm-exec-test.mjs` — toolbox exec smoke
+- `run-vm-bootstrap.mjs` — full bootstrap + cold capture
+- `run-vm-smoke-capture.mjs` — minimal script + capture
+- `test-vm-seed-prep.mjs` — seed prep from `-vm` base
+- `try-eu-vm-16gb.mjs` / `try-vm-regions-matrix.mjs` — region/memory matrix
+- `poll-vm-hot-build.mjs [buildId]` — build status
+- `vm-hot-carepulse-pilot-bootstrap.mjs` — one-shot pilot setup
+
+### Convex debug actions
+
+- `snapshotActions:debugVmExecTest`
+- `snapshotActions:debugVmBootstrapScriptOnly`
+- `snapshotActions:debugVmBootstrapCapture`
+- `snapshotActions:debugKickOffVmSnapshot` (optional `regionId`, `memory`)
+- `snapshotActions:debugListDaytonaRegions`
+- `snapshotActions:inspectDaytonaSnapshot` (optional `vmHot: true`)
+
+---
+
+## Seed chain notes
+
+VM tooling base has **no baked repo** — `createSandboxAndPrepareRepo` detects `isVmToolingBaseSnapshot` and runs `cloneAndSetupRepo` instead of `normalizeSnapshotWorktree`.
+
+vm-hot apps boot from: previous `vm-hot` seeded snapshot **or** active `-vm` base (no container fallback).
+
+At capture time: `skipStopCommands: true` so daemons stay running for hot memory snapshot.
+
+Poll VM snapshots with `vmHot: true` / `getDaytonaForSnapshotName` — EU client cannot see experimental snapshots.
+
+---
+
+## Open items
+
+1. Complete vm-hot **seed chain** for carepulse `apps/web` on dev (build `rn7c19…` was running at handoff).
+2. **Session timing test** — compare `[sessionStartup][timing]` vm-hot vs container seeded.
+3. Promote pilot flag / defaults after latency validation.
+4. Ask Daytona: EU `linux-vm` runners + 16 GiB VM quota.
+
+---
+
+## Related docs
+
+- `internal/plans/todo/running-sandbox-snapshot-seeded-db.md` — original filesystem snapshot design (container, EU).
+- `SNAPSHOT_BUILD_HANDOFF.md` — broader snapshot build pipeline debugging (separate from vm-hot).

--- a/packages/backend/convex/_daytona/git.ts
+++ b/packages/backend/convex/_daytona/git.ts
@@ -28,6 +28,11 @@ import {
 } from "./helpers";
 import { detectPackageManager } from "./devServer";
 import { ensureGitCredentialHelper } from "./gitCredentials";
+export { VM_SNAPSHOT_REGION } from "./snapshots";
+import {
+  isVmToolingBaseSnapshot,
+  VM_SNAPSHOT_THIN_SUFFIX,
+} from "./vmSnapshotNames";
 
 type ActionCtx = GenericActionCtx<DataModel>;
 
@@ -297,10 +302,16 @@ export async function createSandbox(
   snapshotName?: string,
   volumes?: VolumeMount[],
   readyTimeoutSeconds?: number,
+  seededSnapshotClass?: "container" | "vm-hot",
+  sandboxRegionId?: string,
+  skipPostCreateSetup?: boolean,
 ): Promise<Sandbox> {
   const details = [
     `installation=${installationId}`,
     snapshotName ? `snapshot=${snapshotName}` : "snapshot=none",
+    seededSnapshotClass
+      ? `seededClass=${seededSnapshotClass}`
+      : "seededClass=none",
     lifecycle.ephemeral ? "ephemeral=true" : "ephemeral=false",
     `volumes=${volumes?.length ?? 0}`,
   ].join(", ");
@@ -343,8 +354,10 @@ export async function createSandbox(
     const createParams: CreateSandboxFromSnapshotParams = {
       ...commonParams,
       snapshot: snapshotName ?? DEFAULT_SNAPSHOT,
+      ...(sandboxRegionId ? { regionId: sandboxRegionId } : {}),
     };
 
+    const daytonaCreateStartedAt = Date.now();
     const sandbox = await withTimeout(
       daytona.create(createParams, { timeout: timeoutSeconds }),
       readyTimeoutSeconds
@@ -352,8 +365,9 @@ export async function createSandbox(
         : DAYTONA_CREATE_TIMEOUT_MS,
       "create",
     );
+    const daytonaCreateMs = Date.now() - daytonaCreateStartedAt;
     logGit(
-      `createSandbox: created id=${sandbox.id}, cpu=${sandbox.cpu}, memory=${sandbox.memory}, disk=${sandbox.disk}`,
+      `createSandbox: daytona.create ready in ${formatDurationMsShort(daytonaCreateMs)} id=${sandbox.id}, cpu=${sandbox.cpu}, memory=${sandbox.memory}, disk=${sandbox.disk}`,
     );
 
     const appSlug = process.env.GITHUB_APP_SLUG;
@@ -363,16 +377,22 @@ export async function createSandbox(
         "GITHUB_APP_SLUG and GITHUB_BOT_USER_ID must be set in Convex env",
       );
     }
-    await exec(
-      sandbox,
-      `git config --global user.name "${appSlug}[bot]" && git config --global user.email "${botUserId}+${appSlug}[bot]@users.noreply.github.com"`,
-      10,
-    );
+    // Thin VM base images (node:20-bookworm pull) lack tooling until bootstrap;
+    // skip exec hooks that require bash/docker/git before bootstrap runs.
+    const isVmThinBootstrap =
+      snapshotName?.endsWith(VM_SNAPSHOT_THIN_SUFFIX) === true;
+    if (!isVmThinBootstrap && skipPostCreateSetup !== true) {
+      await exec(
+        sandbox,
+        `git config --global user.name "${appSlug}[bot]" && git config --global user.email "${botUserId}+${appSlug}[bot]@users.noreply.github.com"`,
+        10,
+      );
 
-    // Start Docker daemon if available (for Docker-in-Docker / Supabase local dev).
-    // Idempotent — also re-invoked from ensureSandboxRunning on resume since
-    // dockerd doesn't survive auto-stop.
-    await ensureDockerDaemon(sandbox);
+      // Start Docker daemon if available (for Docker-in-Docker / Supabase local dev).
+      // Idempotent — also re-invoked from ensureSandboxRunning on resume since
+      // dockerd doesn't survive auto-stop.
+      await ensureDockerDaemon(sandbox);
+    }
 
     return sandbox;
   });
@@ -750,7 +770,7 @@ async function installDependencies(
   if (pm === "pnpm") {
     await exec(
       sandbox,
-      `npm install -g pnpm && cd ${workspaceDir} && pnpm install`,
+      `cd ${workspaceDir} && (command -v pnpm >/dev/null 2>&1 || npm install -g pnpm) && pnpm install`,
       PNPM_INSTALL_TIMEOUT_SECONDS,
     );
   } else if (pm === "yarn") {
@@ -951,6 +971,8 @@ export async function createSandboxAndPrepareRepo(
   // snapshot builds) pass a longer value to avoid spurious create timeouts +
   // the orphaned sandboxes they leave server-side.
   readyTimeoutSeconds?: number,
+  seededSnapshotClass?: "container" | "vm-hot",
+  sandboxRegionId?: string,
 ): Promise<{ sandbox: Sandbox; usedSnapshot: boolean }> {
   let sandbox: Sandbox | undefined;
   try {
@@ -970,6 +992,8 @@ export async function createSandboxAndPrepareRepo(
             effectiveSnapshot,
             volumes,
             readyTimeoutSeconds,
+            seededSnapshotClass,
+            sandboxRegionId,
           );
         } catch (err) {
           if (effectiveSnapshot && isSnapshotUnusableError(err)) {
@@ -987,6 +1011,8 @@ export async function createSandboxAndPrepareRepo(
               undefined,
               volumes,
               readyTimeoutSeconds,
+              undefined,
+              undefined,
             );
           } else {
             throw err;
@@ -996,14 +1022,27 @@ export async function createSandboxAndPrepareRepo(
           await onSandboxAcquired(sandbox);
         }
         if (effectiveSnapshot) {
-          await normalizeSnapshotWorktree(sandbox);
-          // The snapshot was baked with a stale token in its git config /
-          // remotes. Install the credential helper before any git network op
-          // so syncRepo (and later in-sandbox `git pull`) authenticate cleanly.
-          await ensureGitCredentialHelper(ctx, sandbox, installationId);
-          if (syncStrategy.mode !== "none") {
-            if (onProgress) await onProgress("Syncing repository...");
-            await syncRepo(sandbox, owner, name, syncStrategy);
+          if (isVmToolingBaseSnapshot(effectiveSnapshot)) {
+            // VM tooling base has docker/node/etc. but no baked repo clone.
+            await cloneAndSetupRepo(
+              ctx,
+              sandbox,
+              installationId,
+              owner,
+              name,
+              syncStrategy.mode === "all",
+              onProgress,
+            );
+          } else {
+            await normalizeSnapshotWorktree(sandbox);
+            // The snapshot was baked with a stale token in its git config /
+            // remotes. Install the credential helper before any git network op
+            // so syncRepo (and later in-sandbox `git pull`) authenticate cleanly.
+            await ensureGitCredentialHelper(ctx, sandbox, installationId);
+            if (syncStrategy.mode !== "none") {
+              if (onProgress) await onProgress("Syncing repository...");
+              await syncRepo(sandbox, owner, name, syncStrategy);
+            }
           }
           await copySandboxConfigFilesToWorkspace(sandbox, { force: true });
           return { sandbox, usedSnapshot: true };

--- a/packages/backend/convex/_daytona/helpers.ts
+++ b/packages/backend/convex/_daytona/helpers.ts
@@ -5,6 +5,8 @@ import type { DataModel, Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { resolveDaytonaApiKey } from "../envVarResolver";
 import { launchScript } from "./launch";
+import { VM_SNAPSHOT_REGION } from "./snapshots";
+import { isVmRegionSnapshotName } from "./vmSnapshotNames";
 
 export const WORKSPACE_DIR = "/tmp/repo";
 export const LEGACY_WORKSPACE_DIR = "/workspace/repo";
@@ -80,6 +82,19 @@ export const ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS = 600;
 
 const EXEC_CLIENT_TIMEOUT_BUFFER_MS = 15_000;
 
+/** VM sandboxes run in the experimental region (linux-vm). */
+function isVmSandbox(sandbox: Sandbox): boolean {
+  return sandbox.target === VM_SNAPSHOT_REGION;
+}
+
+/** Toolbox cwd: thin VM images may not have /tmp/repo yet. */
+function toolboxCwd(sandbox: Sandbox, cwd: string): string {
+  if (isVmSandbox(sandbox) && cwd === WORKSPACE_DIR) {
+    return "/";
+  }
+  return cwd;
+}
+
 /** Executes a shell command on a sandbox and returns stdout, throwing on non-zero exit. */
 export async function exec(
   sandbox: Sandbox,
@@ -89,7 +104,12 @@ export async function exec(
 ): Promise<string> {
   const clientTimeoutMs = timeout * 1000 + EXEC_CLIENT_TIMEOUT_BUFFER_MS;
   const resp = await withTimeout(
-    sandbox.process.executeCommand(cmd, cwd, undefined, timeout),
+    sandbox.process.executeCommand(
+      cmd,
+      toolboxCwd(sandbox, cwd),
+      undefined,
+      timeout,
+    ),
     clientTimeoutMs,
     `exec (${timeout}s)`,
   );
@@ -102,6 +122,37 @@ export async function exec(
     );
   }
   return resp.result;
+}
+
+/**
+ * Runs a multi-line shell script via toolbox exec (chunked b64 upload for size).
+ * Use for VM bootstrap scripts that exceed a single argv limit.
+ */
+export async function execScript(
+  sandbox: Sandbox,
+  script: string,
+  timeoutSec: number,
+): Promise<string> {
+  const b64 = Buffer.from(script, "utf8").toString("base64");
+  const chunkSize = 12_000;
+  const cwd = "/";
+  await exec(sandbox, "rm -f /tmp/eva-script.b64", 30, cwd);
+  for (let offset = 0; offset < b64.length; offset += chunkSize) {
+    const chunk = b64.slice(offset, offset + chunkSize);
+    const quoted = chunk.replace(/'/g, `'\\''`);
+    await exec(
+      sandbox,
+      `printf '%s' '${quoted}' >> /tmp/eva-script.b64`,
+      30,
+      cwd,
+    );
+  }
+  return exec(
+    sandbox,
+    "base64 -d /tmp/eva-script.b64 > /tmp/eva-script.sh && /bin/bash /tmp/eva-script.sh",
+    timeoutSec,
+    cwd,
+  );
 }
 
 /**
@@ -227,9 +278,24 @@ export function requireEnv(name: string): string {
   return value;
 }
 
-/** Creates a new Daytona SDK client with the given API key. */
-export function getDaytona(apiKey: string): Daytona {
+/** Creates a new Daytona SDK client with the given API key and optional region target. */
+export function getDaytona(apiKey: string, target?: string): Daytona {
+  if (target) {
+    return new Daytona({ apiKey, target });
+  }
   return new Daytona({ apiKey });
+}
+
+/** Resolves the Daytona client for snapshot lookups (VM bases live in experimental). */
+export function getDaytonaForSnapshotName(
+  apiKey: string,
+  snapshotName: string,
+  vmHot?: boolean,
+): Daytona {
+  if (vmHot === true || isVmRegionSnapshotName(snapshotName)) {
+    return getDaytona(apiKey, VM_SNAPSHOT_REGION);
+  }
+  return getDaytona(apiKey);
 }
 
 /** Returns a promise that resolves after the specified milliseconds. */
@@ -268,6 +334,9 @@ export function errorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
+/** Re-export for session/seed sandbox region selection. */
+export { VM_SNAPSHOT_REGION } from "./snapshots";
+
 /** Resolves Daytona client, sandbox env vars, and snapshot name for a repo. */
 export async function resolveSandboxContext(
   ctx: GenericActionCtx<DataModel>,
@@ -276,21 +345,27 @@ export async function resolveSandboxContext(
   daytona: Daytona;
   sandboxEnvVars: Record<string, string>;
   snapshotName: string | undefined;
+  seededSnapshotClass: "container" | "vm-hot" | undefined;
 }> {
   const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
     ctx,
     repoId,
   );
-  const daytona = getDaytona(daytonaApiKey);
   const repoSnapshot = await ctx.runQuery(
     internal.repoSnapshots.getRepoSnapshotName,
     { repoId },
   );
   const snapshotName = repoSnapshot?.snapshotName;
+  const seededSnapshotClass = repoSnapshot?.seededSnapshotClass;
+  const daytona = getDaytona(
+    daytonaApiKey,
+    seededSnapshotClass === "vm-hot" ? VM_SNAPSHOT_REGION : undefined,
+  );
   return {
     daytona,
     sandboxEnvVars: { ...sandboxEnvVars, REPO_ID: repoId },
     snapshotName,
+    seededSnapshotClass,
   };
 }
 
@@ -301,7 +376,16 @@ export async function getSandbox(
   sandboxId: string,
 ): Promise<Sandbox> {
   const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, repoId);
-  const daytona = getDaytona(daytonaApiKey);
+  const repoSnapshot = await ctx.runQuery(
+    internal.repoSnapshots.getRepoSnapshotName,
+    { repoId },
+  );
+  const daytona = getDaytona(
+    daytonaApiKey,
+    repoSnapshot?.seededSnapshotClass === "vm-hot"
+      ? VM_SNAPSHOT_REGION
+      : undefined,
+  );
   return daytona.get(sandboxId);
 }
 

--- a/packages/backend/convex/_daytona/sessions.ts
+++ b/packages/backend/convex/_daytona/sessions.ts
@@ -13,6 +13,8 @@ import {
   errorMessage,
   sleep,
   workspaceDirShell,
+  getSandbox,
+  VM_SNAPSHOT_REGION,
 } from "./helpers";
 import {
   setupBranch,
@@ -43,6 +45,24 @@ function devOverrides(
   if (repo.devPort === undefined && repo.devCommand === undefined)
     return undefined;
   return { devPort: repo.devPort, devCommand: repo.devCommand };
+}
+
+/** Logs structured startup timing for new-session latency work. */
+function logStartupTiming(
+  sessionId: Id<"sessions">,
+  phase: string,
+  flowStartedAt: number,
+  extra?: Record<string, string | number | boolean>,
+): void {
+  const elapsed = Date.now() - flowStartedAt;
+  const extraStr = extra
+    ? ` ${Object.entries(extra)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(" ")}`
+    : "";
+  console.log(
+    `[sessionStartup][timing] sessionId=${sessionId} phase=${phase} elapsedMs=${elapsed} elapsed=${formatDurationMsShort(elapsed)}${extraStr}`,
+  );
 }
 
 /** Logs a session-scoped message with the daytona/sessions prefix. */
@@ -331,6 +351,8 @@ type SessionSandboxPreparationArgs = {
   baseBranch: string;
   repoId: Id<"githubRepos">;
   startDesktop: boolean;
+  /** When true, skip dev server / bg / startup commands so sandboxReady can fire sooner. */
+  deferPostReadySetup?: boolean;
 };
 
 type PreparedSessionSandbox = {
@@ -339,8 +361,10 @@ type PreparedSessionSandbox = {
   usedSnapshot: boolean;
   sandboxDetails: string;
   branchName: string;
-  devPort: number;
-  devCommand: string;
+  devPort?: number;
+  devCommand?: string;
+  deferPostReadySetup?: boolean;
+  sandboxProvisionMs?: number;
 };
 
 type ProgressStep = { type: string; label: string; status: string };
@@ -437,6 +461,13 @@ async function prepareSessionSandboxInternal(
 ): Promise<PreparedSessionSandbox> {
   const actionDetails = `sessionId=${args.sessionId}, repo=${args.repoOwner}/${args.repoName}, branch=${args.branchName}, base=${args.baseBranch}, existingSandboxId=${args.existingSandboxId ?? "none"}`;
   const completedSteps: ProgressStep[] = [];
+  const sessionDoc = await ctx.runQuery(internal.sessions.getInternal, {
+    id: args.sessionId,
+  });
+  const flowStartedAt = sessionDoc?.startupRequestedAt ?? Date.now();
+  logStartupTiming(args.sessionId, "prepareStart", flowStartedAt, {
+    deferPostReadySetup: args.deferPostReadySetup === true,
+  });
 
   await emitSessionProgress(
     ctx,
@@ -465,14 +496,19 @@ async function prepareSessionSandboxInternal(
     completedSteps,
     "Resolving sandbox context...",
   );
-  const { daytona, sandboxEnvVars, snapshotName } = await runLoggedSessionStep(
-    "resolveSessionSandboxContext",
-    actionDetails,
-    () => resolveSandboxContext(ctx, args.repoId),
-  );
+  const { daytona, sandboxEnvVars, snapshotName, seededSnapshotClass } =
+    await runLoggedSessionStep(
+      "resolveSessionSandboxContext",
+      actionDetails,
+      () => resolveSandboxContext(ctx, args.repoId),
+    );
   logSession(
-    `prepareSessionSandbox context resolved (${actionDetails}, snapshot=${snapshotName ?? "none"}, rootDir=${rootDir || "."})`,
+    `prepareSessionSandbox context resolved (${actionDetails}, snapshot=${snapshotName ?? "none"}, seededClass=${seededSnapshotClass ?? "none"}, rootDir=${rootDir || "."})`,
   );
+  logStartupTiming(args.sessionId, "sandboxContextResolved", flowStartedAt, {
+    snapshotName: snapshotName ?? "none",
+    seededSnapshotClass: seededSnapshotClass ?? "none",
+  });
   completedSteps.push({
     type: "tool",
     label: "Resolving sandbox context...",
@@ -645,9 +681,10 @@ async function prepareSessionSandboxInternal(
     completedSteps,
     "Creating sandbox...",
   );
+  const sandboxProvisionStartedAt = Date.now();
   const prepared = await runLoggedSessionStep(
     "createSessionSandboxAndPrepareRepo",
-    `${actionDetails}, snapshot=${snapshotName ?? "none"}`,
+    `${actionDetails}, snapshot=${snapshotName ?? "none"}, seededClass=${seededSnapshotClass ?? "none"}`,
     () =>
       createSandboxAndPrepareRepo(
         ctx,
@@ -662,10 +699,21 @@ async function prepareSessionSandboxInternal(
         undefined,
         undefined,
         { mode: "none" },
+        undefined,
+        seededSnapshotClass,
+        seededSnapshotClass === "vm-hot" ? VM_SNAPSHOT_REGION : undefined,
       ),
   );
+  const sandboxProvisionMs = Date.now() - sandboxProvisionStartedAt;
   const sandbox = prepared.sandbox;
   const sandboxDetails = `${actionDetails}, sandboxId=${sandbox.id}, usedSnapshot=${prepared.usedSnapshot ? "true" : "false"}`;
+  logStartupTiming(args.sessionId, "sandboxProvisionComplete", flowStartedAt, {
+    sandboxProvisionMs,
+    sandboxId: sandbox.id,
+    usedSnapshot: prepared.usedSnapshot,
+    seededSnapshotClass: seededSnapshotClass ?? "none",
+    snapshotName: snapshotName ?? "none",
+  });
   // Any setup step below (ref sync, branch checkout, config restore, seeded-
   // runtime restore, dev server) can throw. This is the new-session path — the
   // sandbox was just created here — so delete it on failure before rethrowing,
@@ -758,6 +806,22 @@ async function prepareSessionSandboxInternal(
       label: "Restoring config files...",
       status: "complete",
     });
+
+    if (args.deferPostReadySetup) {
+      logStartupTiming(args.sessionId, "deferPostReadySetup", flowStartedAt, {
+        sandboxProvisionMs,
+      });
+      await completeSessionProgress(ctx, args.sessionId);
+      return {
+        sandbox,
+        isNew: true,
+        usedSnapshot: prepared.usedSnapshot,
+        sandboxDetails,
+        branchName: args.branchName,
+        deferPostReadySetup: true,
+        sandboxProvisionMs,
+      };
+    }
 
     await emitSessionProgress(
       ctx,
@@ -911,7 +975,12 @@ export const startSessionSandbox = internalAction({
         baseBranch: args.baseBranch,
         repoId: args.repoId,
         startDesktop: false,
+        deferPostReadySetup: true,
       });
+      const sessionDoc = await ctx.runQuery(internal.sessions.getInternal, {
+        id: args.sessionId,
+      });
+      const flowStartedAt = sessionDoc?.startupRequestedAt ?? actionStartedAt;
       await runLoggedSessionStep(
         prepared.isNew
           ? "newSessionSandbox.sandboxReady"
@@ -928,6 +997,31 @@ export const startSessionSandbox = internalAction({
             devCommand: prepared.devCommand,
           }),
       );
+      logStartupTiming(
+        args.sessionId,
+        "sandboxReadyMutationDone",
+        flowStartedAt,
+        {
+          isNew: prepared.isNew,
+          sandboxId: prepared.sandbox.id,
+          sandboxProvisionMs: prepared.sandboxProvisionMs ?? 0,
+        },
+      );
+      if (prepared.deferPostReadySetup && prepared.isNew) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.daytona.finishNewSessionSandboxSetup,
+          {
+            sessionId: args.sessionId,
+            sandboxId: prepared.sandbox.id,
+            repoId: args.repoId,
+            startDesktop: false,
+          },
+        );
+        logSession(
+          `scheduled finishNewSessionSandboxSetup (${prepared.sandboxDetails})`,
+        );
+      }
       logSession(
         `startSessionSandbox completed in ${formatDurationMsShort(Date.now() - actionStartedAt)} (${prepared.sandboxDetails})`,
       );
@@ -939,6 +1033,90 @@ export const startSessionSandbox = internalAction({
         sessionId: args.sessionId,
         error: errorMessage(e, "Unknown error"),
       });
+    }
+    return null;
+  },
+});
+
+/** Finishes dev server, background, and startup commands after sandboxReady (new sessions). */
+export const finishNewSessionSandboxSetup = internalAction({
+  args: {
+    sessionId: v.id("sessions"),
+    sandboxId: v.string(),
+    repoId: v.id("githubRepos"),
+    startDesktop: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const deferredStartedAt = Date.now();
+    const sessionDoc = await ctx.runQuery(internal.sessions.getInternal, {
+      id: args.sessionId,
+    });
+    const flowStartedAt = sessionDoc?.startupRequestedAt ?? deferredStartedAt;
+    const sandboxDetails = `sessionId=${args.sessionId}, sandboxId=${args.sandboxId}`;
+    logStartupTiming(args.sessionId, "deferredSetupStart", flowStartedAt);
+    try {
+      const repo = await ctx.runQuery(internal.githubRepos.getInternal, {
+        id: args.repoId,
+      });
+      const rootDir = repo?.rootDirectory ?? "";
+      const sandbox = await getSandbox(ctx, args.repoId, args.sandboxId);
+
+      const { port: devPort, devCommand } = await runLoggedSessionStep(
+        "deferred.startSessionServices",
+        sandboxDetails,
+        () => startSessionServices(sandbox, rootDir, devOverrides(repo)),
+      );
+      if (args.startDesktop) {
+        await runLoggedSessionStep(
+          "deferred.startDesktop",
+          sandboxDetails,
+          () => startDesktopWithChrome(sandbox),
+        );
+      }
+      await runLoggedSessionStep(
+        "deferred.runBackgroundCommands",
+        sandboxDetails,
+        async () => {
+          const result = await ctx.runAction(
+            internal.daytona.runBackgroundCommands,
+            { sandboxId: sandbox.id, repoId: args.repoId },
+          );
+          if (result.ran && result.commandCount > 0) {
+            logSession(
+              `deferred: launched ${result.commandCount} background command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+            );
+          }
+        },
+      );
+      await runLoggedSessionStep(
+        "deferred.runStartupCommands",
+        sandboxDetails,
+        async () => {
+          const result = await ctx.runAction(
+            internal.daytona.runStartupCommands,
+            { sandboxId: sandbox.id, repoId: args.repoId },
+          );
+          if (result.ran && result.commandCount > 0) {
+            logSession(
+              `deferred: ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+            );
+          }
+        },
+      );
+      await ctx.runMutation(internal.sessions.patchDevServer, {
+        sessionId: args.sessionId,
+        devPort,
+        devCommand,
+      });
+      logStartupTiming(args.sessionId, "deferredSetupComplete", flowStartedAt, {
+        devPort,
+        deferredWallMs: Date.now() - deferredStartedAt,
+      });
+    } catch (error) {
+      console.error(
+        `[daytona][sessions] finishNewSessionSandboxSetup failed after ${formatDurationMsShort(Date.now() - deferredStartedAt)} (${sandboxDetails}): ${errorMessage(error, "Unknown error")}`,
+      );
     }
     return null;
   },

--- a/packages/backend/convex/_daytona/snapshots.ts
+++ b/packages/backend/convex/_daytona/snapshots.ts
@@ -14,6 +14,18 @@ import { DaytonaTimeoutError } from "@daytonaio/sdk";
  * or throws).
  */
 
+export const DAYTONA_API_BASE = "https://app.daytona.io/api";
+
+/** VM pilot resource limits (experimental VM region — 12 GiB, not container 16). */
+export const VM_SNAPSHOT_RESOURCES = {
+  cpu: 4,
+  memory: 12,
+  disk: 10,
+} as const;
+
+/** linux-vm runners live on Daytona's dedicated experimental region (12 GiB cap). */
+export const VM_SNAPSHOT_REGION = "experimental";
+
 /** Narrowed view of a Daytona snapshot — the fields callers actually read. */
 export type SnapshotInfo = {
   id: string;
@@ -80,22 +92,86 @@ export async function waitForSnapshotRemoval(
 }
 
 /**
- * Fires a sandbox→snapshot capture (the seeded-DB filesystem snapshot) and
- * returns WITHOUT waiting for it to finish.
+ * Kicks off a VM base snapshot from a public OCI image (linux-vm). Declarative
+ * buildInfo/dockerfile builds are container-only per Daytona docs — VM class uses
+ * imageName pull, then bootstrapVmBaseTooling bakes Eva tooling via sandbox exec.
+ */
+export async function kickOffVmBaseSnapshot(
+  apiKey: string,
+  name: string,
+  _dockerfileContent: string,
+  regionId: string = VM_SNAPSHOT_REGION,
+): Promise<void> {
+  const resp = await fetch(`${DAYTONA_API_BASE}/snapshots`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      name,
+      imageName: "ubuntu:22.04",
+      sandboxClass: "linux-vm",
+      regionId,
+      cpu: VM_SNAPSHOT_RESOURCES.cpu,
+      memory: VM_SNAPSHOT_RESOURCES.memory,
+      disk: VM_SNAPSHOT_RESOURCES.disk,
+    }),
+  });
+  const body = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`Daytona VM snapshot API error (${resp.status}): ${body}`);
+  }
+  if (body.length > 0) {
+    console.log(
+      `[vm-hot] kickOffVmBaseSnapshot response (${regionId}): ${body.slice(0, 500)}`,
+    );
+  }
+}
+
+type TriggerSandboxSnapshotOptions = {
+  includeMemory?: boolean;
+  apiKey?: string;
+};
+
+/**
+ * Fires a sandbox→snapshot capture and returns WITHOUT waiting for completion.
  *
- * The SDK helper blocks the caller polling the source sandbox's state for the
- * entire capture, which for a seeded DB volume routinely exceeds Convex's 600s
- * per-action ceiling. We pass a short timeout so the helper bails fast with a
- * DaytonaTimeoutError (the capture keeps running server-side) and let the caller
- * poll completion via getSnapshot. Any non-timeout error is a real failure and
- * propagates.
+ * Cold captures use the SDK helper (short timeout, DaytonaTimeoutError = still
+ * building). Hot VM captures use the REST API with includeMemory=true because
+ * the sandbox must stay started.
  */
 export async function triggerSandboxSnapshot(
   daytona: Daytona,
   sandboxId: string,
   name: string,
   timeoutSec: number,
+  options: TriggerSandboxSnapshotOptions = {},
 ): Promise<void> {
+  const apiKey = options.apiKey;
+  if (apiKey) {
+    const body: { name: string; includeMemory?: boolean } = { name };
+    if (options.includeMemory === true) {
+      body.includeMemory = true;
+    }
+    const resp = await fetch(
+      `${DAYTONA_API_BASE}/sandbox/${encodeURIComponent(sandboxId)}/snapshot`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Daytona snapshot API error (${resp.status}): ${text}`);
+    }
+    return;
+  }
+
   const sandbox = await daytona.get(sandboxId);
   try {
     await sandbox._experimental_createSnapshot(name, timeoutSec);

--- a/packages/backend/convex/_daytona/vmSnapshotNames.ts
+++ b/packages/backend/convex/_daytona/vmSnapshotNames.ts
@@ -1,0 +1,27 @@
+/** Thin VM image pull (node:20-bookworm) before tooling bootstrap. */
+export const VM_SNAPSHOT_THIN_SUFFIX = "-vm-thin";
+export const VM_SNAPSHOT_BASE_SUFFIX = "-vm";
+
+export function vmBaseSnapshotName(containerSnapshotName: string): string {
+  return `${containerSnapshotName}${VM_SNAPSHOT_BASE_SUFFIX}`;
+}
+
+export function vmThinSnapshotName(containerSnapshotName: string): string {
+  return `${containerSnapshotName}${VM_SNAPSHOT_THIN_SUFFIX}`;
+}
+
+/** Eva tooling base on experimental (no baked repo — seed prep clones fresh). */
+export function isVmToolingBaseSnapshot(snapshotName: string): boolean {
+  return (
+    snapshotName.endsWith(VM_SNAPSHOT_BASE_SUFFIX) &&
+    !snapshotName.endsWith(VM_SNAPSHOT_THIN_SUFFIX)
+  );
+}
+
+/** VM-class snapshots are registered in Daytona's experimental region. */
+export function isVmRegionSnapshotName(snapshotName: string): boolean {
+  return (
+    snapshotName.endsWith(VM_SNAPSHOT_THIN_SUFFIX) ||
+    snapshotName.endsWith(VM_SNAPSHOT_BASE_SUFFIX)
+  );
+}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -47,6 +47,7 @@ import type * as _daytona_services from "../_daytona/services.js";
 import type * as _daytona_sessions from "../_daytona/sessions.js";
 import type * as _daytona_snapshotStates from "../_daytona/snapshotStates.js";
 import type * as _daytona_snapshots from "../_daytona/snapshots.js";
+import type * as _daytona_vmSnapshotNames from "../_daytona/vmSnapshotNames.js";
 import type * as _daytona_volumes from "../_daytona/volumes.js";
 import type * as _deployment_vercel from "../_deployment/vercel.js";
 import type * as _designSessions_execution from "../_designSessions/execution.js";
@@ -298,6 +299,7 @@ declare const fullApi: ApiFromModules<{
   "_daytona/sessions": typeof _daytona_sessions;
   "_daytona/snapshotStates": typeof _daytona_snapshotStates;
   "_daytona/snapshots": typeof _daytona_snapshots;
+  "_daytona/vmSnapshotNames": typeof _daytona_vmSnapshotNames;
   "_daytona/volumes": typeof _daytona_volumes;
   "_deployment/vercel": typeof _deployment_vercel;
   "_designSessions/execution": typeof _designSessions_execution;

--- a/packages/backend/convex/_repoSnapshots/builds.ts
+++ b/packages/backend/convex/_repoSnapshots/builds.ts
@@ -304,6 +304,9 @@ export const recordSeededApp = internalMutation({
     repoId: v.id("githubRepos"),
     status: seededAppStatusValidator,
     seededSnapshotName: v.union(v.string(), v.null()),
+    seededSnapshotClass: v.optional(
+      v.union(v.literal("container"), v.literal("vm-hot")),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -317,6 +320,9 @@ export const recordSeededApp = internalMutation({
         app: repo?.rootDirectory,
         status: args.status,
         seededSnapshotName: args.seededSnapshotName,
+        ...(args.seededSnapshotClass
+          ? { seededSnapshotClass: args.seededSnapshotClass }
+          : {}),
       },
     ];
     await ctx.db.patch(args.buildId, { seededApps });
@@ -343,6 +349,7 @@ export const updateSeededAppWarmupStatus = internalMutation({
         app: app.app,
         status: app.status,
         seededSnapshotName: app.seededSnapshotName,
+        seededSnapshotClass: app.seededSnapshotClass,
         warmupStatus: args.status,
         warmupError: args.error,
       };

--- a/packages/backend/convex/_repoSnapshots/config.ts
+++ b/packages/backend/convex/_repoSnapshots/config.ts
@@ -7,6 +7,11 @@ import { snapshotScheduleValidator } from "../validators";
 import { authQuery, authMutation } from "../functions";
 import { safeDeleteCron, safeReplaceCron } from "../cronManager";
 
+/** True when this app repo uses the VM hot seeded-snapshot pilot path. */
+export function isVmHotSeedRepo(repo: Doc<"githubRepos">): boolean {
+  return repo.vmHotSeededSnapshots === true;
+}
+
 /** Converts a schedule string to a cron expression, returning null for "manual". */
 function resolveCronspec(schedule: string): string | null {
   if (schedule === "manual") return null;
@@ -79,12 +84,25 @@ export const getRepoSnapshot = authQuery({
  */
 export const getRepoSnapshotName = internalQuery({
   args: { repoId: v.id("githubRepos") },
-  returns: v.union(v.object({ snapshotName: v.string() }), v.null()),
+  returns: v.union(
+    v.object({
+      snapshotName: v.string(),
+      seededSnapshotClass: v.optional(
+        v.union(v.literal("container"), v.literal("vm-hot")),
+      ),
+    }),
+    v.null(),
+  ),
   handler: async (ctx, args) => {
     // Per-app seeded snapshot takes precedence (fast start with seeded DB).
     const repo = await ctx.db.get(args.repoId);
     if (repo?.seededSnapshotName) {
-      return { snapshotName: repo.seededSnapshotName };
+      return {
+        snapshotName: repo.seededSnapshotName,
+        ...(repo.seededSnapshotClass
+          ? { seededSnapshotClass: repo.seededSnapshotClass }
+          : {}),
+      };
     }
 
     const snapshot = await findSnapshotForRepo(ctx.db, args.repoId);
@@ -152,6 +170,12 @@ export const getSeedableAppRepos = internalQuery({
       // Seed-input fingerprint stored at the last successful capture — when it
       // still matches the current inputs the workflow skips re-seeding.
       seededFingerprint: v.union(v.string(), v.null()),
+      vmHotSeededSnapshots: v.boolean(),
+      seededSnapshotClass: v.union(
+        v.literal("container"),
+        v.literal("vm-hot"),
+        v.null(),
+      ),
     }),
   ),
   handler: async (ctx, args) => {
@@ -160,6 +184,8 @@ export const getSeedableAppRepos = internalQuery({
       repoId: r._id,
       seededSnapshotName: r.seededSnapshotName ?? null,
       seededFingerprint: r.seededFingerprint ?? null,
+      vmHotSeededSnapshots: isVmHotSeedRepo(r),
+      seededSnapshotClass: r.seededSnapshotClass ?? null,
     }));
   },
 });
@@ -244,6 +270,9 @@ export const setSeededSnapshotName = internalMutation({
     repoId: v.id("githubRepos"),
     seededSnapshotName: v.union(v.string(), v.null()),
     seededFingerprint: v.optional(v.union(v.string(), v.null())),
+    seededSnapshotClass: v.optional(
+      v.union(v.literal("container"), v.literal("vm-hot"), v.null()),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -252,6 +281,24 @@ export const setSeededSnapshotName = internalMutation({
       ...(args.seededFingerprint !== undefined
         ? { seededFingerprint: args.seededFingerprint ?? undefined }
         : {}),
+      ...(args.seededSnapshotClass !== undefined
+        ? { seededSnapshotClass: args.seededSnapshotClass ?? undefined }
+        : {}),
+    });
+    return null;
+  },
+});
+
+/** Enables or disables VM hot seeded snapshots for a pilot app repo (ops). */
+export const enableVmHotSeededSnapshotsPilot = internalMutation({
+  args: {
+    repoId: v.id("githubRepos"),
+    enabled: v.optional(v.boolean()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.repoId, {
+      vmHotSeededSnapshots: args.enabled !== false,
     });
     return null;
   },

--- a/packages/backend/convex/_sessions/internal.ts
+++ b/packages/backend/convex/_sessions/internal.ts
@@ -75,6 +75,24 @@ export const setPrState = internalMutation({
   },
 });
 
+/** Updates dev server fields after deferred post-ready setup completes. */
+export const patchDevServer = internalMutation({
+  args: {
+    sessionId: v.id("sessions"),
+    devPort: v.number(),
+    devCommand: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.sessionId, {
+      devPort: args.devPort,
+      devCommand: args.devCommand,
+      updatedAt: Date.now(),
+    });
+    return null;
+  },
+});
+
 /** Marks a session's PR ready for review and archives the sandbox (internal use). */
 export const markReadyAndArchive = internalMutation({
   args: { id: v.id("sessions") },

--- a/packages/backend/convex/_sessions/mutations.ts
+++ b/packages/backend/convex/_sessions/mutations.ts
@@ -22,14 +22,19 @@ export const create = authMutation({
     }
     const repo = await ctx.db.get(args.repoId);
     if (!repo) throw new Error("Repository not found");
+    const startupRequestedAt = Date.now();
     const sessionId = await ctx.db.insert("sessions", {
       repoId: args.repoId,
       userId: ctx.userId,
       title: args.title,
       status: "starting",
       createdBy: ctx.userId,
-      updatedAt: Date.now(),
+      updatedAt: startupRequestedAt,
+      startupRequestedAt,
     });
+    console.log(
+      `[sessionStartup] create sessionId=${sessionId} repoId=${args.repoId} startupRequestedAt=${startupRequestedAt}`,
+    );
     const branchName = `eva/session-${sessionId}`;
     await ctx.db.patch(sessionId, { branchName });
     const baseBranch = repo.defaultBaseBranch ?? FALLBACK_GIT_BASE_BRANCH;

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { formatDurationMsShort } from "@conductor/shared/duration";
 import { internal } from "../_generated/api";
 import { internalAction, internalMutation } from "../_generated/server";
 import { authMutation } from "../functions";
@@ -226,6 +227,12 @@ export const sandboxReady = internalMutation({
       devPort: args.devPort,
       devCommand: args.devCommand,
     });
+    if (args.isNew && session.startupRequestedAt) {
+      const activeMs = Date.now() - session.startupRequestedAt;
+      console.log(
+        `[sessionStartup][timing] sessionId=${args.sessionId} phase=sessionActive elapsedMs=${activeMs} elapsed=${formatDurationMsShort(activeMs)} sandboxId=${args.sandboxId} usedSnapshot=${args.usedSnapshot === true}`,
+      );
+    }
     return null;
   },
 });

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -61,6 +61,9 @@ export const sessionSandboxStartupWorkflow = workflow.define({
     repoId: v.id("githubRepos"),
   },
   handler: async (step, args): Promise<void> => {
+    console.log(
+      `[sessionStartup] workflow started sessionId=${args.sessionId} existingSandboxId=${args.existingSandboxId ?? "none"}`,
+    );
     // Thaw an archived/stopped sandbox across polling steps before the start
     // action, so a multi-minute cold-storage restore doesn't blow the
     // per-action 10-minute limit inside startSessionSandbox →

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -158,6 +158,8 @@ export const sessionFields = {
   terminalPanes: v.optional(v.array(terminalPaneValidator)),
   deploymentStatus: v.optional(deploymentStatusValidator),
   deploymentUrl: v.optional(v.string()),
+  /** Wall-clock ms when the user clicked New Session — drives startup timing logs. */
+  startupRequestedAt: v.optional(v.number()),
 };
 
 export const syncSettingFields = {
@@ -194,11 +196,17 @@ export const seededAppStatusValidator = v.union(
 // for build records created before the field existed (treat absent as terminal,
 // inferred from seededSnapshotName). seededSnapshotName is the captured snapshot
 // name on success, or null while running / when it fell back to the base Image.
+export const seededSnapshotClassValidator = v.union(
+  v.literal("container"),
+  v.literal("vm-hot"),
+);
+
 export const seededAppResultValidator = v.object({
   repoId: v.id("githubRepos"),
   app: v.optional(v.string()),
   status: v.optional(seededAppStatusValidator),
   seededSnapshotName: v.union(v.string(), v.null()),
+  seededSnapshotClass: v.optional(seededSnapshotClassValidator),
   warmupStatus: v.optional(snapshotWarmupStatusValidator),
   warmupError: v.optional(v.string()),
 });
@@ -240,6 +248,10 @@ export const githubRepoFields = {
   // build workflow skips re-seeding — the existing snapshot's data is identical
   // and re-capturing it would only contend with the image build.
   seededFingerprint: v.optional(v.string()),
+  // Pilot: hot VM snapshot capture for faster session boot (eva apps/web).
+  vmHotSeededSnapshots: v.optional(v.boolean()),
+  // Set when seededSnapshotName is swapped — tracks container vs vm-hot capture.
+  seededSnapshotClass: v.optional(seededSnapshotClassValidator),
   devPort: v.optional(v.number()),
   devCommand: v.optional(v.string()),
   systemPrompt: v.optional(v.string()),

--- a/packages/backend/convex/daytona.ts
+++ b/packages/backend/convex/daytona.ts
@@ -47,6 +47,7 @@ export {
 export {
   startSessionSandbox,
   prepareSessionSandbox,
+  finishNewSessionSandboxSetup,
   startDesignSandbox,
   startTaskPreviewSandbox,
   startProjectPreviewSandbox,

--- a/packages/backend/convex/repoSnapshots.ts
+++ b/packages/backend/convex/repoSnapshots.ts
@@ -9,6 +9,7 @@ export {
   getOrphanedSeededApps,
   getSeededAppStatus,
   setSeededSnapshotName,
+  enableVmHotSeededSnapshotsPilot,
   getSeedFingerprint,
   setImageFingerprint,
 } from "./_repoSnapshots/config";

--- a/packages/backend/convex/sessions.ts
+++ b/packages/backend/convex/sessions.ts
@@ -31,4 +31,5 @@ export {
   setPrState,
   markReadyAndArchive,
   updateDeploymentStatus,
+  patchDevServer,
 } from "./_sessions/internal";

--- a/packages/backend/convex/snapshotActions.ts
+++ b/packages/backend/convex/snapshotActions.ts
@@ -7,10 +7,13 @@ import { resolveAllEnvVars, resolveDaytonaApiKey } from "./envVarResolver";
 import { getInstallationToken } from "./githubAuth";
 import {
   getDaytona,
+  getDaytonaForSnapshotName,
   buildConfigFileDownloadCommands,
   filterDownloadableConfigFiles,
   exec,
+  execScript,
   getSandbox,
+  sleep,
   type SandboxConfigFile,
 } from "./_daytona/helpers";
 import {
@@ -18,18 +21,23 @@ import {
   createSandboxAndPrepareRepo,
   SESSION_LIFECYCLE,
   WARMING_LIFECYCLE,
+  VM_SNAPSHOT_REGION,
 } from "./_daytona/git";
 import {
   getSnapshot,
   deleteSnapshotByName,
   waitForSnapshotRemoval,
   triggerSandboxSnapshot,
+  kickOffVmBaseSnapshot,
+  VM_SNAPSHOT_RESOURCES,
 } from "./_daytona/snapshots";
+import { vmThinSnapshotName } from "./_daytona/vmSnapshotNames";
 import { isTerminalSnapshotState } from "./_daytona/snapshotStates";
 import { Image } from "@daytonaio/sdk";
 import type { Id } from "./_generated/dataModel";
 
 const DAYTONA_API_URL = "https://app.daytona.io/api";
+import { VM_SNAPSHOT_THIN_SUFFIX } from "./_daytona/vmSnapshotNames";
 const SEED_PREP_LABEL_KEY = "eva.purpose";
 const SEED_PREP_LABEL_VALUE = "snapshot-seed-prep";
 const SEEDED_SNAPSHOT_WARM_READY_TIMEOUT_SECONDS = 300;
@@ -404,6 +412,265 @@ export const kickOffSnapshotBuild = internalAction({
 });
 
 /**
+ * Workflow step: kick off the parallel VM-class base Image build (linux-vm,
+ * memory=12). Same Dockerfile as the container base; only sandboxClass differs.
+ */
+export const kickOffVmSnapshotBuild = internalAction({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoSnapshotId: v.id("repoSnapshots"),
+  },
+  returns: v.union(
+    v.object({
+      snapshotName: v.string(),
+      repoId: v.id("githubRepos"),
+    }),
+    v.null(),
+  ),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ snapshotName: string; repoId: Id<"githubRepos"> } | null> => {
+    const config = await ctx.runQuery(
+      internal.repoSnapshots.getRepoSnapshotInternal,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+    if (!config) {
+      await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: "error",
+        logs: "",
+        error: "Snapshot config not found",
+      });
+      return null;
+    }
+
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: config.repoId,
+    });
+    if (!repo) {
+      await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: "error",
+        logs: "",
+        error: "GitHub repo not found",
+      });
+      return null;
+    }
+
+    let token: string;
+    try {
+      token = await getInstallationToken(repo.installationId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: "error",
+        logs: "",
+        error: `Failed to get GitHub installation token: ${message}`,
+      });
+      return null;
+    }
+
+    let daytonaApiKey: string;
+    try {
+      const envVars = await resolveAllEnvVars(ctx, config.repoId);
+      const key = envVars.DAYTONA_API_KEY;
+      if (!key) {
+        throw new Error(
+          "DAYTONA_API_KEY not found in team or repo environment variables",
+        );
+      }
+      daytonaApiKey = key;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: "error",
+        logs: "",
+        error: message,
+      });
+      return null;
+    }
+
+    const branch = config.workflowRef ?? "main";
+    const configFiles: SandboxConfigFile[] = await ctx.runQuery(
+      internal.sandboxConfigFiles.getConfigFilesForSnapshot,
+      { repoId: config.repoId },
+    );
+    const buildCommands = config.buildCommands ?? [];
+    const image = buildSnapshotImage(
+      token,
+      repo.owner,
+      repo.name,
+      branch,
+      configFiles,
+      buildCommands,
+    );
+
+    const vmSnapshotName = vmThinSnapshotName(config.snapshotName);
+    try {
+      await kickOffVmBaseSnapshot(
+        daytonaApiKey,
+        vmSnapshotName,
+        image.dockerfile,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: "error",
+        logs: "",
+        error: message,
+      });
+      return null;
+    }
+
+    await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+      buildId: args.buildId,
+      chunk:
+        `[vm-hot] VM base snapshot build initiated ${vmSnapshotName} ` +
+        `(region=${VM_SNAPSHOT_REGION}, cpu=${VM_SNAPSHOT_RESOURCES.cpu}, memory=${VM_SNAPSHOT_RESOURCES.memory}, disk=${VM_SNAPSHOT_RESOURCES.disk}). Polling...\n`,
+    });
+
+    return { snapshotName: vmSnapshotName, repoId: config.repoId };
+  },
+});
+
+/**
+ * Shell script mirroring the container Image's system-tooling layers (not repo
+ * clone / pnpm install — those happen at seed-prep time). Runs inside a VM
+ * sandbox booted from the thin node:20-bookworm pull, then cold-captured as
+ * the final `-vm` base snapshot.
+ */
+function buildVmBootstrapShellScript(): string {
+  const lines = [
+    "set -euo pipefail",
+    "export DEBIAN_FRONTEND=noninteractive",
+    "apt-get update && apt-get install -y ca-certificates curl gnupg",
+    "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
+    "apt-get install -y nodejs",
+    "apt-get install -y git curl jq ripgrep fd-find git-lfs gh sudo build-essential python3",
+    "apt-get install -y xvfb xfce4 xfce4-terminal x11vnc novnc dbus-x11 x11-utils libx11-6 libxrandr2 libxext6 libxrender1 libxfixes3 libxss1 libxtst6 libxi6",
+    "sed -i 's/mdns4_minimal \\[NOTFOUND=return\\] //' /etc/nsswitch.conf",
+    "echo 'precedence ::ffff:0:0/96 100' > /etc/gai.conf",
+    'apt-get install -y wget gnupg && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && apt-get update && apt-get install -y google-chrome-stable',
+    "curl -fsSL https://get.docker.com | VERSION=28.3.3 sh",
+    'mkdir -p /etc/docker && echo \'{"dns":["1.1.1.1","8.8.8.8"],"mtu":1400,"ipv6":false,"ip6tables":false,"max-concurrent-downloads":3}\' > /etc/docker/daemon.json',
+    `printf %s ${EVA_SUDOERS_B64}|base64 -d>/etc/sudoers.d/eva&&chmod 440 /etc/sudoers.d/eva`,
+    `printf %s ${EVA_ENTRYPOINT_B64}|base64 -d>/usr/local/bin/eva-entrypoint.sh&&chmod 755 /usr/local/bin/eva-entrypoint.sh`,
+    "rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*",
+    "corepack enable",
+    "ln -sf /usr/bin/fdfind /usr/local/bin/fd",
+    "git lfs install --system",
+    "npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai agent-browser convex agentation-mcp@1.2.0 @anthropic-ai/claude-agent-sdk@0.3.201",
+    "curl -fsSL https://code-server.dev/install.sh | sh",
+    "curl -fsSL https://github.com/supabase/cli/releases/download/v2.90.0/supabase_2.90.0_linux_amd64.deb -o /tmp/supabase.deb && dpkg -i /tmp/supabase.deb && rm /tmp/supabase.deb",
+    "useradd -m -s /bin/bash eva || true",
+    "usermod -aG docker eva",
+    "mkdir -p /workspace /home/eva/.pnpm /home/eva/.local/bin && chown -R eva:eva /workspace /home/eva",
+    "su - eva -c 'corepack prepare pnpm@10.33.4 --activate'",
+    "echo VM bootstrap complete",
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Workflow step: boot thin VM snapshot, install Eva tooling, cold-capture final
+ * `-vm` base snapshot (declarative dockerfile builds are container-only).
+ */
+export const bootstrapVmBaseTooling = internalAction({
+  args: {
+    buildId: v.id("snapshotBuilds"),
+    repoId: v.id("githubRepos"),
+    thinSnapshotName: v.string(),
+    finalSnapshotName: v.string(),
+  },
+  returns: v.union(v.object({ finalSnapshotName: v.string() }), v.null()),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const daytona = getDaytona(daytonaApiKey, VM_SNAPSHOT_REGION);
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) {
+      await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: "error",
+        logs: "",
+        error: "GitHub repo not found for VM bootstrap",
+      });
+      return null;
+    }
+
+    let sandboxId: string | null = null;
+    try {
+      const sandbox = await createSandbox(
+        daytona,
+        repo.installationId,
+        { ...sandboxEnvVars, REPO_ID: args.repoId },
+        {
+          ...SESSION_LIFECYCLE,
+          labels: {
+            "eva.managed": "true",
+            "eva.purpose": "vm-base-bootstrap",
+            "eva.repoId": args.repoId,
+          },
+        },
+        args.thinSnapshotName,
+        undefined,
+        300,
+      );
+      sandboxId = sandbox.id;
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[vm-hot] Bootstrap sandbox ${sandboxId} booted from ${args.thinSnapshotName}. Installing tooling...\n`,
+      });
+      const script = buildVmBootstrapShellScript();
+      await execScript(sandbox, script, 540);
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[vm-hot] Bootstrap script finished on ${sandboxId}. Capturing ${args.finalSnapshotName}...\n`,
+      });
+      // VM filesystem snapshots require a stopped sandbox (Daytona 400 otherwise).
+      await sandbox.stop();
+      await deleteSnapshotByName(daytona, args.finalSnapshotName);
+      await waitForSnapshotRemoval(daytona, args.finalSnapshotName, {
+        attempts: 20,
+      });
+      await triggerSandboxSnapshot(
+        daytona,
+        sandboxId,
+        args.finalSnapshotName,
+        SEEDED_SNAPSHOT_TRIGGER_TIMEOUT_SEC,
+        { includeMemory: false, apiKey: daytonaApiKey },
+      );
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[vm-hot] Cold capture triggered for ${args.finalSnapshotName}.\n`,
+      });
+      return { finalSnapshotName: args.finalSnapshotName };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+        buildId: args.buildId,
+        chunk: `[vm-hot] VM bootstrap failed: ${message}\n`,
+      });
+      await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: "error",
+        logs: "",
+        error: `VM bootstrap failed: ${message}`,
+      });
+      return null;
+    }
+  },
+});
+
+/**
  * Workflow step 2 (called in a loop): Checks snapshot build state and streams
  * build logs from the Daytona API. Returns the current snapshot state string.
  * Each invocation is a fresh action with its own timeout.
@@ -414,6 +681,8 @@ export const pollSnapshotProgress = internalAction({
     snapshotName: v.string(),
     repoId: v.id("githubRepos"),
     attempt: v.number(),
+    /** When false, active only appends logs — workflow finalizes the build later. */
+    finalizeBuildOnActive: v.optional(v.boolean()),
   },
   returns: v.string(),
   handler: async (ctx, args): Promise<string> => {
@@ -476,13 +745,21 @@ export const pollSnapshotProgress = internalAction({
       }
 
       if (state === "active") {
-        await ctx.runMutation(internal.repoSnapshots.completeBuild, {
-          buildId: args.buildId,
-          status: "success",
-          logs:
-            (logs ? logs + "\n" : "") +
-            `[Poll ${args.attempt}] Snapshot build completed successfully.\n`,
-        });
+        const completionLogs =
+          (logs ? logs + "\n" : "") +
+          `[Poll ${args.attempt}] Snapshot build completed successfully.\n`;
+        if (args.finalizeBuildOnActive !== false) {
+          await ctx.runMutation(internal.repoSnapshots.completeBuild, {
+            buildId: args.buildId,
+            status: "success",
+            logs: completionLogs,
+          });
+        } else {
+          await ctx.runMutation(internal.repoSnapshots.appendLogs, {
+            buildId: args.buildId,
+            chunk: completionLogs,
+          });
+        }
         return "active";
       }
 
@@ -853,6 +1130,8 @@ export const launchSeedRun = internalAction({
     // Repo build commands (pnpm install / codegen etc), run after the reset so
     // the captured snapshot carries fresh node_modules and build artifacts.
     buildCommands: v.array(v.string()),
+    // VM hot capture: daemons stay running; stopCommands run on session teardown.
+    skipStopCommands: v.optional(v.boolean()),
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
@@ -864,10 +1143,11 @@ export const launchSeedRun = internalAction({
       internal.repoSnapshots.getBackgroundCommands,
       { repoId: args.repoId },
     );
-    const stopCommands: string[] | null = await ctx.runQuery(
-      internal.repoSnapshots.getStopCommands,
-      { repoId: args.repoId },
-    );
+    const stopCommands: string[] | null = args.skipStopCommands
+      ? null
+      : await ctx.runQuery(internal.repoSnapshots.getStopCommands, {
+          repoId: args.repoId,
+        });
     const requireSupabaseDump = shouldCaptureSupabaseState([
       ...(startupCommands ?? []),
       ...(backgroundCommands ?? []),
@@ -1008,7 +1288,12 @@ export const createSeedPrepSandbox = internalAction({
       ctx,
       args.repoId,
     );
-    const daytona = getDaytona(daytonaApiKey);
+    const vmRegionId =
+      args.imageSnapshot.endsWith("-vm") ||
+      args.imageSnapshot.endsWith(VM_SNAPSHOT_THIN_SUFFIX)
+        ? VM_SNAPSHOT_REGION
+        : undefined;
+    const daytona = getDaytona(daytonaApiKey, vmRegionId);
     const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
       repoId: args.repoId,
     });
@@ -1037,6 +1322,7 @@ export const createSeedPrepSandbox = internalAction({
       // Large seeded snapshots take well over the 30s default to boot; 180s
       // avoids the spurious create timeout + orphaned sandbox on warm boots.
       180,
+      undefined,
     );
     return { sandboxId: sandbox.id };
   },
@@ -1070,16 +1356,24 @@ export const triggerSeededSnapshot = internalAction({
     repoId: v.id("githubRepos"),
     sandboxId: v.string(),
     seededName: v.string(),
+    includeMemory: v.optional(v.boolean()),
   },
   returns: v.null(),
   handler: async (ctx, args): Promise<null> => {
     const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
-    const daytona = getDaytona(daytonaApiKey);
+    const daytona = getDaytona(
+      daytonaApiKey,
+      args.includeMemory === true ? VM_SNAPSHOT_REGION : undefined,
+    );
     await triggerSandboxSnapshot(
       daytona,
       args.sandboxId,
       args.seededName,
       SEEDED_SNAPSHOT_TRIGGER_TIMEOUT_SEC,
+      {
+        includeMemory: args.includeMemory === true,
+        apiKey: args.includeMemory === true ? daytonaApiKey : undefined,
+      },
     );
     return null;
   },
@@ -1100,11 +1394,16 @@ export const pollSeededSnapshotState = internalAction({
   args: {
     repoId: v.id("githubRepos"),
     seededName: v.string(),
+    vmHot: v.optional(v.boolean()),
   },
   returns: v.string(),
   handler: async (ctx, args): Promise<string> => {
     const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
-    const daytona = getDaytona(daytonaApiKey);
+    const daytona = getDaytonaForSnapshotName(
+      daytonaApiKey,
+      args.seededName,
+      args.vmHot,
+    );
     // Not registered yet (or a transient lookup miss) → treat as still pending.
     const snapshot = await getSnapshot(daytona, args.seededName);
     return snapshot ? snapshot.state : "pending";
@@ -1204,5 +1503,300 @@ export const warmSeededSnapshotCache = internalAction({
       }
     }
     return null;
+  },
+});
+
+/** Ops/debug: boot daytona-vm-large in experimental and test shell exec. */
+export const debugVmExecTest = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    region: v.optional(v.string()),
+    snapshotName: v.optional(v.string()),
+  },
+  returns: v.object({
+    output: v.string(),
+    sandboxId: v.string(),
+    target: v.string(),
+    via: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) throw new Error("Repo not found");
+    const region = args.region ?? VM_SNAPSHOT_REGION;
+    const daytona = getDaytona(daytonaApiKey, region);
+    const snapshot =
+      args.snapshotName ??
+      (region === VM_SNAPSHOT_REGION
+        ? "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-thin"
+        : "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3");
+    const skipPostCreate =
+      region === VM_SNAPSHOT_REGION || args.snapshotName !== undefined;
+    const sandbox = await createSandbox(
+      daytona,
+      repo.installationId,
+      { ...sandboxEnvVars, REPO_ID: args.repoId },
+      {
+        ...SESSION_LIFECYCLE,
+        labels: { "eva.managed": "true", "eva.purpose": "vm-exec-test" },
+      },
+      snapshot,
+      undefined,
+      120,
+      undefined,
+      undefined,
+      skipPostCreate,
+    );
+    const output = await exec(
+      sandbox,
+      "echo EXEC_OK && which bash && which sh",
+      30,
+      "/",
+    );
+    await sandbox.delete();
+    return {
+      output,
+      sandboxId: sandbox.id,
+      target: sandbox.target,
+      via: "toolbox",
+    };
+  },
+});
+
+/** Ops/debug: run full VM bootstrap shell script via toolbox execScript (no capture). */
+export const debugVmBootstrapScriptOnly = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.object({
+    sandboxId: v.string(),
+    ok: v.boolean(),
+    output: v.string(),
+    error: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const daytona = getDaytona(daytonaApiKey, VM_SNAPSHOT_REGION);
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) throw new Error("Repo not found");
+    const sandbox = await createSandbox(
+      daytona,
+      repo.installationId,
+      { ...sandboxEnvVars, REPO_ID: args.repoId },
+      {
+        ...SESSION_LIFECYCLE,
+        labels: {
+          "eva.managed": "true",
+          "eva.purpose": "vm-bootstrap-script-test",
+        },
+      },
+      "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-thin",
+      undefined,
+      120,
+    );
+    try {
+      const output = await execScript(
+        sandbox,
+        buildVmBootstrapShellScript(),
+        540,
+      );
+      await sandbox.delete();
+      return {
+        sandboxId: sandbox.id,
+        ok: true,
+        output: output.slice(-2000),
+        error: null,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await sandbox.delete();
+      return {
+        sandboxId: sandbox.id,
+        ok: false,
+        output: "",
+        error: message,
+      };
+    }
+  },
+});
+
+/** Ops/debug: POST a VM base snapshot and return the raw Daytona response. */
+export const debugKickOffVmSnapshot = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    repoSnapshotId: v.id("repoSnapshots"),
+    snapshotName: v.string(),
+    regionId: v.optional(v.string()),
+    memory: v.optional(v.number()),
+  },
+  returns: v.object({
+    httpStatus: v.number(),
+    body: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const config = await ctx.runQuery(
+      internal.repoSnapshots.getRepoSnapshotInternal,
+      { repoSnapshotId: args.repoSnapshotId },
+    );
+    if (!config) throw new Error("Snapshot config not found");
+    const envVars = await resolveAllEnvVars(ctx, config.repoId);
+    const daytonaApiKey = envVars.DAYTONA_API_KEY;
+    if (!daytonaApiKey) throw new Error("DAYTONA_API_KEY not found");
+    const regionId = args.regionId ?? VM_SNAPSHOT_REGION;
+    const memory = args.memory ?? VM_SNAPSHOT_RESOURCES.memory;
+    const resp = await fetch(`${DAYTONA_API_URL}/snapshots`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${daytonaApiKey}`,
+      },
+      body: JSON.stringify({
+        name: args.snapshotName,
+        sandboxClass: "linux-vm",
+        regionId,
+        imageName: "ubuntu:22.04",
+        cpu: VM_SNAPSHOT_RESOURCES.cpu,
+        memory,
+        disk: VM_SNAPSHOT_RESOURCES.disk,
+      }),
+    });
+    const body = await resp.text();
+    return { httpStatus: resp.status, body: body.slice(0, 3000) };
+  },
+});
+
+/** Ops/debug: list Daytona regions available to the org. */
+export const debugListDaytonaRegions = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+  },
+  returns: v.object({
+    sharedStatus: v.number(),
+    sharedBody: v.string(),
+    orgStatus: v.number(),
+    orgBody: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
+    const headers = { Authorization: `Bearer ${daytonaApiKey}` };
+    const sharedResp = await fetch(`${DAYTONA_API_URL}/shared-regions`, {
+      headers,
+    });
+    const sharedBody = await sharedResp.text();
+    const orgResp = await fetch(`${DAYTONA_API_URL}/regions`, { headers });
+    const orgBody = await orgResp.text();
+    return {
+      sharedStatus: sharedResp.status,
+      sharedBody: sharedBody.slice(0, 4000),
+      orgStatus: orgResp.status,
+      orgBody: orgBody.slice(0, 4000),
+    };
+  },
+});
+
+/** Ops/debug: resolve a snapshot name on Daytona (SDK + REST). */
+export const inspectDaytonaSnapshot = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    snapshotName: v.string(),
+    vmHot: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    sdkState: v.union(v.string(), v.null()),
+    sdkErrorReason: v.union(v.string(), v.null()),
+    listStatus: v.number(),
+    listBody: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey } = await resolveDaytonaApiKey(ctx, args.repoId);
+    const daytona = getDaytonaForSnapshotName(
+      daytonaApiKey,
+      args.snapshotName,
+      args.vmHot,
+    );
+    const snapshot = await getSnapshot(daytona, args.snapshotName);
+    const listResp = await fetch(
+      `${DAYTONA_API_URL}/snapshots/${encodeURIComponent(args.snapshotName)}`,
+      { headers: { Authorization: `Bearer ${daytonaApiKey}` } },
+    );
+    const listBody = await listResp.text();
+    return {
+      sdkState: snapshot?.state ?? null,
+      sdkErrorReason: snapshot?.errorReason ?? null,
+      listStatus: listResp.status,
+      listBody: listBody.slice(0, 2000),
+    };
+  },
+});
+
+/** Ops/debug: minimal VM bootstrap + cold capture smoke test. */
+export const debugVmBootstrapCapture = internalAction({
+  args: {
+    repoId: v.id("githubRepos"),
+    thinSnapshotName: v.string(),
+    testSnapshotName: v.string(),
+  },
+  returns: v.object({
+    sandboxId: v.string(),
+    execOutput: v.string(),
+    snapshotState: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const { daytonaApiKey, sandboxEnvVars } = await resolveDaytonaApiKey(
+      ctx,
+      args.repoId,
+    );
+    const daytona = getDaytona(daytonaApiKey, VM_SNAPSHOT_REGION);
+    const repo = await ctx.runQuery(internal.repoSnapshots.getRepo, {
+      repoId: args.repoId,
+    });
+    if (!repo) throw new Error("Repo not found");
+    const sandbox = await createSandbox(
+      daytona,
+      repo.installationId,
+      { ...sandboxEnvVars, REPO_ID: args.repoId },
+      {
+        ...SESSION_LIFECYCLE,
+        labels: { "eva.managed": "true", "eva.purpose": "vm-bootstrap-smoke" },
+      },
+      args.thinSnapshotName,
+      undefined,
+      120,
+    );
+    const script = ["set -e", "echo minimal-vm-bootstrap", "date -u"].join(
+      "\n",
+    );
+    const execOutput = await execScript(sandbox, script, 60);
+    await deleteSnapshotByName(daytona, args.testSnapshotName);
+    await waitForSnapshotRemoval(daytona, args.testSnapshotName, {
+      attempts: 10,
+    });
+    await sandbox.stop();
+    await triggerSandboxSnapshot(
+      daytona,
+      sandbox.id,
+      args.testSnapshotName,
+      60,
+      { apiKey: daytonaApiKey },
+    );
+    let snapshotState = "pending";
+    for (let i = 0; i < 20; i += 1) {
+      const snap = await getSnapshot(daytona, args.testSnapshotName);
+      snapshotState = snap?.state ?? "pending";
+      if (snapshotState === "active" || snapshotState === "error") break;
+      await sleep(15_000);
+    }
+    await sandbox.delete();
+    return { sandboxId: sandbox.id, execOutput, snapshotState };
   },
 });

--- a/packages/backend/convex/snapshotWorkflow.ts
+++ b/packages/backend/convex/snapshotWorkflow.ts
@@ -2,6 +2,10 @@ import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { workflow } from "./workflowManager";
 import { isTerminalSnapshotState } from "./_daytona/snapshotStates";
+import {
+  vmBaseSnapshotName,
+  vmThinSnapshotName,
+} from "./_daytona/vmSnapshotNames";
 
 const POLL_DELAY_MS = 30_000;
 const MAX_POLLS = 60; // ~30 minutes at 30s intervals
@@ -97,6 +101,9 @@ export const snapshotBuildWorkflow = workflow.define({
       internal.repoSnapshots.getSeedableAppRepos,
       { repoSnapshotId: args.repoSnapshotId },
     );
+    const hasVmHotApp = apps.some((app) => app.vmHotSeededSnapshots);
+    const vmBaseName = vmBaseSnapshotName(config.snapshotName);
+    const vmThinName = vmThinSnapshotName(config.snapshotName);
 
     try {
       await step.runAction(internal.snapshotActions.sweepSeedPrepSandboxes, {
@@ -129,6 +136,7 @@ export const snapshotBuildWorkflow = workflow.define({
         await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
           repoId: orphan.repoId,
           seededSnapshotName: null,
+          seededSnapshotClass: null,
         });
         console.log(
           `[snapshot] cleaned up orphaned seeded snapshot ${orphan.seededSnapshotName} (repo ${orphan.repoId} no longer seedable)`,
@@ -167,6 +175,7 @@ export const snapshotBuildWorkflow = workflow.define({
             snapshotName: kickOffResult.snapshotName,
             repoId: kickOffResult.repoId,
             attempt,
+            finalizeBuildOnActive: false,
           },
           { runAfter: attempt === 1 ? 10_000 : POLL_DELAY_MS },
         );
@@ -187,6 +196,98 @@ export const snapshotBuildWorkflow = workflow.define({
         }
         return;
       }
+
+      // Parallel VM-class base build for vm-hot pilot apps.
+      if (hasVmHotApp) {
+        await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
+          snapshotName: vmThinName,
+          repoId: config.repoId,
+          buildId: args.buildId,
+        });
+        const vmKickOff = await step.runAction(
+          internal.snapshotActions.kickOffVmSnapshotBuild,
+          { buildId: args.buildId, repoSnapshotId: args.repoSnapshotId },
+        );
+        if (!vmKickOff) return;
+        let vmAttempt = 0;
+        let vmState = "pending";
+        while (
+          vmAttempt < MAX_POLLS &&
+          !isTerminalSnapshotState(vmState) &&
+          vmState !== "active"
+        ) {
+          vmAttempt++;
+          vmState = await step.runAction(
+            internal.snapshotActions.pollSeededSnapshotState,
+            {
+              repoId: vmKickOff.repoId,
+              seededName: vmKickOff.snapshotName,
+              vmHot: true,
+            },
+            { runAfter: vmAttempt === 1 ? 10_000 : POLL_DELAY_MS },
+          );
+        }
+        if (vmState !== "active") {
+          await step.runMutation(internal.repoSnapshots.completeBuild, {
+            buildId: args.buildId,
+            status: "error",
+            logs: `[vm-hot] VM thin base ${vmKickOff.snapshotName} did not reach active (last state: ${vmState}).\n`,
+            error: `VM thin base snapshot failed or timed out (state: ${vmState})`,
+          });
+          return;
+        }
+        await step.runMutation(internal.repoSnapshots.appendLogs, {
+          buildId: args.buildId,
+          chunk: `[vm-hot] VM thin base ${vmKickOff.snapshotName} is active. Bootstrapping Eva tooling → ${vmBaseName}...\n`,
+        });
+        const bootstrap = await step.runAction(
+          internal.snapshotActions.bootstrapVmBaseTooling,
+          {
+            buildId: args.buildId,
+            repoId: config.repoId,
+            thinSnapshotName: vmKickOff.snapshotName,
+            finalSnapshotName: vmBaseName,
+          },
+        );
+        if (!bootstrap) {
+          return;
+        }
+        let finalAttempt = 0;
+        let finalState = "pending";
+        while (
+          finalAttempt < MAX_POLLS &&
+          !isTerminalSnapshotState(finalState) &&
+          finalState !== "active"
+        ) {
+          finalAttempt++;
+          finalState = await step.runAction(
+            internal.snapshotActions.pollSeededSnapshotState,
+            {
+              repoId: config.repoId,
+              seededName: bootstrap.finalSnapshotName,
+              vmHot: true,
+            },
+            { runAfter: finalAttempt === 1 ? 10_000 : POLL_DELAY_MS },
+          );
+        }
+        if (finalState !== "active") {
+          await step.runMutation(internal.repoSnapshots.completeBuild, {
+            buildId: args.buildId,
+            status: "error",
+            logs: `[vm-hot] VM base ${bootstrap.finalSnapshotName} did not reach active (last state: ${finalState}).\n`,
+            error: `VM base snapshot bootstrap failed or timed out (state: ${finalState})`,
+          });
+          return;
+        }
+        await step.runMutation(internal.repoSnapshots.appendLogs, {
+          buildId: args.buildId,
+          chunk: `[vm-hot] VM base snapshot ${bootstrap.finalSnapshotName} is active.\n`,
+        });
+        await step.runAction(internal.snapshotActions.deleteDaytonaSnapshot, {
+          snapshotName: vmKickOff.snapshotName,
+          repoId: config.repoId,
+        });
+      }
     } else {
       await step.runMutation(internal.repoSnapshots.appendLogs, {
         buildId: args.buildId,
@@ -202,6 +303,13 @@ export const snapshotBuildWorkflow = workflow.define({
       internal.snapshotActions.pollSeededSnapshotState,
       { repoId: config.repoId, seededName: config.snapshotName },
     );
+    const vmImageState = hasVmHotApp
+      ? await step.runAction(internal.snapshotActions.pollSeededSnapshotState, {
+          repoId: config.repoId,
+          seededName: vmBaseName,
+          vmHot: true,
+        })
+      : "inactive";
 
     // Per-app pipeline. Versioned capture name (buildId is unique per build):
     // the previous seeded snapshot stays LIVE and untouched until the
@@ -212,6 +320,9 @@ export const snapshotBuildWorkflow = workflow.define({
     const runSeedChain = async (
       app: (typeof apps)[number],
     ): Promise<boolean> => {
+      const isVmHot = app.vmHotSeededSnapshots;
+      const captureClass = isVmHot ? "vm-hot" : "container";
+      const pathTag = isVmHot ? "[vm-hot]" : "[container]";
       const seededName = `seeded-${app.repoId}-${args.buildId}`;
       let prepSandboxId: string | null = null;
       try {
@@ -223,18 +334,28 @@ export const snapshotBuildWorkflow = workflow.define({
           status: "running",
           seededSnapshotName: null,
         });
-        // Boot source cascade: previous seeded snapshot (warm: toolchain +
-        // service images + deps all present) → base Image (bootstrap). The
-        // retry/backoff absorbs runner propagation lag on fresh snapshots.
-        const sources = [
-          ...(app.seededSnapshotName && args.forceBaseSeed !== true
-            ? [app.seededSnapshotName]
-            : []),
-          ...(imageState === "active" ? [config.snapshotName] : []),
-        ];
+        // Boot source cascade. VM hot: previous vm-hot seeded → VM base only
+        // (no container fallback). Container: previous seeded → base Image.
+        const sources = isVmHot
+          ? [
+              ...(app.seededSnapshotName &&
+              app.seededSnapshotClass === "vm-hot" &&
+              args.forceBaseSeed !== true
+                ? [app.seededSnapshotName]
+                : []),
+              ...(vmImageState === "active" ? [vmBaseName] : []),
+            ]
+          : [
+              ...(app.seededSnapshotName && args.forceBaseSeed !== true
+                ? [app.seededSnapshotName]
+                : []),
+              ...(imageState === "active" ? [config.snapshotName] : []),
+            ];
         if (sources.length === 0) {
           throw new Error(
-            `No boot source for ${app.repoId}: no previous seeded snapshot and no base Image — run forceImageRebuild to bootstrap`,
+            isVmHot
+              ? `No VM boot source for ${app.repoId}: need active ${vmBaseName} (run forceImageRebuild) or a previous vm-hot seeded snapshot`
+              : `No boot source for ${app.repoId}: no previous seeded snapshot and no base Image — run forceImageRebuild to bootstrap`,
           );
         }
         for (const source of sources) {
@@ -246,12 +367,12 @@ export const snapshotBuildWorkflow = workflow.define({
             );
             prepSandboxId = created.sandboxId;
             console.log(
-              `[snapshot] booted seed sandbox for ${app.repoId} from ${source}`,
+              `${pathTag} [snapshot] booted seed sandbox for ${app.repoId} from ${source}`,
             );
             break;
           } catch (e) {
             console.error(
-              `[snapshot] boot from ${source} failed for ${app.repoId}: ${
+              `${pathTag} [snapshot] boot from ${source} failed for ${app.repoId}: ${
                 e instanceof Error ? e.message : String(e)
               }`,
             );
@@ -285,6 +406,7 @@ export const snapshotBuildWorkflow = workflow.define({
             repoId: app.repoId,
             branch,
             buildCommands: config.buildCommands ?? [],
+            skipStopCommands: isVmHot,
           },
           { retry: { maxAttempts: 3, initialBackoffMs: 10000, base: 2 } },
         );
@@ -322,6 +444,7 @@ export const snapshotBuildWorkflow = workflow.define({
           repoId: app.repoId,
           sandboxId: prepSandboxId,
           seededName,
+          includeMemory: isVmHot,
         });
         let snapState = "pending";
         for (
@@ -332,7 +455,7 @@ export const snapshotBuildWorkflow = workflow.define({
         ) {
           snapState = await step.runAction(
             internal.snapshotActions.pollSeededSnapshotState,
-            { repoId: app.repoId, seededName },
+            { repoId: app.repoId, seededName, vmHot: isVmHot },
             {
               runAfter:
                 pollAttempt === 1 ? 10_000 : SEED_SNAPSHOT_POLL_DELAY_MS,
@@ -355,12 +478,14 @@ export const snapshotBuildWorkflow = workflow.define({
         await step.runMutation(internal.repoSnapshots.setSeededSnapshotName, {
           repoId: app.repoId,
           seededSnapshotName: seededName,
+          seededSnapshotClass: captureClass,
         });
         await step.runMutation(internal.repoSnapshots.recordSeededApp, {
           buildId: args.buildId,
           repoId: app.repoId,
           status: "seeded",
           seededSnapshotName: seededName,
+          seededSnapshotClass: captureClass,
         });
         try {
           await step.runMutation(
@@ -448,10 +573,19 @@ export const snapshotBuildWorkflow = workflow.define({
 
     const results = await Promise.all(apps.map((app) => runSeedChain(app)));
 
-    // Finalize the build record (the forceImageRebuild path already recorded
-    // the image outcome; per-app outcomes live in seededApps either way).
-    if (!args.forceImageRebuild) {
-      const succeeded = results.filter(Boolean).length;
+    const succeeded = results.filter(Boolean).length;
+    if (args.forceImageRebuild) {
+      await step.runMutation(internal.repoSnapshots.completeBuild, {
+        buildId: args.buildId,
+        status: succeeded === apps.length ? "success" : "error",
+        logs: `Force rebuild finished: container base + ${hasVmHotApp ? "VM base + " : ""}${succeeded}/${apps.length} app snapshot(s) refreshed.\n`,
+        ...(succeeded === apps.length
+          ? {}
+          : {
+              error: `${apps.length - succeeded} app snapshot(s) fell back — see per-app diagnostics in the logs`,
+            }),
+      });
+    } else {
       await step.runMutation(internal.repoSnapshots.completeBuild, {
         buildId: args.buildId,
         status: succeeded === apps.length ? "success" : "error",

--- a/packages/backend/scripts/check-bootstrap-logs.mjs
+++ b/packages/backend/scripts/check-bootstrap-logs.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BUILD_ID = "rn724ah5b2akh3em1mc6gqzymn8a12fr";
+
+function query(code) {
+  const result = spawnSync(
+    "node",
+    ["node_modules/convex/bin/main.js", "run", "--inline-query", code],
+    {
+      cwd: backendDir,
+      encoding: "utf8",
+      env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+    },
+  );
+  return JSON.parse(result.stdout);
+}
+
+const data = query(
+  `const b = await ctx.db.get('${BUILD_ID}'); const logs = b?.logs ?? ''; const lines = logs.split('\\n'); return { status: b?.status, error: b?.error, tail: lines.slice(-15), markers: lines.filter(l => l.includes('bcdef07a') || l.includes('Bootstrap script finished') || l.includes('Cold capture') || l.includes('bootstrap failed')).slice(-10) };`,
+);
+console.log(JSON.stringify(data, null, 2));

--- a/packages/backend/scripts/check-build-detail.mjs
+++ b/packages/backend/scripts/check-build-detail.mjs
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BUILD_ID = process.argv[2] ?? "rn7c19amgcqzm9rj4644t83pkd8a1j13";
+
+const result = spawnSync(
+  "node",
+  [
+    "node_modules/convex/bin/main.js",
+    "run",
+    "--inline-query",
+    `const b = await ctx.db.get('${BUILD_ID}'); const web = await ctx.db.get('mh7fdbcrhbt6wbwqkdxr0xe4c182502a'); return { status: b?.status, seededApps: b?.seededApps, workflowId: b?.workflowId, error: b?.error, web: { vmHot: web?.vmHotSeededSnapshots, seeded: web?.seededSnapshotName, class: web?.seededSnapshotClass } };`,
+  ],
+  {
+    cwd: backendDir,
+    encoding: "utf8",
+    env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+  },
+);
+console.log(result.stdout);
+if (result.stderr) console.error(result.stderr);

--- a/packages/backend/scripts/debug-vm-kickoff.mjs
+++ b/packages/backend/scripts/debug-vm-kickoff.mjs
@@ -1,0 +1,19 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const args = JSON.stringify({
+  repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+  repoSnapshotId: "rh74g8w7mczaf7m7kg0vhnj1y181tyh2",
+  snapshotName: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-test",
+});
+
+const result = spawnSync(
+  "node",
+  ["node_modules/convex/bin/main.js", "run", "snapshotActions:debugKickOffVmSnapshot", args],
+  { cwd: backendDir, encoding: "utf8", env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" } },
+);
+console.log(result.stdout);
+if (result.stderr) console.error(result.stderr);
+process.exit(result.status ?? 0);

--- a/packages/backend/scripts/inspect-vm-base.mjs
+++ b/packages/backend/scripts/inspect-vm-base.mjs
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const args = JSON.stringify({
+  repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+  snapshotName: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm",
+  vmHot: true,
+});
+
+const result = spawnSync(
+  "node",
+  ["node_modules/convex/bin/main.js", "run", "snapshotActions:inspectDaytonaSnapshot", args],
+  {
+    cwd: backendDir,
+    encoding: "utf8",
+    env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+  },
+);
+console.log(result.stdout);
+if (result.stderr) console.error(result.stderr);

--- a/packages/backend/scripts/inspect-vm-snapshots.mjs
+++ b/packages/backend/scripts/inspect-vm-snapshots.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const names = [
+  "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm",
+  "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3",
+];
+
+for (const snapshotName of names) {
+  const args = JSON.stringify({
+    repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+    snapshotName,
+  });
+  const result = spawnSync(
+    "node",
+    ["node_modules/convex/bin/main.js", "run", "snapshotActions:inspectDaytonaSnapshot", args],
+    { cwd: backendDir, encoding: "utf8", env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" } },
+  );
+  console.log(`\n=== ${snapshotName} ===`);
+  console.log(result.stdout);
+  if (result.stderr) console.error(result.stderr);
+}

--- a/packages/backend/scripts/list-builds.mjs
+++ b/packages/backend/scripts/list-builds.mjs
@@ -1,0 +1,21 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const result = spawnSync(
+  "node",
+  [
+    "node_modules/convex/bin/main.js",
+    "run",
+    "--inline-query",
+    `const builds = await ctx.db.query('snapshotBuilds').withIndex('by_repo_snapshot', q => q.eq('repoSnapshotId', 'rh74g8w7mczaf7m7kg0vhnj1y181tyh2')).order('desc').take(3); return builds.map(b=>({_id:b._id,status:b.status,error:b.error?.slice(0,120)}));`,
+  ],
+  {
+    cwd: backendDir,
+    encoding: "utf8",
+    env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+  },
+);
+console.log(result.stdout);

--- a/packages/backend/scripts/poll-vm-hot-build.mjs
+++ b/packages/backend/scripts/poll-vm-hot-build.mjs
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BUILD_ID = process.argv[2];
+
+function query(code) {
+  const result = spawnSync(
+    "node",
+    ["node_modules/convex/bin/main.js", "run", "--inline-query", code],
+    {
+      cwd: backendDir,
+      encoding: "utf8",
+      env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+    },
+  );
+  return JSON.parse(result.stdout);
+}
+
+if (!BUILD_ID) {
+  const builds = query(
+    `const builds = await ctx.db.query('snapshotBuilds').withIndex('by_repo_snapshot', q => q.eq('repoSnapshotId', 'rh74g8w7mczaf7m7kg0vhnj1y181tyh2')).order('desc').take(1); return builds[0] ? { _id: builds[0]._id, status: builds[0].status, error: builds[0].error } : null;`,
+  );
+  console.log(JSON.stringify(builds, null, 2));
+  process.exit(0);
+}
+
+const data = query(
+  `const b = await ctx.db.get('${BUILD_ID}'); const logs = b?.logs ?? ''; const web = await ctx.db.get('mh7fdbcrhbt6wbwqkdxr0xe4c182502a'); return { status: b?.status, error: b?.error, logLen: logs.length, web: { seeded: web?.seededSnapshotName, class: web?.seededSnapshotClass }, vmHotLines: logs.split('\\n').filter(l => l.includes('vm-hot') || l.includes('SEEDRUN') || l.includes('seeded build')).slice(-20), tail: logs.slice(-1200) };`,
+);
+console.log(JSON.stringify(data, null, 2));

--- a/packages/backend/scripts/poll-vm-snapshot-state.mjs
+++ b/packages/backend/scripts/poll-vm-snapshot-state.mjs
@@ -1,0 +1,18 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const args = JSON.stringify({
+  repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+  seededName: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm",
+});
+
+const result = spawnSync(
+  "node",
+  ["node_modules/convex/bin/main.js", "run", "snapshotActions:pollSeededSnapshotState", args],
+  { cwd: backendDir, encoding: "utf8", env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" } },
+);
+console.log("stdout:", result.stdout);
+console.log("stderr:", result.stderr);
+console.log("exit:", result.status);

--- a/packages/backend/scripts/run-debug-vm-exec-test.mjs
+++ b/packages/backend/scripts/run-debug-vm-exec-test.mjs
@@ -1,0 +1,18 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const backendRoot = path.resolve(root, "..");
+
+const args = JSON.stringify({
+  repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+});
+
+const result = spawnSync(
+  "node",
+  ["node_modules/convex/bin/main.js", "run", "snapshotActions:debugVmExecTest", args],
+  { cwd: backendRoot, stdio: "inherit", env: process.env },
+);
+
+process.exit(result.status ?? 1);

--- a/packages/backend/scripts/run-vm-bootstrap-script-only.mjs
+++ b/packages/backend/scripts/run-vm-bootstrap-script-only.mjs
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const args = JSON.stringify({
+  repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+});
+
+const result = spawnSync(
+  "node",
+  [
+    "node_modules/convex/bin/main.js",
+    "run",
+    "snapshotActions:debugVmBootstrapScriptOnly",
+    args,
+  ],
+  {
+    cwd: backendDir,
+    encoding: "utf8",
+    env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+  },
+);
+
+console.log("stdout:", result.stdout);
+if (result.stderr) console.error("stderr:", result.stderr);
+process.exit(result.status ?? 1);

--- a/packages/backend/scripts/run-vm-bootstrap.mjs
+++ b/packages/backend/scripts/run-vm-bootstrap.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const args = JSON.stringify({
+  buildId: "rn724ah5b2akh3em1mc6gqzymn8a12fr",
+  repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+  thinSnapshotName: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-thin",
+  finalSnapshotName: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm",
+});
+
+const result = spawnSync(
+  "node",
+  [
+    "node_modules/convex/bin/main.js",
+    "run",
+    "snapshotActions:bootstrapVmBaseTooling",
+    args,
+  ],
+  {
+    cwd: backendDir,
+    stdio: "inherit",
+    env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+  },
+);
+
+process.exit(result.status ?? 1);

--- a/packages/backend/scripts/run-vm-smoke-capture.mjs
+++ b/packages/backend/scripts/run-vm-smoke-capture.mjs
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const args = JSON.stringify({
+  repoId: "mh7ca667pjd7fjaqtw6n86vxex82jev6",
+  thinSnapshotName: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-thin",
+  testSnapshotName: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-smoke2",
+});
+
+const result = spawnSync(
+  "node",
+  [
+    "node_modules/convex/bin/main.js",
+    "run",
+    "snapshotActions:debugVmBootstrapCapture",
+    args,
+  ],
+  {
+    cwd: backendDir,
+    stdio: "inherit",
+    env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+  },
+);
+
+process.exit(result.status ?? 1);

--- a/packages/backend/scripts/test-vm-seed-prep.mjs
+++ b/packages/backend/scripts/test-vm-seed-prep.mjs
@@ -1,0 +1,30 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const args = JSON.stringify({
+  repoId: "mh7fdbcrhbt6wbwqkdxr0xe4c182502a",
+  imageSnapshot: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm",
+});
+
+const result = spawnSync(
+  "node",
+  [
+    "node_modules/convex/bin/main.js",
+    "run",
+    "snapshotActions:createSeedPrepSandbox",
+    args,
+  ],
+  {
+    cwd: backendDir,
+    encoding: "utf8",
+    env: { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" },
+    maxBuffer: 10 * 1024 * 1024,
+  },
+);
+
+console.log("status", result.status);
+console.log("stdout", result.stdout);
+if (result.stderr) console.error("stderr tail:", result.stderr.slice(-3000));

--- a/packages/backend/scripts/try-eu-vm-16gb.mjs
+++ b/packages/backend/scripts/try-eu-vm-16gb.mjs
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const env = { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" };
+const REPO_ID = "mh7ca667pjd7fjaqtw6n86vxex82jev6";
+const REPO_SNAPSHOT_ID = "rh74g8w7mczaf7m7kg0vhnj1y181tyh2";
+const SNAPSHOT_NAME = "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-eu16-test";
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function convexRun(functionName, args) {
+  const result = spawnSync(
+    "node",
+    ["node_modules/convex/bin/main.js", "run", functionName, JSON.stringify(args)],
+    { cwd: backendDir, encoding: "utf8", env, maxBuffer: 10 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    console.error(result.stderr?.slice(-3000));
+    throw new Error(`convex run ${functionName} failed`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+async function main() {
+  console.log("=== Daytona regions ===");
+  const regions = convexRun("snapshotActions:debugListDaytonaRegions", {
+    repoId: REPO_ID,
+  });
+  console.log("shared:", regions.sharedStatus, regions.sharedBody.slice(0, 2000));
+  console.log("org:", regions.orgStatus, regions.orgBody.slice(0, 2000));
+
+  console.log("\n=== Kick off linux-vm snapshot: region=eu, memory=16 ===");
+  const kickoff = convexRun("snapshotActions:debugKickOffVmSnapshot", {
+    repoId: REPO_ID,
+    repoSnapshotId: REPO_SNAPSHOT_ID,
+    snapshotName: SNAPSHOT_NAME,
+    regionId: "eu",
+    memory: 16,
+  });
+  console.log(JSON.stringify(kickoff, null, 2));
+
+  if (kickoff.httpStatus < 200 || kickoff.httpStatus >= 300) {
+    process.exit(1);
+  }
+
+  console.log("\n=== Poll snapshot state (default EU client) ===");
+  let finalState = "pending";
+  for (let i = 0; i < 20; i += 1) {
+    await sleep(15_000);
+    const state = convexRun("snapshotActions:inspectDaytonaSnapshot", {
+      repoId: REPO_ID,
+      snapshotName: SNAPSHOT_NAME,
+    });
+    finalState = state.sdkState ?? "pending";
+    console.log(
+      `poll ${i + 1}: sdk=${finalState} http=${state.listStatus} body=${state.listBody.slice(0, 200)}`,
+    );
+    if (finalState === "active" || finalState === "error") break;
+  }
+
+  if (finalState !== "active") {
+    console.log("Snapshot did not become active — skipping sandbox exec test");
+    process.exit(1);
+  }
+
+  console.log("\n=== Toolbox exec: boot VM snapshot in eu ===");
+  const execTest = convexRun("snapshotActions:debugVmExecTest", {
+    repoId: REPO_ID,
+    region: "eu",
+    snapshotName: SNAPSHOT_NAME,
+  });
+  console.log(JSON.stringify(execTest, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/backend/scripts/try-vm-regions-matrix.mjs
+++ b/packages/backend/scripts/try-vm-regions-matrix.mjs
@@ -1,0 +1,39 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const env = { ...process.env, CONVEX_DEPLOYMENT: "dev:good-mule-506" };
+const REPO_ID = "mh7ca667pjd7fjaqtw6n86vxex82jev6";
+const REPO_SNAPSHOT_ID = "rh74g8w7mczaf7m7kg0vhnj1y181tyh2";
+
+function convexRun(functionName, args) {
+  const result = spawnSync(
+    "node",
+    ["node_modules/convex/bin/main.js", "run", functionName, JSON.stringify(args)],
+    { cwd: backendDir, encoding: "utf8", env, maxBuffer: 10 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    console.error(result.stderr?.slice(-2000));
+    throw new Error(`convex run ${functionName} failed`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+const cases = [
+  { label: "experimental + 16GiB", regionId: "experimental", memory: 16, name: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-exp16-test" },
+  { label: "us + 16GiB", regionId: "us", memory: 16, name: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-us16-test" },
+  { label: "eu + 12GiB (control)", regionId: "eu", memory: 12, name: "snapshot-mh796tpcm1h0a0amat46r27wms81gwz3-vm-eu12-test" },
+];
+
+for (const testCase of cases) {
+  console.log(`\n=== ${testCase.label} ===`);
+  const kickoff = convexRun("snapshotActions:debugKickOffVmSnapshot", {
+    repoId: REPO_ID,
+    repoSnapshotId: REPO_SNAPSHOT_ID,
+    snapshotName: testCase.name,
+    regionId: testCase.regionId,
+    memory: testCase.memory,
+  });
+  console.log(JSON.stringify(kickoff, null, 2));
+}

--- a/packages/backend/scripts/vm-hot-carepulse-pilot-bootstrap.mjs
+++ b/packages/backend/scripts/vm-hot-carepulse-pilot-bootstrap.mjs
@@ -1,0 +1,94 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const deployment = process.env.CONVEX_DEPLOYMENT ?? "dev:good-mule-506";
+
+const CAREPULSE_WEB_REPO_ID = "mh7fdbcrhbt6wbwqkdxr0xe4c182502a";
+const EVA_WEB_REPO_ID = "mh7ccabpz5w729gy9e3vpkachx825916";
+const CAREPULSE_REPO_SNAPSHOT_ID = "rh74g8w7mczaf7m7kg0vhnj1y181tyh2";
+
+function convexRun(functionName, args) {
+  const json = JSON.stringify(args);
+  const result = spawnSync(
+    "node",
+    ["node_modules/convex/bin/main.js", "run", functionName, json],
+    { cwd: backendDir, encoding: "utf8", env: { ...process.env, CONVEX_DEPLOYMENT: deployment } },
+  );
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr ?? "");
+    throw new Error(`convex run ${functionName} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function convexInlineQuery(code) {
+  const result = spawnSync(
+    "node",
+    ["node_modules/convex/bin/main.js", "run", "--inline-query", code],
+    { cwd: backendDir, encoding: "utf8", env: { ...process.env, CONVEX_DEPLOYMENT: deployment } },
+  );
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr ?? "");
+    throw new Error("inline query failed");
+  }
+  return JSON.parse(result.stdout);
+}
+
+// 1. Sync startup/background/stop from prod
+console.log("Fetching prod carepulse web commands...");
+const prodResult = spawnSync(
+  "node",
+  [
+    "node_modules/convex/bin/main.js",
+    "run",
+    "--prod",
+    "--inline-query",
+    `const r = await ctx.db.get('${CAREPULSE_WEB_REPO_ID}'); return { startupCommands: r?.startupCommands ?? [], backgroundCommands: r?.backgroundCommands ?? [], stopCommands: r?.stopCommands ?? [] };`,
+  ],
+  { cwd: backendDir, encoding: "utf8" },
+);
+if (prodResult.status !== 0) throw new Error("prod query failed");
+const prodCommands = JSON.parse(prodResult.stdout);
+console.log(
+  `Prod commands: startup=${prodCommands.startupCommands.length}, bg=${prodCommands.backgroundCommands.length}, stop=${prodCommands.stopCommands.length}`,
+);
+
+console.log("Syncing commands to dev...");
+convexRun("githubRepos:setRepoCommandsInternal", {
+  repoId: CAREPULSE_WEB_REPO_ID,
+  startupCommands: prodCommands.startupCommands,
+  backgroundCommands: prodCommands.backgroundCommands,
+  stopCommands: prodCommands.stopCommands,
+});
+
+// 2. Pilot flags
+console.log("Enabling VM hot on carepulse apps/web...");
+convexRun("repoSnapshots:enableVmHotSeededSnapshotsPilot", {
+  repoId: CAREPULSE_WEB_REPO_ID,
+  enabled: true,
+});
+console.log("Disabling VM hot on eva apps/web...");
+convexRun("repoSnapshots:enableVmHotSeededSnapshotsPilot", {
+  repoId: EVA_WEB_REPO_ID,
+  enabled: false,
+});
+
+// 3. Trigger force rebuild
+console.log("Triggering forceImageRebuild for carepulse-ts...");
+convexRun("repoSnapshots:triggerScheduledBuild", {
+  repoSnapshotId: CAREPULSE_REPO_SNAPSHOT_ID,
+  forceImageRebuild: true,
+  disableRetries: true,
+});
+
+const builds = convexInlineQuery(
+  `const builds = await ctx.db.query('snapshotBuilds').withIndex('by_repo_snapshot', q => q.eq('repoSnapshotId', '${CAREPULSE_REPO_SNAPSHOT_ID}')).order('desc').take(1); return builds[0] ? { _id: builds[0]._id, status: builds[0].status } : null;`,
+);
+console.log("Latest build:", builds);
+writeFileSync(
+  join(backendDir, ".vm-hot-pilot-build.json"),
+  JSON.stringify({ buildId: builds?._id, repoId: CAREPULSE_WEB_REPO_ID, startedAt: Date.now() }, null, 2),
+);


### PR DESCRIPTION
## Summary

- Adds **Path B (vm-hot)** snapshot pipeline: thin `ubuntu:22.04` VM pull in Daytona `experimental`, toolbox bootstrap to Eva tooling base (`-vm`), hot memory seeded capture (`includeMemory: true`), and `vmHotSeededSnapshots` / `seededSnapshotClass` tracking.
- Toolbox-only exec (no SSH): chunked script upload, VM-aware cwd, clone-on-boot for tooling base snapshots.
- Session startup timing logs for latency comparison vs EU container seeded snapshots.
- Ops scripts + debug Convex actions for piloting on carepulse dev (`good-mule-506`).
- Full writeup: `internal/plans/implemented/vm-hot-seeded-snapshots-pilot.md`

## Daytona constraints (probed)

- `linux-vm` only on **experimental** (not EU/US); VM memory capped at **12 GiB** (16 GiB remains container/EU).

## Test plan

- [ ] Deploy backend to dev `good-mule-506`
- [ ] `node scripts/run-debug-vm-exec-test.mjs` — toolbox exec on thin VM
- [ ] Confirm `-vm` base snapshot active (`inspect-vm-base.mjs`)
- [ ] Run seed-only build for carepulse; verify vm-hot seeded snapshot + `seededSnapshotClass: vm-hot`
- [ ] Create carepulse session; compare `[sessionStartup][timing]` vs container seeded boot
