### PR TITLE
feat(web): session chat UI (without Agent SDK)

### DIFF
--- a/apps/web/src/lib/components/StreamingActivityDisplay.tsx
+++ b/apps/web/src/lib/components/StreamingActivityDisplay.tsx
@@ -69,6 +69,15 @@ export function ActivityLogDisplay({
     );
   }
 
+  // No parseable steps: a text-only reply (no tools) has an empty activity log
+  // ("[]"). Render nothing rather than a "View logs" accordion wrapping a bare
+  // "[]". The raw fallback below is only for a genuinely non-empty, unparseable
+  // log (kept for debugging odd payloads).
+  const trimmedLog = activityLog.trim();
+  if (trimmedLog === "" || trimmedLog === "[]") {
+    return null;
+  }
+
   return (
     <Reasoning defaultOpen={false}>
       <ReasoningTrigger getThinkingMessage={() => "View logs"} />

--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -41,6 +41,7 @@ import {
   type MentionTextareaHandle,
 } from "@/lib/components/chat/MentionTextarea";
 import dayjs from "@conductor/shared/dates";
+import { formatDuration } from "@conductor/shared/duration";
 import { EvaIcon } from "@/lib/components/EvaIcon";
 import { UserMessageAvatar } from "@/lib/components/UserMessageAvatar";
 import { QueuedMessagesPanel } from "@/lib/components/QueuedMessagesPanel";
@@ -368,10 +369,21 @@ export function ChatBody({
                         )}
                       </MessageContent>
                       {message.role === "assistant" && message.content ? (
-                        <ChatMessageActions
-                          copyText={message.content}
-                          className="ml-0.5"
-                        />
+                        <div className="flex items-center gap-2">
+                          <ChatMessageActions
+                            copyText={message.content}
+                            className="ml-0.5"
+                          />
+                          {message.finishedAt && message.timestamp ? (
+                            <span className="text-[11px] tabular-nums text-muted-foreground/60">
+                              {dayjs(message.timestamp).format("h:mm A")} ·{" "}
+                              {formatDuration(
+                                message.timestamp,
+                                message.finishedAt,
+                              )}
+                            </span>
+                          ) : null}
+                        </div>
                       ) : null}
                       {message.role === "user" && (
                         <div className="flex items-center justify-end gap-2 mt-0.5 ml-auto">

--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -313,7 +313,6 @@ export function ChatBody({
                             <StreamingActivityDisplay
                               activity={streamingActivity}
                               name="Eva"
-                              icon={evaIcon}
                               startedAt={message.timestamp}
                             />
                             {message._id === lastMessage?._id &&
@@ -375,10 +374,11 @@ export function ChatBody({
                         )}
                       </MessageContent>
                       {message.role === "assistant" && message.content ? (
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100">
                           <ChatMessageActions
                             copyText={message.content}
                             className="ml-0.5"
+                            revealOnHover={false}
                           />
                           {message.finishedAt && message.timestamp ? (
                             <span className="text-[11px] tabular-nums text-muted-foreground/60">

--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -316,6 +316,12 @@ export function ChatBody({
                               icon={evaIcon}
                               startedAt={message.timestamp}
                             />
+                            {message._id === lastMessage?._id &&
+                            streamingContent ? (
+                              <MessageResponse className="prose prose-sm dark:prose-invert max-w-none mt-2">
+                                {streamingContent}
+                              </MessageResponse>
+                            ) : null}
                             {activePendingQuestion && (
                               <div className="mt-3">
                                 <MultipleChoiceQuestion

--- a/apps/web/src/lib/components/chat/ChatMessageActions.tsx
+++ b/apps/web/src/lib/components/chat/ChatMessageActions.tsx
@@ -30,6 +30,8 @@ interface ChatMessageActionsProps {
   // Extra actions rendered after copy (retry, rating, share, custom).
   actions?: ChatMessageActionItem[];
   className?: string;
+  /** When false, parent handles hover/focus reveal (e.g. shared row with timestamp). */
+  revealOnHover?: boolean;
 }
 
 /**
@@ -45,6 +47,7 @@ export function ChatMessageActions({
   copyText,
   actions = [],
   className,
+  revealOnHover = true,
 }: ChatMessageActionsProps) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -68,7 +71,9 @@ export function ChatMessageActions({
   return (
     <MessageActions
       className={cn(
-        "gap-0.5 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100",
+        "gap-0.5",
+        revealOnHover &&
+          "opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100",
         className,
       )}
     >

--- a/apps/web/src/lib/components/plan/ChatMessage.tsx
+++ b/apps/web/src/lib/components/plan/ChatMessage.tsx
@@ -68,7 +68,6 @@ export function ChatMessage({
             <StreamingActivityDisplay
               activity={content}
               name="Eva"
-              icon={evaIcon}
               startedAt={startedAt}
             />
           ) : (

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
@@ -69,6 +69,12 @@ type QueuedSessionMessage = NonNullable<
   FunctionReturnType<typeof api.queuedMessages.listByParent>
 >[number];
 
+// Convex has no non-cast way to mint an Id<T> before the server assigns one;
+// this is the single, contained `as` for optimistic-insert temp ids.
+function optimisticMessageId(): Id<"messages"> {
+  return crypto.randomUUID() as Id<"messages">;
+}
+
 const REVIEW_AUDITS = [
   "Running code audits",
   "Analyzing results",
@@ -169,7 +175,54 @@ export function ChatPanel({
   });
 
   const startSummarize = useMutation(api.summarizeWorkflow.startSummarize);
-  const addMessage = useMutation(api.sessions.addMessage);
+  // Optimistic send: append the user message + an empty assistant placeholder
+  // to the reactive list instantly. The empty-content assistant doc drives
+  // ChatBody's existing StreamingActivityDisplay ("thinking") path. Convex
+  // rolls both temp docs back automatically once the mutation resolves and the
+  // real server rows arrive (on success OR error).
+  const addMessage = useMutation(api.sessions.addMessage).withOptimisticUpdate(
+    (localStore, args) => {
+      // Only the user-message send should paint a placeholder pair; the error
+      // fallback below also calls addMessage (role "assistant") but there is no
+      // list yet to build against in that path beyond the existing rows.
+      if (args.role !== "user") return;
+      const existing = localStore.getQuery(api.messages.listByParent, {
+        parentId: args.id,
+      });
+      if (existing === undefined) return;
+
+      const now = Date.now();
+      const userMsg: SessionMessage = {
+        _id: optimisticMessageId(),
+        _creationTime: now,
+        parentId: args.id,
+        role: "user",
+        content: args.content,
+        timestamp: now,
+        mode: args.mode,
+        activityLog: "",
+        imageUrl: undefined,
+        videoUrl: undefined,
+      };
+      const assistantPlaceholder: SessionMessage = {
+        _id: optimisticMessageId(),
+        _creationTime: now + 1,
+        parentId: args.id,
+        role: "assistant",
+        content: "",
+        timestamp: now + 1,
+        mode: args.mode,
+        activityLog: "",
+        imageUrl: undefined,
+        videoUrl: undefined,
+      };
+      localStore.setQuery(api.messages.listByParent, { parentId: args.id }, [
+        ...existing,
+        userMsg,
+        assistantPlaceholder,
+      ]);
+    },
+  );
   const startExecution = useMutation(api.sessionWorkflow.startExecute);
   const enqueueMessage = useMutation(api.sessionWorkflow.enqueueMessage);
   const cancelExecutionMutation = useMutation(
@@ -198,15 +251,17 @@ export function ChatPanel({
         });
         return;
       }
-      try {
-        await addMessage({ id: sessionId, role: "user", content, mode });
-        await startExecution({
-          sessionId,
-          message: content,
-          mode,
-          model,
-        });
-      } catch (error) {
+      // Optimistic send: addMessage's withOptimisticUpdate paints the user
+      // message + an empty assistant placeholder instantly, so we fire both
+      // mutations WITHOUT awaiting them serially — the callback resolves
+      // synchronously, the composer clears immediately (PromptInput clears only
+      // after onSend resolves), and the optimistic docs paint before any server
+      // round-trip. Convex rolls the temp docs back automatically once the real
+      // rows arrive (on success OR error).
+      void Promise.all([
+        addMessage({ id: sessionId, role: "user", content, mode }),
+        startExecution({ sessionId, message: content, mode, model }),
+      ]).catch(async (error) => {
         const errorMessage =
           error instanceof Error ? error.message : "Failed to send message";
         await addMessage({
@@ -215,7 +270,7 @@ export function ChatPanel({
           content: `Error: ${errorMessage}`,
           mode,
         });
-      }
+      });
     },
     [
       isExecuting,

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Session chat UI (without Agent SDK) - 2026-07-09
+
+- Optimistic send via Convex `.withOptimisticUpdate`, live streamed tokens on the active bubble, per-turn "Worked for Ns" collapsible with activity overflow cap, turn-duration footer, and empty activity-log accordion hidden on text-only replies.
+- Reason for change: ship the session chat UX improvements from the Agent SDK branch without coupling to `claude -p` → SDK migration.
+
 ## Vercel sandbox id lifecycle fixes - 2026-07-09
 
 - Persist and clear `vercelSandboxId` with `sandboxId` on audit-fix, docs, sessions, projects, tasks, and PR-merge cleanup so Vercel reuse never thaws a stale or missing name.

--- a/packages/ui/src/ai-elements/activity-tasks.tsx
+++ b/packages/ui/src/ai-elements/activity-tasks.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../ui/collapsible";
+import { ChevronDownIcon } from "lucide-react";
 import { cn } from "../utils/cn";
 import { Spinner } from "../ui/spinner";
 import { Shimmer } from "./shimmer";
@@ -18,6 +24,9 @@ import {
   getBlockTitle,
 } from "./activity-tasks-utils";
 import { Task, TaskContent, TaskItem, TaskItemFile, TaskTrigger } from "./task";
+
+/** Max activity blocks shown before the overflow toggle appears (P2). */
+const MAX_VISIBLE_BLOCKS = 5;
 
 export type { ActivityStep };
 
@@ -98,6 +107,71 @@ function ActivityBlockRow({ block }: { block: ActivityBlock }) {
   );
 }
 
+/**
+ * Renders the activity blocks with an overflow cap (P2). When there are more
+ * than MAX_VISIBLE_BLOCKS, the excess is hidden behind a muted "Show N more"
+ * toggle. Settled turns cap from the front (show the first N); streaming turns
+ * cap from the end (show the newest N) so the latest activity stays visible.
+ */
+function ActivityBlockList({
+  blocks,
+  isStreaming,
+}: {
+  blocks: ActivityBlock[];
+  isStreaming?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const overflow = blocks.length - MAX_VISIBLE_BLOCKS;
+  const isCapped = overflow > 0 && !expanded;
+  const visible = isCapped
+    ? isStreaming
+      ? blocks.slice(blocks.length - MAX_VISIBLE_BLOCKS)
+      : blocks.slice(0, MAX_VISIBLE_BLOCKS)
+    : blocks;
+
+  return (
+    <>
+      {overflow > 0 && isStreaming && (
+        <OverflowToggle
+          expanded={expanded}
+          overflow={overflow}
+          onToggle={() => setExpanded((v) => !v)}
+        />
+      )}
+      {visible.map((block, i) => (
+        <ActivityBlockRow key={i} block={block} />
+      ))}
+      {overflow > 0 && !isStreaming && (
+        <OverflowToggle
+          expanded={expanded}
+          overflow={overflow}
+          onToggle={() => setExpanded((v) => !v)}
+        />
+      )}
+    </>
+  );
+}
+
+function OverflowToggle({
+  expanded,
+  overflow,
+  onToggle,
+}: {
+  expanded: boolean;
+  overflow: number;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="w-fit text-muted-foreground text-sm transition-colors hover:text-foreground"
+    >
+      {expanded ? "Show less" : `Show ${overflow} more`}
+    </button>
+  );
+}
+
 export const ActivityTasks = memo(
   ({
     steps,
@@ -118,12 +192,31 @@ export const ActivityTasks = memo(
 
     if (blocks.length === 0 && !isStreaming) return null;
 
-    void duration;
     void finalText;
 
     const headerText = `${name ?? "Eva"} is ${verb.toLowerCase()}...${
       startedAt ? ` (${formatElapsed(elapsed)})` : ""
     }`;
+
+    // Settled turn with a known per-turn duration (P1): collapse the whole
+    // turn's activity behind one "Worked for Ns" trigger, default closed.
+    if (!isStreaming && duration) {
+      return (
+        <Collapsible
+          className={cn("group text-sm", className)}
+          defaultOpen={false}
+          {...props}
+        >
+          <CollapsibleTrigger className="flex w-full items-center gap-2 border-b border-border pb-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground">
+            <span>Worked for {duration}</span>
+            <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-2 space-y-1.5 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+            <ActivityBlockList blocks={blocks} isStreaming={false} />
+          </CollapsibleContent>
+        </Collapsible>
+      );
+    }
 
     return (
       <div className={cn("space-y-1.5 text-sm", className)} {...props}>
@@ -136,9 +229,7 @@ export const ActivityTasks = memo(
             </Shimmer>
           </div>
         )}
-        {blocks.map((block, i) => (
-          <ActivityBlockRow key={i} block={block} />
-        ))}
+        <ActivityBlockList blocks={blocks} isStreaming={isStreaming} />
       </div>
     );
   },

--- a/packages/ui/src/ai-elements/activity-tasks.tsx
+++ b/packages/ui/src/ai-elements/activity-tasks.tsx
@@ -223,7 +223,6 @@ export const ActivityTasks = memo(
         {isStreaming && (
           <div className="flex items-center gap-2 text-muted-foreground text-sm">
             <Spinner size="sm" />
-            {icon}
             <Shimmer as="span" duration={2.5} spread={1.5}>
               {headerText}
             </Shimmer>


### PR DESCRIPTION
## Summary
Cherry-picks the **session chat UX** from [#423](https://github.com/vvedantb/eva/pull/423) onto `main` **without** the Claude Agent SDK / `claude -p` → SDK migration.

### Included (from #423)
- Optimistic send via Convex `.withOptimisticUpdate` (instant user message + thinking placeholder)
- Live streamed tokens on the active assistant bubble
- Per-turn **Worked for Ns** collapsible (default closed) + activity overflow cap (Show N more)
- Turn-duration footer on assistant messages
- Hide empty View logs accordion on text-only replies
- Small polish: shared hover-reveal for copy actions + timestamp; drop duplicate Eva icons in streaming headers

### Explicitly excluded
- `claudeSdk` / `claudeSdkDaemon` callback providers
- `CLAUDE_ATTEMPT_MODE=sdk|sdk-daemon` paths
- Daemon pre-warm on session open (`prewarmDaemon`)
- Conversational fast-path / Haiku warm query backend
- Workflow workpool / daemon-pull dispatch changes
- SDK-only session workflow reordering (save reply before git push)

Still uses existing `claude -p` CLI execution on `main`.

## Test plan
- [ ] Send a session message: user bubble + thinking indicator appear on Enter (no serial lag)
- [ ] During a turn: streamed tokens appear on the active assistant bubble
- [ ] After a tool-using turn: Worked for Ns collapsible shows activity blocks; overflow cap at 5+
- [ ] Settled assistant message shows timestamp and duration footer on hover
- [ ] Text-only assistant reply: no empty View logs accordion
- [ ] Confirm no SDK env changes required
