### PR TITLE
fix(sandbox/vercel): vercelSandboxId lifecycle on cutover

### DIFF
--- a/VERCEL_SANDBOX_PR_MERGE_ISSUES.md
+++ b/VERCEL_SANDBOX_PR_MERGE_ISSUES.md
@@ -69,7 +69,9 @@
 
 - **Stacked fix:** design stop + design chat launch use `preferPersistedSandboxId`.
 
-### 16. Dead `unwrapDaytonaSandbox` import in `git.ts` — defer cleanup
+### 16. Dead `unwrapDaytonaSandbox` import in `git.ts` — FIXED
+
+- **Stacked fix:** removed unused import from `_daytona/git.ts`.
 
 ### 17. Changelog overclaims full entity cutover — FIXED via #3 wiring + stacked changelog entry
 

--- a/VERCEL_SANDBOX_PR_MERGE_ISSUES.md
+++ b/VERCEL_SANDBOX_PR_MERGE_ISSUES.md
@@ -3,7 +3,7 @@
 **Base PR:** [#425](https://github.com/vvedantb/eva/pull/425) — `feat/vercel-sandbox-migration` → `main`  
 **Fix PR:** stacked on #425 — `fix/vercel-sandbox-id-lifecycle`  
 **Checked:** 2026-07-09  
-**Verdict:** Code blockers #1–#6, #8–#10, #13, #15 addressed on stacked branch. Ops #7 still required before production flip. Remaining items are known limitations / cleanup.
+**Verdict:** Actionable code items on stacked PR done (#1–#6, #8–#10, #13, #15–#16). Ops #7 + E2E #5 re-check remain. Deferred: #11/#12/#14 (known limitations).
 
 **PR status (base):** MERGEABLE, checks green, `REVIEW_REQUIRED`. Title still says WIP.
 

--- a/VERCEL_SANDBOX_PR_MERGE_ISSUES.md
+++ b/VERCEL_SANDBOX_PR_MERGE_ISSUES.md
@@ -1,0 +1,96 @@
+# Vercel sandbox PR merge issues
+
+**Base PR:** [#425](https://github.com/vvedantb/eva/pull/425) — `feat/vercel-sandbox-migration` → `main`  
+**Fix PR:** stacked on #425 — `fix/vercel-sandbox-id-lifecycle`  
+**Checked:** 2026-07-09  
+**Verdict:** Code blockers #1–#6, #8–#10, #13, #15 addressed on stacked branch. Ops #7 still required before production flip. Remaining items are known limitations / cleanup.
+
+**PR status (base):** MERGEABLE, checks green, `REVIEW_REQUIRED`. Title still says WIP.
+
+---
+
+## Blockers
+
+### 1. `saveAuditFixSandboxId` never persists `vercelSandboxId` — FIXED
+
+- **Stacked fix:** `saveAuditFixSandboxId` + audit create path persist `vercelSandboxId`.
+
+### 2. Clear/stop mutations leave stale `vercelSandboxId` — FIXED
+
+- **Stacked fix:** `clearSandbox` / `clearProjectSandbox` / `clearTaskSandbox` / `clearInterview` / PR-merge project clear all unset both ids; project delete uses `vercelSandboxId ?? sandboxId`.
+
+---
+
+## High
+
+### 3. Doc workflows omit `vercelSandboxId` — FIXED
+
+- **Stacked fix:** `docInterviewWorkflow` + `docPrdWorkflow` pass/persist via `saveDocSandboxId`.
+
+### 4. `resolveTaskSandboxIdForRun` is provider-blind — FIXED
+
+- **Stacked fix:** uses `preferPersistedSandboxId`.
+
+### 5. Design post-create install still flaky on pnpm monorepos — MITIGATED
+
+- **Stacked fix:** stronger `detectPackageManager` (`packageManager: pnpm@` + `workspace:` → pnpm). Still worth E2E re-check on carepulse designs.
+
+### 6. `sessionExecuteWorkflow` thaw gated only on `data.sandboxId` — FIXED
+
+- **Stacked fix:** thaw when `sandboxId || vercelSandboxId`.
+
+### 7. Production needs a Vercel seeded `snap_*` before flip — OPS (open)
+
+- Not a code change. Document/run seed per repo before `SANDBOX_PROVIDER=vercel`.
+
+---
+
+## Medium
+
+### 8. `projectInterviewWorkflow` thaw only when `projectData.sandboxId` — FIXED
+
+### 9. Auth `updateProjectSandbox` sets only `sandboxId` — FIXED
+
+### 10. `auditFixWorkflow` catch clears only one resume id — FIXED
+
+### 11. Daytona persistence volumes disabled on Vercel — known limitation (defer)
+
+### 12. `kickOffSnapshotBuild` still Daytona-only — known limitation (defer)
+
+### 13. Audit-fix fallback omits `vercelSandboxId` persist — FIXED (with #1)
+
+### 14. Design create is one long action — defer (architecture)
+
+---
+
+## Low
+
+### 15. Design/PTY guards check `sandboxId` only — FIXED
+
+- **Stacked fix:** design stop + design chat launch use `preferPersistedSandboxId`.
+
+### 16. Dead `unwrapDaytonaSandbox` import in `git.ts` — defer cleanup
+
+### 17. Changelog overclaims full entity cutover — FIXED via #3 wiring + stacked changelog entry
+
+---
+
+## What’s OK (not blocking)
+
+- Provider factory + `SANDBOX_PROVIDER` + credential validation
+- `resolveExistingSandboxId` — Vercel never uses Daytona UUID for `get`
+- Thaw polling via `resumeSandboxSteps` for session/task/project/design startup
+- Happy-path persist of both ids on session/task/project/design ready
+- Automations create on Vercel + persist `vercelSandboxId` (verified E2E)
+- Agent run reuse of Vercel sandbox (verified E2E)
+- Session/task/project preview create/resume (verified E2E)
+
+---
+
+## Recommended before production cutover
+
+1. ~~Fix #1 and #2~~ done on stacked PR
+2. ~~Fix #4~~ done
+3. ~~Wire #3~~ done
+4. Re-verify #5 design start on carepulse after pnpm fix (E2E)
+5. Ensure each flipped repo has a successful Vercel seed build (#7) before setting `SANDBOX_PROVIDER=vercel`

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Vercel sandbox id lifecycle fixes - 2026-07-09
+
+- Persist and clear `vercelSandboxId` with `sandboxId` on audit-fix, docs, sessions, projects, tasks, and PR-merge cleanup so Vercel reuse never thaws a stale or missing name.
+- Shared `preferPersistedSandboxId` for provider-blind callers; thaw gates and design stop/launch use either id; stronger pnpm detect for `workspace:` monorepos.
+- Reason for change: stacked fixes on the Vercel cutover PR so close→start and audit/doc reuse work after provider flip.
+
 ## Vercel everywhere cutover - 2026-07-09
 
 - All sandbox create/resume paths (sessions, tasks, projects, designs, automations, agent runs) now use Vercel when `SANDBOX_PROVIDER=vercel`, with `vercelSandboxId` as the only reuse key so Daytona UUIDs never hit Vercel `get`.

--- a/packages/backend/convex/_audits/fixes.ts
+++ b/packages/backend/convex/_audits/fixes.ts
@@ -79,19 +79,26 @@ export const saveAuditFixSandboxId = internalMutation({
   args: {
     taskId: v.id("agentTasks"),
     sandboxId: v.string(),
+    vercelSandboxId: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     const task = await ctx.db.get(args.taskId);
     if (!task) return null;
+    const vercelPatch =
+      args.vercelSandboxId !== undefined
+        ? { vercelSandboxId: args.vercelSandboxId }
+        : {};
     if (task.projectId) {
       await ctx.db.patch(task.projectId, {
         sandboxId: args.sandboxId,
+        ...vercelPatch,
         lastSandboxActivity: Date.now(),
       });
     } else {
       await ctx.db.patch(args.taskId, {
         sandboxId: args.sandboxId,
+        ...vercelPatch,
         updatedAt: Date.now(),
       });
     }

--- a/packages/backend/convex/_daytona/audit.ts
+++ b/packages/backend/convex/_daytona/audit.ts
@@ -195,6 +195,7 @@ export const launchSelectedAuditFixes = internalAction({
         await ctx.runMutation(internal.audits.saveAuditFixSandboxId, {
           taskId: args.taskId,
           sandboxId,
+          vercelSandboxId: result.vercelSandboxId,
         });
       }
 

--- a/packages/backend/convex/_daytona/devServer.ts
+++ b/packages/backend/convex/_daytona/devServer.ts
@@ -23,15 +23,22 @@ export async function detectPackageManager(
   const dir = rootDir ? `${workspaceRoot}/${rootDir}` : workspaceRoot;
   // Prefer the package rootDir, then fall back to the workspace root — monorepos
   // often keep pnpm-lock.yaml at the repo root while rootDirectory points at an app.
-  const lockFile = (
+  // Also treat packageManager / workspace: deps as pnpm so npm never hits workspace:*.
+  const detection = (
     await execHandle(
       sandbox,
-      `{ cd ${dir} && ls -1 pnpm-lock.yaml yarn.lock 2>/dev/null; cd ${workspaceRoot} && ls -1 pnpm-lock.yaml yarn.lock 2>/dev/null; } | head -n1`,
+      [
+        `if [ -f ${dir}/pnpm-lock.yaml ] || [ -f ${workspaceRoot}/pnpm-lock.yaml ]; then echo pnpm;`,
+        `elif [ -f ${dir}/yarn.lock ] || [ -f ${workspaceRoot}/yarn.lock ]; then echo yarn;`,
+        `elif grep -q '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@' ${dir}/package.json ${workspaceRoot}/package.json 2>/dev/null; then echo pnpm;`,
+        `elif grep -q 'workspace:' ${dir}/package.json ${workspaceRoot}/package.json 2>/dev/null; then echo pnpm;`,
+        `else echo npm; fi`,
+      ].join(" "),
       5,
     )
   ).trim();
-  if (lockFile === "pnpm-lock.yaml") return "pnpm";
-  if (lockFile === "yarn.lock") return "yarn";
+  if (detection === "pnpm") return "pnpm";
+  if (detection === "yarn") return "yarn";
   return "npm";
 }
 

--- a/packages/backend/convex/_daytona/git.ts
+++ b/packages/backend/convex/_daytona/git.ts
@@ -27,7 +27,6 @@ import {
 } from "./helpers";
 import { detectPackageManager } from "./devServer";
 import { ensureGitCredentialHelper } from "./gitCredentials";
-import { unwrapDaytonaSandbox } from "../_sandbox/daytonaProvider";
 import {
   EVA_ENV_FILE,
   renderEvaEnvFile,

--- a/packages/backend/convex/_designSessions/sandbox.ts
+++ b/packages/backend/convex/_designSessions/sandbox.ts
@@ -4,6 +4,7 @@ import { internal } from "../_generated/api";
 import { workflow } from "../workflowManager";
 import { authMutation } from "../functions";
 import { FALLBACK_GIT_BASE_BRANCH } from "@conductor/shared";
+import { preferPersistedSandboxId } from "../_sandbox/resolveExistingSandboxId";
 
 /** Updates the sandbox ID and/or branch name for a design session (internal). */
 export const updateSandbox = internalMutation({
@@ -78,13 +79,17 @@ export const stopSandbox = authMutation({
     const session = await ctx.db.get(args.id);
     if (!session) throw new Error("Design session not found");
 
-    if (session.sandboxId) {
+    const stopId = preferPersistedSandboxId({
+      sandboxId: session.sandboxId,
+      vercelSandboxId: session.vercelSandboxId,
+    });
+    if (stopId) {
       await ctx.scheduler.runAfter(
         0,
         internal.designSessions.finalizeStopSandbox,
         {
           designSessionId: args.id,
-          sandboxId: session.sandboxId,
+          sandboxId: stopId,
           repoId: session.repoId,
         },
       );

--- a/packages/backend/convex/_migrations/projectInterview.ts
+++ b/packages/backend/convex/_migrations/projectInterview.ts
@@ -59,7 +59,9 @@ export const repairStuckProjectInterview = internalMutation({
       activeWorkflowId: undefined,
       reviewProjectSandboxStatus: "closed",
       lastSandboxActivity: Date.now(),
-      ...(args.clearSandboxId === true ? { sandboxId: undefined } : {}),
+      ...(args.clearSandboxId === true
+        ? { sandboxId: undefined, vercelSandboxId: undefined }
+        : {}),
     });
 
     return { clearedWorkflow, removedEmptyAssistant, resetSandboxStatus };

--- a/packages/backend/convex/_projects/mutations.ts
+++ b/packages/backend/convex/_projects/mutations.ts
@@ -235,12 +235,16 @@ export const updateProjectSandbox = authMutation({
   args: {
     id: v.id("projects"),
     sandboxId: v.string(),
+    vercelSandboxId: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     await getProjectWithAccess(ctx.db, args.id, ctx.userId);
     await ctx.db.patch(args.id, {
       sandboxId: args.sandboxId,
+      ...(args.vercelSandboxId !== undefined
+        ? { vercelSandboxId: args.vercelSandboxId }
+        : {}),
       lastSandboxActivity: Date.now(),
     });
     return null;
@@ -253,14 +257,16 @@ export const clearProjectSandbox = authMutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     const project = await getProjectWithAccess(ctx.db, args.id, ctx.userId);
-    if (project.sandboxId) {
+    const deleteId = project.vercelSandboxId ?? project.sandboxId;
+    if (deleteId) {
       await ctx.scheduler.runAfter(0, internal.daytona.deleteSandbox, {
-        sandboxId: project.sandboxId,
+        sandboxId: deleteId,
         repoId: project.repoId,
       });
     }
     await ctx.db.patch(args.id, {
       sandboxId: undefined,
+      vercelSandboxId: undefined,
       lastSandboxActivity: undefined,
     });
     return null;

--- a/packages/backend/convex/_sandbox/resolveExistingSandboxId.ts
+++ b/packages/backend/convex/_sandbox/resolveExistingSandboxId.ts
@@ -11,3 +11,15 @@ export function resolveExistingSandboxId(args: {
   }
   return args.sandboxId;
 }
+
+/**
+ * Picks the id to use when the provider kind is unknown (e.g. query helpers).
+ * Prefer vercelSandboxId when present — on Vercel both fields are the same name
+ * after create; on Daytona vercelSandboxId is unset so sandboxId wins.
+ */
+export function preferPersistedSandboxId(args: {
+  sandboxId: string | undefined;
+  vercelSandboxId: string | undefined;
+}): string | undefined {
+  return args.vercelSandboxId ?? args.sandboxId;
+}

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -42,7 +42,11 @@ export const clearSandbox = authMutation({
     if (!session) {
       throw new Error("Session not found");
     }
-    await ctx.db.patch(args.id, { sandboxId: undefined, status: "closed" });
+    await ctx.db.patch(args.id, {
+      sandboxId: undefined,
+      vercelSandboxId: undefined,
+      status: "closed",
+    });
     return null;
   },
 });

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -125,7 +125,7 @@ export const sessionExecuteWorkflow = workflow.define({
 
     let validatedSandboxId: string | null = null;
 
-    if (data.sandboxId) {
+    if (data.sandboxId || data.vercelSandboxId) {
       // Bring an archived/stopped sandbox back to "started" via durable polling
       // steps first, so a multi-minute cold-storage thaw doesn't blow the
       // per-action 10-minute limit inside validateSandbox. Once started, the

--- a/packages/backend/convex/_taskWorkflow/helpers.ts
+++ b/packages/backend/convex/_taskWorkflow/helpers.ts
@@ -6,6 +6,7 @@ import type { WorkflowId } from "@convex-dev/workflow";
 import { LlmJson } from "@solvers-hub/llm-json";
 import { workflow } from "../workflowManager";
 import { buildProjectBranchName } from "../_projects/helpers";
+import { preferPersistedSandboxId } from "../_sandbox/resolveExistingSandboxId";
 import { isUsageLimitError, parseUsageLimitResetTime } from "./recovery";
 
 export const llmJson = new LlmJson({ attemptCorrection: true });
@@ -24,6 +25,10 @@ export async function resolveTaskBranchName(
   return `eva/task-${String(task._id)}`;
 }
 
+/**
+ * Resolves the sandbox id to use for a task run (push / audit-fix).
+ * Prefer vercelSandboxId when present so Vercel never receives a Daytona UUID.
+ */
 export async function resolveTaskSandboxIdForRun(
   db: GenericDatabaseReader<DataModel>,
   task: Doc<"agentTasks">,
@@ -31,9 +36,15 @@ export async function resolveTaskSandboxIdForRun(
 ): Promise<string | undefined> {
   if (task.projectId) {
     const project = await db.get(task.projectId);
-    return project?.sandboxId ?? run.sandboxId;
+    return preferPersistedSandboxId({
+      sandboxId: project?.sandboxId ?? run.sandboxId,
+      vercelSandboxId: project?.vercelSandboxId ?? run.vercelSandboxId,
+    });
   }
-  return run.sandboxId ?? task.sandboxId;
+  return preferPersistedSandboxId({
+    sandboxId: run.sandboxId ?? task.sandboxId,
+    vercelSandboxId: run.vercelSandboxId ?? task.vercelSandboxId,
+  });
 }
 
 /** Returns the streaming entity ID used for a task run's activity stream. */

--- a/packages/backend/convex/_taskWorkflow/runLifecycle.ts
+++ b/packages/backend/convex/_taskWorkflow/runLifecycle.ts
@@ -253,6 +253,7 @@ export const clearTaskSandbox = internalMutation({
     if (!task) return null;
     await ctx.db.patch(args.taskId, {
       sandboxId: undefined,
+      vercelSandboxId: undefined,
       reviewTaskSandboxStatus: undefined,
       updatedAt: Date.now(),
     });

--- a/packages/backend/convex/auditFixWorkflow.ts
+++ b/packages/backend/convex/auditFixWorkflow.ts
@@ -57,6 +57,7 @@ export const auditFixWorkflow = workflow.define({
         // fresh sandbox (launchSelectedAuditFixes creates one when sandboxId is
         // undefined, checking out the pushed branch).
         resumeSandboxId = undefined;
+        resumeVercelSandboxId = undefined;
       }
     }
     await step.runAction(internal.daytona.launchSelectedAuditFixes, {

--- a/packages/backend/convex/designWorkflow.ts
+++ b/packages/backend/convex/designWorkflow.ts
@@ -17,6 +17,7 @@ import {
   sendCompletionEvent,
 } from "./_taskWorkflow/helpers";
 import { startNextQueuedDesignMessage } from "./_queues/helpers";
+import { preferPersistedSandboxId } from "./_sandbox/resolveExistingSandboxId";
 import {
   resolveDocMentions,
   stripMentionTokens,
@@ -303,7 +304,10 @@ export const getSessionDataAndPrompt = internalQuery({
     }
 
     return {
-      sandboxId: session.sandboxId,
+      sandboxId: preferPersistedSandboxId({
+        sandboxId: session.sandboxId,
+        vercelSandboxId: session.vercelSandboxId,
+      }),
       branchName: session.branchName,
       repoOwner: repo.owner,
       repoName: repo.name,

--- a/packages/backend/convex/docInterviewWorkflow.ts
+++ b/packages/backend/convex/docInterviewWorkflow.ts
@@ -102,14 +102,21 @@ export const docInterviewWorkflow = workflow.define({
     );
     const fullPrompt = `${INTERVIEW_PROMPT} ${questionPrompt}`;
 
-    const { sandboxId } = await prepareSandboxSteps(step, {
+    const { sandboxId, vercelSandboxId } = await prepareSandboxSteps(step, {
       existingSandboxId: docData.sandboxId,
+      vercelSandboxId: docData.vercelSandboxId,
       installationId: args.installationId,
       repoOwner: docData.repoOwner,
       repoName: docData.repoName,
       repoId: docData.repoId,
       streamingEntityId: args.docId,
       ephemeral: false,
+    });
+
+    await step.runMutation(internal.docInterviewWorkflow.saveDocSandboxId, {
+      docId: args.docId,
+      sandboxId,
+      vercelSandboxId,
     });
 
     await step.runAction(internal.daytona.launchOnExistingSandbox, {
@@ -147,6 +154,7 @@ export const getDocData = internalQuery({
   args: { docId: v.id("docs") },
   returns: v.object({
     sandboxId: v.optional(v.string()),
+    vercelSandboxId: v.optional(v.string()),
     repoOwner: v.string(),
     repoName: v.string(),
     repoId: v.id("githubRepos"),
@@ -160,10 +168,30 @@ export const getDocData = internalQuery({
 
     return {
       sandboxId: doc.sandboxId,
+      vercelSandboxId: doc.vercelSandboxId,
       repoOwner: repo.owner,
       repoName: repo.name,
       repoId: doc.repoId,
     };
+  },
+});
+
+/** Persists sandbox ids on a doc after prepare so Vercel reuse works. */
+export const saveDocSandboxId = internalMutation({
+  args: {
+    docId: v.id("docs"),
+    sandboxId: v.string(),
+    vercelSandboxId: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.docId, {
+      sandboxId: args.sandboxId,
+      ...(args.vercelSandboxId !== undefined
+        ? { vercelSandboxId: args.vercelSandboxId }
+        : {}),
+    });
+    return null;
   },
 });
 
@@ -363,14 +391,21 @@ Generate a product description, acceptance criteria, and user journeys for this 
 
 Output ONLY valid JSON.`;
 
-    const { sandboxId } = await prepareSandboxSteps(step, {
+    const { sandboxId, vercelSandboxId } = await prepareSandboxSteps(step, {
       existingSandboxId: docData.sandboxId,
+      vercelSandboxId: docData.vercelSandboxId,
       installationId: args.installationId,
       repoOwner: docData.repoOwner,
       repoName: docData.repoName,
       repoId: docData.repoId,
       streamingEntityId: args.docId,
       ephemeral: false,
+    });
+
+    await step.runMutation(internal.docInterviewWorkflow.saveDocSandboxId, {
+      docId: args.docId,
+      sandboxId,
+      vercelSandboxId,
     });
 
     await step.runAction(internal.daytona.launchOnExistingSandbox, {

--- a/packages/backend/convex/docPrdWorkflow.ts
+++ b/packages/backend/convex/docPrdWorkflow.ts
@@ -89,14 +89,21 @@ export const docPrdWorkflow = workflow.define({
       docId: args.docId,
     });
 
-    const { sandboxId } = await prepareSandboxSteps(step, {
+    const { sandboxId, vercelSandboxId } = await prepareSandboxSteps(step, {
       existingSandboxId: docData.sandboxId,
+      vercelSandboxId: docData.vercelSandboxId,
       installationId: args.installationId,
       repoOwner: docData.repoOwner,
       repoName: docData.repoName,
       repoId: docData.repoId,
       streamingEntityId: args.docId,
       ephemeral: false,
+    });
+
+    await step.runMutation(internal.docInterviewWorkflow.saveDocSandboxId, {
+      docId: args.docId,
+      sandboxId,
+      vercelSandboxId,
     });
 
     await step.runAction(internal.daytona.launchOnExistingSandbox, {
@@ -133,6 +140,7 @@ export const getDocData = internalQuery({
   },
   returns: v.object({
     sandboxId: v.optional(v.string()),
+    vercelSandboxId: v.optional(v.string()),
     repoOwner: v.string(),
     repoName: v.string(),
     repoId: v.id("githubRepos"),
@@ -160,6 +168,7 @@ Output ONLY valid JSON.`;
 
     return {
       sandboxId: doc.sandboxId,
+      vercelSandboxId: doc.vercelSandboxId,
       repoOwner: repo.owner,
       repoName: repo.name,
       repoId: doc.repoId,

--- a/packages/backend/convex/docs.ts
+++ b/packages/backend/convex/docs.ts
@@ -355,6 +355,7 @@ export const clearInterview = authMutation({
     await ctx.db.patch(args.id, {
       interviewHistory: undefined,
       sandboxId: undefined,
+      vercelSandboxId: undefined,
     });
     return null;
   },

--- a/packages/backend/convex/githubWebhook.ts
+++ b/packages/backend/convex/githubWebhook.ts
@@ -242,15 +242,17 @@ export const handlePrClosed = internalMutation({
       const newPhase = args.merged ? "completed" : "cancelled";
       if (args.merged && project) {
         const nextVersion = (project.branchVersion ?? 1) + 1;
-        if (project.sandboxId) {
+        const deleteId = project.vercelSandboxId ?? project.sandboxId;
+        if (deleteId) {
           await ctx.scheduler.runAfter(0, internal.daytona.deleteSandbox, {
-            sandboxId: project.sandboxId,
+            sandboxId: deleteId,
             repoId: project.repoId,
           });
         }
         await ctx.db.patch(task.projectId, {
           phase: newPhase,
           sandboxId: undefined,
+          vercelSandboxId: undefined,
           lastSandboxActivity: undefined,
           branchVersion: nextVersion,
           branchName: buildProjectBranchName(task.projectId, nextVersion),

--- a/packages/backend/convex/projectInterviewWorkflow.ts
+++ b/packages/backend/convex/projectInterviewWorkflow.ts
@@ -134,7 +134,7 @@ export const projectInterviewWorkflow = workflow.define({
     // on the project (otherwise every answer would spawn a fresh sandbox) and
     // the card/sidebar "active" indicator lights up while the interview runs.
     try {
-      if (projectData.sandboxId) {
+      if (projectData.sandboxId || projectData.vercelSandboxId) {
         // Thaw an archived/stopped sandbox across polling steps first so a
         // cold-storage restore can exceed the per-action 10-minute limit; the
         // surrounding catch handles thaw failures.
@@ -528,7 +528,7 @@ Based on the interview conversation above, generate an implementation spec with 
 Output ONLY valid JSON.`;
 
     try {
-      if (projectData.sandboxId) {
+      if (projectData.sandboxId || projectData.vercelSandboxId) {
         // Thaw an archived/stopped sandbox across polling steps first so a
         // cold-storage restore can exceed the per-action 10-minute limit; the
         // surrounding catch handles thaw failures.


### PR DESCRIPTION
## Summary
- Persist and clear `vercelSandboxId` with `sandboxId` across audit-fix, docs, sessions, projects, tasks, design stop, and PR-merge cleanup so Vercel thaw never uses a stale/missing name.
- Add `preferPersistedSandboxId` for provider-blind callers; fix thaw gates and stronger pnpm detect for `workspace:` monorepos.
- Track remaining cutover notes in `VERCEL_SANDBOX_PR_MERGE_ISSUES.md` (stacked on #425).

## Test plan
- [ ] Close → Start session/task/project: no stale Vercel name thaw
- [ ] Audit-fix create/reuse persists `vercelSandboxId`
- [ ] Doc interview/PRD prepare persists both ids
- [ ] Design stop uses `vercelSandboxId ?? sandboxId`
- [ ] Optional: carepulse design start after pnpm detect harden (#5)
- [ ] Confirm this PR targets `feat/vercel-sandbox-migration` only (not main)
