### PR TITLE
Fix Vercel sandbox stop/resume lifecycle drift

### DIFF
--- a/apps/web/src/lib/components/sandbox/useSandboxPreview.ts
+++ b/apps/web/src/lib/components/sandbox/useSandboxPreview.ts
@@ -64,6 +64,12 @@ export function useSandboxPreview({
 
   const getPreviewUrl = useAction(api.daytona.getPreviewUrl);
   const pollingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Poll generation. An in-flight getPreviewUrl continuation used to re-arm the
+  // 3s timer AFTER the isActive-flip cleanup ran (stale closure with the old
+  // isActive=true), so the poll chain kept hitting the backend forever after a
+  // sandbox stop — which on Vercel resumed the stopped sandbox. Each config
+  // change bumps the generation; stale continuations see the mismatch and bail.
+  const generationRef = useRef(0);
 
   useEffect(() => {
     clearLegacyPreviewUrlCache();
@@ -78,6 +84,7 @@ export function useSandboxPreview({
 
   const fetchPreview = useCallback(async () => {
     if (!sandboxId || !isActive) return;
+    const generation = generationRef.current;
     setIsLoading(true);
     setError(null);
     stopPolling();
@@ -89,6 +96,9 @@ export function useSandboxPreview({
         navigationSync: true,
         repoId,
       });
+      // Config changed (sandbox stopped / port switched) while the request was
+      // in flight — drop the result and do NOT re-arm the poll timer.
+      if (generation !== generationRef.current) return;
       if (data.ready) {
         await dismissDaytonaWarning(data.url);
         setPreviewInfo(data);
@@ -100,12 +110,16 @@ export function useSandboxPreview({
         }, 3000);
       }
     } catch (err) {
+      if (generation !== generationRef.current) return;
       setError(err instanceof Error ? err.message : "Failed to load preview");
       setIsLoading(false);
     }
   }, [sandboxId, isActive, getPreviewUrl, stopPolling, repoId, effectivePort]);
 
   useEffect(() => {
+    // Invalidate any in-flight poll from the previous config before starting
+    // (or not starting) a new chain for this one.
+    generationRef.current++;
     if (isActive && sandboxId) {
       setPreviewInfo(null);
       fetchPreview();

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
@@ -107,6 +107,8 @@ interface ChatPanelProps {
   startupStreamingActivity?: string;
   isSandboxActive: boolean;
   isSandboxToggling: boolean;
+  /** True while status is stopping / stop mutation in flight — not a start. */
+  isSandboxStopping?: boolean;
   onSandboxToggle: (action: "start" | "stop") => void;
   isArchived?: boolean;
   deploymentStatus?: "queued" | "building" | "deployed" | "error";
@@ -131,6 +133,7 @@ export function ChatPanel({
   startupStreamingActivity,
   isSandboxActive,
   isSandboxToggling,
+  isSandboxStopping = false,
   onSandboxToggle,
   isArchived,
   deploymentStatus,
@@ -351,8 +354,9 @@ export function ChatPanel({
 
   const hasSummary = Boolean(summary && summary.length > 0);
   const showSummaryStreaming = Boolean(summaryStreamingActivity);
+  // Startup steps only while starting — stopping must not reuse start activity.
   const isStartupStreaming =
-    isSandboxToggling && !isSandboxActive && Boolean(startupStreamingActivity);
+    isSandboxToggling && !isSandboxActive && !isSandboxStopping;
 
   const selectedModeOption =
     SESSION_MODE_OPTIONS.find((option) => option.value === mode) ??
@@ -579,9 +583,11 @@ export function ChatPanel({
 
   const emptyStateTitle = isSandboxActive
     ? "No messages yet. Start the conversation!"
-    : isSandboxToggling
-      ? "Starting sandbox..."
-      : "Sandbox is inactive. Start the sandbox to begin chatting.";
+    : isSandboxStopping
+      ? "Stopping sandbox..."
+      : isSandboxToggling
+        ? "Starting sandbox..."
+        : "Sandbox is inactive. Start the sandbox to begin chatting.";
 
   const placeholder = !isSandboxActive
     ? "Start the sandbox to begin chatting..."

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/SessionDetailClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/SessionDetailClient.tsx
@@ -102,6 +102,7 @@ export function SessionDetailClient({
           isSandboxToggling={
             isSandboxStarting || isSandboxStopping || isStopPending
           }
+          isSandboxStopping={isSandboxStopping || isStopPending}
           onSandboxToggle={handleSandboxToggle}
           isArchived={session.archived === true}
           deploymentStatus={session.deploymentStatus}

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Deduplicate sandbox start/resume mechanics across entity flows - 2026-07-09
+
+- Extracted `resolveReusableVercelSandboxId`, `seedSandboxStartupActivity`/`clearSandboxStartupActivity`, and `resumeReusedSandbox` so the Vercel-id fallback, startup streaming seed/clear, and reuse ordering live in one place instead of being copy-pasted across the session, task, and project sandbox flows.
+- Reason for change: the resume ordering fix (start docker after early-ready) had to be applied in four separate sites; centralising the mechanics stops the next fix landing in one path but not the others.
+
+## Reissue Vercel stop while session remains running - 2026-07-09
+
+- Stop confirmation now actively reissues Vercel stop against the latest session id when a sandbox keeps reporting `running`, instead of passively waiting until timeout.
+- Reason for change: concurrent multi-session stops could leave one sandbox running for 180s despite an initial stop request; reissuing stop confirmed `coral-novel-pig-9y4qKG` stopped.
+
 ## Stop by session id; never mark closed on failed stop - 2026-07-09
 
 - When `get(resume:false)` has no attached session but listSessions still shows `running`, stop via Vercel session-id API instead of waiting (old path never called stop, timed out at 60s, then Eva marked closed while Vercel stayed running).

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,10 +1,46 @@
 # Changelog
 
+## Stop by session id; never mark closed on failed stop - 2026-07-09
+
+- When `get(resume:false)` has no attached session but listSessions still shows `running`, stop via Vercel session-id API instead of waiting (old path never called stop, timed out at 60s, then Eva marked closed while Vercel stayed running).
+- `stopSandbox` propagates real failures; finalize only marks closed on success and reverts to active on failure; start aborts if session is already stopping/closed.
+- Reason for change: Convex logs showed stop confirmation timing out at `last status: running`, errors swallowed, UI off while Vercel still had live sandboxes / auto-restart.
+
+## Stop waits for Vercel terminal state; no silent resume mid-stop - 2026-07-09
+
+- Stop confirmation polls `listSessions` when `get(resume:false)` omits the session, and requires consecutive terminal/idle readings before Eva marks closed — so UI no longer flips to stopped while Vercel still shows stopping.
+- Missing session is no longer mapped to idle-stopped; `start()` refuses `resume:true` while stop/snapshot is in flight (and on stop-in-flight API errors) so in-flight resume cannot auto-restart a sandbox the user just stopped; `sandboxReady` ignores stopping/closed.
+- Reason for change: Eva showed stopped while Vercel was still stopping, and one of four stopped sandboxes silently became active again.
+
+## Fix Vercel stream-closed orphan after early-ready - 2026-07-09
+
+- Retry Vercel `exec` once after refresh when the command stream closes; stop the VM on start failure after early-ready so UI closed matches a stopped sandbox.
+- Reason for change: resume could mark the session active then fail on git, leaving a live Vercel sandbox while the UI showed inactive / "Failed to start".
+
+## Fix resume creating a second sandbox + stop/start UI copy - 2026-07-09
+
+- Session reuse no longer silently creates a replacement on prepare errors (`fallbackOnPrepareError: false`); Vercel resume copy is "Resuming sandbox..." (cold-storage wording stays Daytona-only); stop clears startup streaming and no longer shows start steps.
+- Legacy rows missing `vercelSandboxId` fall back to a non-UUID `sandboxId` so Vercel resume reuses instead of creating.
+- Reason for change: resume was orphaning the old VM and the UI reused start activity / Daytona cold-storage labels on Vercel stop/resume.
+
+## Faster sandbox resume parity (session + task + project) - 2026-07-09
+
+- Vercel start mutations schedule the start action directly (skip ~6s workflow scheduling); credentials-only client on resume; full env map deferred until create.
+- Task/project early-ready + streaming seed aligned with sessions; ActivityTasks drops random "inferring" above real tool steps / uses step label when only thinking.
+- Reason for change: measured non-resume overhead and blank/inferring UI before Vercel `start()` began.
+
 ## Readable per-repo numId URLs + soft delete - 2026-07-09
 
 - Sessions, docs, testing arena, projects, tasks, design sessions, and automations now use per-repo sequential `numId` in URLs (`/sessions/3`, `/projects/1/5`, etc.) instead of Convex `_id`; `getByNumId` resolves routes while internal refs stay on `_id`.
 - Entities soft-delete via `deletedAt` (hidden from lists, direct URL → not-found); `repoEntityCounters` allocates ids atomically; `backfillNumIds` migration backfills existing rows.
 - Reason for change: human-readable shareable URLs and safer deletes without orphaning related data or breaking internal Convex references.
+
+## Faster Vercel session resume - 2026-07-09
+
+- Vercel kickoff no longer blocks ~15–30s waiting for resume with no progress UI; restore happens in `ensureSandboxRunning` with a restoring label.
+- Session reuse marks the sandbox active as soon as the VM is up (before docker/git/services), and docker bootstrap prefers the Vercel path first to avoid a failed Daytona-style restart.
+- `ensureSandboxRunning` refreshes state first and skips the exec probe when already stopped — a stopped Vercel sandbox was burning ~20s on a timed-out `echo` before `start()`.
+- Reason for change: measured resume spent ~17s in silent kickoff, then ~20s on a useless stopped-sandbox probe, plus docker before chat unlocked.
 
 ## Cursor-style chat scroll pin - 2026-07-09
 
@@ -5448,6 +5484,10 @@ Behavior per context:
 - Updated `TerminalPanel.tsx` to POST new cols/rows to backend after `FitAddon.fit()`
 - Added `TERM: "xterm-256color"` env to PTY creation for proper terminal rendering
 - Removed unnecessary 50ms/100ms sleep delays after input and connection
+
+## Confirm Vercel stop completion before closing sessions - 2026-07-09
+
+- Keep session state in `stopping` until Vercel confirms that its asynchronous stop/snapshot transition has reached a terminal stopped state, preventing a misleading closed UI and start/stop races.
 
 ## Extract shared `@conductor/ui` workspace package - 2026-02-07
 

--- a/packages/backend/convex/_agentTasks/queries.ts
+++ b/packages/backend/convex/_agentTasks/queries.ts
@@ -200,14 +200,13 @@ export const getDependentTasks = authQuery({
     const depTasks = await Promise.all(
       dependents.map((dep) => ctx.db.get(dep.taskId)),
     );
-    return depTasks
-      .filter((t): t is Exclude<typeof t, null> => t !== null)
-      .filter((t) => t.deletedAt === undefined)
-      .map((t) => ({
-        _id: t._id,
-        title: t.title,
-        taskNumber: t.taskNumber,
-      }));
+    return filterActiveEntities(
+      depTasks.filter((t): t is Exclude<typeof t, null> => t !== null),
+    ).map((t) => ({
+      _id: t._id,
+      title: t.title,
+      taskNumber: t.taskNumber,
+    }));
   },
 });
 

--- a/packages/backend/convex/_agentTasks/sandbox.ts
+++ b/packages/backend/convex/_agentTasks/sandbox.ts
@@ -76,38 +76,29 @@ export const startTaskSandbox = authMutation({
       `[tasks] startTaskSandbox taskId=${args.taskId} existingSandboxId=${task.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
 
+    const startArgs = {
+      taskId: args.taskId,
+      existingSandboxId: task.sandboxId,
+      vercelSandboxId: vercelSandboxId ?? task.vercelSandboxId,
+      installationId: repo.installationId,
+      repoOwner: repo.owner,
+      repoName: repo.name,
+      branchName,
+      baseBranch,
+      repoId: task.repoId,
+    };
     // Vercel: schedule start action directly (skip ~6s workflow scheduling).
     if (vercelSandboxId) {
       await ctx.scheduler.runAfter(
         0,
         internal.daytona.startTaskPreviewSandbox,
-        {
-          taskId: args.taskId,
-          existingSandboxId: task.sandboxId,
-          vercelSandboxId,
-          installationId: repo.installationId,
-          repoOwner: repo.owner,
-          repoName: repo.name,
-          branchName,
-          baseBranch,
-          repoId: task.repoId,
-        },
+        startArgs,
       );
     } else {
       await workflow.start(
         ctx,
         internal.taskSandboxWorkflow.taskPreviewSandboxStartupWorkflow,
-        {
-          taskId: args.taskId,
-          existingSandboxId: task.sandboxId,
-          vercelSandboxId: task.vercelSandboxId,
-          installationId: repo.installationId,
-          repoOwner: repo.owner,
-          repoName: repo.name,
-          branchName,
-          baseBranch,
-          repoId: task.repoId,
-        },
+        startArgs,
       );
     }
 

--- a/packages/backend/convex/_agentTasks/sandbox.ts
+++ b/packages/backend/convex/_agentTasks/sandbox.ts
@@ -4,6 +4,11 @@ import { internalAction, internalMutation } from "../_generated/server";
 import { authMutation, hasRepoAccess } from "../functions";
 import { workflow } from "../workflowManager";
 import { resolveTaskWorkflowBaseBranchForTask } from "../_taskWorkflow/resolveBaseBranch";
+import { resolveReusableVercelSandboxId } from "../_sandbox/resolveExistingSandboxId";
+import {
+  seedSandboxStartupActivity,
+  clearSandboxStartupActivity,
+} from "../_sandbox/startupActivity";
 
 const PREVIEW_ALLOWED_STATUSES = [
   "code_review",
@@ -62,36 +67,11 @@ export const startTaskSandbox = authMutation({
     });
     // Seed startup streaming immediately so the UI shows a real step instead of
     // the random "Eva is inferring…" spinner while the workflow schedules.
-    const startupEntityId = `task-sandbox-startup-${args.taskId}`;
-    const startupActivity = JSON.stringify([
-      { type: "tool", label: "Starting sandbox...", status: "active" },
-    ]);
-    const existingStreaming = await ctx.db
-      .query("streamingActivity")
-      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
-      .first();
-    if (existingStreaming) {
-      await ctx.db.patch(existingStreaming._id, {
-        currentActivity: startupActivity,
-        currentContent: "",
-        lastUpdatedAt: Date.now(),
-      });
-    } else {
-      await ctx.db.insert("streamingActivity", {
-        entityId: startupEntityId,
-        currentActivity: startupActivity,
-        currentContent: "",
-        lastUpdatedAt: Date.now(),
-      });
-    }
-    const looksLikeDaytonaUuid =
-      typeof task.sandboxId === "string" &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        task.sandboxId,
-      );
-    const vercelSandboxId =
-      task.vercelSandboxId ??
-      (task.sandboxId && !looksLikeDaytonaUuid ? task.sandboxId : undefined);
+    await seedSandboxStartupActivity(
+      ctx.db,
+      `task-sandbox-startup-${args.taskId}`,
+    );
+    const vercelSandboxId = resolveReusableVercelSandboxId(task);
     console.log(
       `[tasks] startTaskSandbox taskId=${args.taskId} existingSandboxId=${task.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
@@ -345,12 +325,10 @@ export const stopTaskSandbox = authMutation({
     );
 
     // Clear leftover start steps so stop does not re-show startup activity.
-    const startupEntityId = `task-sandbox-startup-${args.taskId}`;
-    const startupStreaming = await ctx.db
-      .query("streamingActivity")
-      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
-      .first();
-    if (startupStreaming) await ctx.db.delete(startupStreaming._id);
+    await clearSandboxStartupActivity(
+      ctx.db,
+      `task-sandbox-startup-${args.taskId}`,
+    );
 
     // Keep sandboxId so we can resume the stopped sandbox later.
     await ctx.db.patch(args.taskId, {

--- a/packages/backend/convex/_agentTasks/sandbox.ts
+++ b/packages/backend/convex/_agentTasks/sandbox.ts
@@ -60,22 +60,76 @@ export const startTaskSandbox = authMutation({
       reviewTaskSandboxStatus: "starting",
       updatedAt: Date.now(),
     });
-
-    await workflow.start(
-      ctx,
-      internal.taskSandboxWorkflow.taskPreviewSandboxStartupWorkflow,
-      {
-        taskId: args.taskId,
-        existingSandboxId: task.sandboxId,
-        vercelSandboxId: task.vercelSandboxId,
-        installationId: repo.installationId,
-        repoOwner: repo.owner,
-        repoName: repo.name,
-        branchName,
-        baseBranch,
-        repoId: task.repoId,
-      },
+    // Seed startup streaming immediately so the UI shows a real step instead of
+    // the random "Eva is inferring…" spinner while the workflow schedules.
+    const startupEntityId = `task-sandbox-startup-${args.taskId}`;
+    const startupActivity = JSON.stringify([
+      { type: "tool", label: "Starting sandbox...", status: "active" },
+    ]);
+    const existingStreaming = await ctx.db
+      .query("streamingActivity")
+      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
+      .first();
+    if (existingStreaming) {
+      await ctx.db.patch(existingStreaming._id, {
+        currentActivity: startupActivity,
+        currentContent: "",
+        lastUpdatedAt: Date.now(),
+      });
+    } else {
+      await ctx.db.insert("streamingActivity", {
+        entityId: startupEntityId,
+        currentActivity: startupActivity,
+        currentContent: "",
+        lastUpdatedAt: Date.now(),
+      });
+    }
+    const looksLikeDaytonaUuid =
+      typeof task.sandboxId === "string" &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        task.sandboxId,
+      );
+    const vercelSandboxId =
+      task.vercelSandboxId ??
+      (task.sandboxId && !looksLikeDaytonaUuid ? task.sandboxId : undefined);
+    console.log(
+      `[tasks] startTaskSandbox taskId=${args.taskId} existingSandboxId=${task.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
+
+    // Vercel: schedule start action directly (skip ~6s workflow scheduling).
+    if (vercelSandboxId) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.daytona.startTaskPreviewSandbox,
+        {
+          taskId: args.taskId,
+          existingSandboxId: task.sandboxId,
+          vercelSandboxId,
+          installationId: repo.installationId,
+          repoOwner: repo.owner,
+          repoName: repo.name,
+          branchName,
+          baseBranch,
+          repoId: task.repoId,
+        },
+      );
+    } else {
+      await workflow.start(
+        ctx,
+        internal.taskSandboxWorkflow.taskPreviewSandboxStartupWorkflow,
+        {
+          taskId: args.taskId,
+          existingSandboxId: task.sandboxId,
+          vercelSandboxId: task.vercelSandboxId,
+          installationId: repo.installationId,
+          repoOwner: repo.owner,
+          repoName: repo.name,
+          branchName,
+          baseBranch,
+          repoId: task.repoId,
+        },
+      );
+    }
 
     return null;
   },
@@ -290,6 +344,14 @@ export const stopTaskSandbox = authMutation({
       },
     );
 
+    // Clear leftover start steps so stop does not re-show startup activity.
+    const startupEntityId = `task-sandbox-startup-${args.taskId}`;
+    const startupStreaming = await ctx.db
+      .query("streamingActivity")
+      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
+      .first();
+    if (startupStreaming) await ctx.db.delete(startupStreaming._id);
+
     // Keep sandboxId so we can resume the stopped sandbox later.
     await ctx.db.patch(args.taskId, {
       reviewTaskSandboxStatus: "stopping",
@@ -301,10 +363,9 @@ export const stopTaskSandbox = authMutation({
 });
 
 /**
- * Awaits the Daytona stop and finalizes the task sandbox status to `"closed"`.
- * Always flips status, even if Daytona errors — a stuck `"stopping"` state
- * would leave the user unable to Start. Captures any Daytona error so the
- * mutation can record a `stop_failed` event with full detail.
+ * Awaits provider stop and finalizes task sandbox status. Only marks `"closed"`
+ * after a successful stop — on failure reverts to `"active"` so the UI matches
+ * a still-running Vercel VM.
  */
 export const finalizeStopTaskSandbox = internalAction({
   args: {
@@ -332,9 +393,8 @@ export const finalizeStopTaskSandbox = internalAction({
 });
 
 /**
- * Internal: flips task sandbox status from `"stopping"` to `"closed"` after
- * Daytona stop completes, and logs a `stopped` (success) or `stop_failed`
- * (with error detail) event to the activity timeline.
+ * Internal: after stop settles, either close (success) or revert to active
+ * (failure) so Eva never shows off while Vercel is still running.
  */
 export const markTaskSandboxClosed = internalMutation({
   args: {
@@ -347,19 +407,38 @@ export const markTaskSandboxClosed = internalMutation({
     if (!task) return null;
     // Only flip if still stopping — don't overwrite a fresh start.
     if (task.reviewTaskSandboxStatus !== "stopping") return null;
+    if (args.error) {
+      await ctx.db.insert("taskSandboxEvents", {
+        taskId: args.taskId,
+        event: "stop_failed",
+        errorDetail: args.error,
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("messages", {
+        parentId: args.taskId,
+        role: "assistant",
+        content: "Failed to stop sandbox",
+        timestamp: Date.now(),
+        isSystemAlert: true,
+        errorDetail: args.error,
+      });
+      await ctx.db.patch(args.taskId, {
+        reviewTaskSandboxStatus: "active",
+        updatedAt: Date.now(),
+      });
+      return null;
+    }
     await ctx.db.insert("taskSandboxEvents", {
       taskId: args.taskId,
-      event: args.error ? "stop_failed" : "stopped",
-      errorDetail: args.error,
+      event: "stopped",
       createdAt: Date.now(),
     });
     await ctx.db.insert("messages", {
       parentId: args.taskId,
       role: "assistant",
-      content: args.error ? "Failed to stop sandbox" : "Sandbox stopped",
+      content: "Sandbox stopped",
       timestamp: Date.now(),
       isSystemAlert: true,
-      errorDetail: args.error,
     });
     await ctx.db.patch(args.taskId, {
       reviewTaskSandboxStatus: "closed",
@@ -387,19 +466,36 @@ export const taskSandboxReady = internalMutation({
     const task = await ctx.db.get(args.taskId);
     if (!task) return null;
 
-    const content = args.isNew ? "Sandbox started" : "Sandbox reconnected";
-    await ctx.db.insert("taskSandboxEvents", {
-      taskId: args.taskId,
-      event: args.isNew ? "started" : "reconnected",
-      createdAt: Date.now(),
-    });
-    await ctx.db.insert("messages", {
-      parentId: args.taskId,
-      role: "assistant",
-      content,
-      timestamp: Date.now(),
-      isSystemAlert: true,
-    });
+    if (
+      task.reviewTaskSandboxStatus === "stopping" ||
+      task.reviewTaskSandboxStatus === "closed"
+    ) {
+      console.log(
+        `[tasks] taskSandboxReady ignored taskId=${args.taskId} status=${task.reviewTaskSandboxStatus} sandboxId=${args.sandboxId}`,
+      );
+      return null;
+    }
+
+    // Early-ready (VM up) + final-ready (after services) both call this. Only
+    // emit the system alert once; still patch latest sandbox/dev metadata.
+    const alreadyActive =
+      task.reviewTaskSandboxStatus === "active" &&
+      task.sandboxId === args.sandboxId;
+    if (!alreadyActive) {
+      const content = args.isNew ? "Sandbox started" : "Sandbox reconnected";
+      await ctx.db.insert("taskSandboxEvents", {
+        taskId: args.taskId,
+        event: args.isNew ? "started" : "reconnected",
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("messages", {
+        parentId: args.taskId,
+        role: "assistant",
+        content,
+        timestamp: Date.now(),
+        isSystemAlert: true,
+      });
+    }
 
     await ctx.db.patch(args.taskId, {
       sandboxId: args.sandboxId,
@@ -408,8 +504,8 @@ export const taskSandboxReady = internalMutation({
         : {}),
       reviewTaskSandboxStatus: "active",
       updatedAt: Date.now(),
-      devPort: args.devPort,
-      devCommand: args.devCommand,
+      ...(args.devPort !== undefined ? { devPort: args.devPort } : {}),
+      ...(args.devCommand !== undefined ? { devCommand: args.devCommand } : {}),
     });
 
     return null;

--- a/packages/backend/convex/_daytona/execution.ts
+++ b/packages/backend/convex/_daytona/execution.ts
@@ -425,6 +425,16 @@ export const getPreviewUrl = action({
 
     let ready = true;
     if (args.checkReady) {
+      // Never probe or restart the dev server on a sandbox that is not
+      // running. On Vercel every exec goes through the SDK's withResume: on a
+      // stopped sandbox it RESUMES it, and on a stopping/snapshotting one it
+      // waits the stop out and then revives it — so the preview poll loop was
+      // waking sandboxes the user had just stopped. Report not-ready without
+      // touching the VM; polling recovers once the sandbox is started again.
+      // (handle.state is fresh: getSandboxHandle fetches with resume:false.)
+      if (handle.state !== "running") {
+        return { url: "", port: args.port, ready: false };
+      }
       ready = await probePreviewReady(handle, upstreamPort);
       // Only auto-restart the app/dev server for app preview ports.
       // Desktop (6080) and editor (8080) are started by their own toggle

--- a/packages/backend/convex/_daytona/git.ts
+++ b/packages/backend/convex/_daytona/git.ts
@@ -1220,7 +1220,9 @@ async function tryResumeSandbox(
         onRestoring: onProgress
           ? () =>
               onProgress(
-                "Restoring sandbox from cold storage (can take up to 10 minutes)...",
+                client.kind === "vercel"
+                  ? "Resuming sandbox..."
+                  : "Restoring sandbox from cold storage (can take up to 10 minutes)...",
               )
           : undefined,
       });

--- a/packages/backend/convex/_daytona/helpers.ts
+++ b/packages/backend/convex/_daytona/helpers.ts
@@ -6,6 +6,7 @@ import { internal } from "../_generated/api";
 import {
   resolveDaytonaApiKey,
   resolveSandboxCredentials,
+  resolveSandboxCredentialsOnly,
 } from "../envVarResolver";
 import type { SandboxClient, SandboxHandle } from "../_sandbox/provider";
 import { getSandboxClient } from "../_sandbox/factory";
@@ -171,16 +172,19 @@ export async function ensureDockerDaemon(
   } catch {
     // Not running (or docker not installed) — try to start it below.
   }
+
+  // Prefer the shared bootstrap first. On Vercel resume the older Daytona-style
+  // restart below often fails (wasting ~1s) before this same bootstrap succeeds.
+  if (await bootstrapVercelDocker(sandbox)) {
+    return true;
+  }
+
   try {
     // Cleanup before restart: kill any half-alive dockerd/containerd, then
     // remove their pidfiles AND sockets. After Daytona auto-stop/resume, both
     // pidfiles survive but their PIDs map to unrelated processes in the new
     // boot — dockerd/containerd refuse to start while a pidfile claims a
     // running peer, so we must delete them.
-    //
-    // Vercel sandboxes bake docker via dnf but do not auto-start dockerd on
-    // snapshot restore — use systemctl when available, then setsid dockerd,
-    // then poll up to 60s (Daytona's 4s sleep was too short).
     await execHandle(
       sandbox,
       [
@@ -207,7 +211,7 @@ export async function ensureDockerDaemon(
     );
   }
 
-  return bootstrapVercelDocker(sandbox);
+  return false;
 }
 
 /**
@@ -276,56 +280,104 @@ export async function ensureSandboxRunning(
   options: {
     timeoutSeconds?: number;
     onRestoring?: () => Promise<void>;
+    /** When true, skip dockerd bootstrap — caller runs it after unlocking the UI. */
+    skipDocker?: boolean;
+    /**
+     * When true, skip the post-start `echo 1` exec probe. start() already
+     * verifies the provider reports the session running; the first REAL exec
+     * pays the same warmup the probe would, so on latency-sensitive paths
+     * (session resume early-ready) the probe only delays the UI unlock —
+     * observed ~14s on Vercel resumes. Callers that follow up with their own
+     * commands (git checkout, services) get equivalent failure surfacing.
+     */
+    skipExecProbe?: boolean;
   } = {},
 ): Promise<void> {
   const defaultTimeout =
     options.timeoutSeconds ?? DEFAULT_SANDBOX_READY_TIMEOUT_SECONDS;
   const startedAt = Date.now();
+
+  // Refresh first. On a stopped Vercel sandbox, probing with exec waits ~20s for
+  // the SDK's auto-resume path to time out before we ever call start() — skip
+  // that probe when state already says we need a resume.
+  let knownState: string | null = null;
   try {
+    await sandbox.refresh();
+    knownState = sandbox.state;
+  } catch (refreshErr) {
     console.log(
-      `[daytona] ensureSandboxRunning: checking if sandbox ${sandbox.id} is running...`,
-    );
-    await execHandle(sandbox, "echo 1", 5);
-    console.log(
-      `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} already running (${Date.now() - startedAt}ms)`,
-    );
-  } catch (e) {
-    const checkDuration = Date.now() - startedAt;
-    console.log(
-      `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} not running, starting... (check took ${checkDuration}ms, error: ${e instanceof Error ? e.message : String(e)})`,
-    );
-    let startTimeout = defaultTimeout;
-    try {
-      await sandbox.refresh();
-      const state = sandbox.state;
-      if (state === "archived" || state === "restoring") {
-        startTimeout = Math.max(
-          startTimeout,
-          ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
-        );
-        console.log(
-          `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} is ${state}, extending start timeout to ${startTimeout}s`,
-        );
-        if (options.onRestoring) await options.onRestoring();
-      }
-    } catch (refreshErr) {
-      console.log(
-        `[daytona] ensureSandboxRunning: refreshData failed (${refreshErr instanceof Error ? refreshErr.message : String(refreshErr)}); using default ${defaultTimeout}s timeout`,
-      );
-    }
-    const startStartedAt = Date.now();
-    await sandbox.start(startTimeout);
-    console.log(
-      `[daytona] ensureSandboxRunning: sandbox.start() completed in ${Date.now() - startStartedAt}ms`,
-    );
-    await execHandle(sandbox, "echo 1", 5);
-    console.log(
-      `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} now running (total ${Date.now() - startedAt}ms)`,
+      `[daytona] ensureSandboxRunning: initial refresh failed (${refreshErr instanceof Error ? refreshErr.message : String(refreshErr)}); falling back to exec probe`,
     );
   }
+
+  const needsStart =
+    knownState !== null && knownState !== "running" && knownState !== "unknown";
+
+  if (!needsStart) {
+    try {
+      console.log(
+        `[daytona] ensureSandboxRunning: checking if sandbox ${sandbox.id} is running...`,
+      );
+      await execHandle(sandbox, "echo 1", 5);
+      console.log(
+        `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} already running (${Date.now() - startedAt}ms)`,
+      );
+      if (!options.skipDocker) {
+        await ensureDockerDaemon(sandbox);
+      }
+      return;
+    } catch (e) {
+      console.log(
+        `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} not running, starting... (check took ${Date.now() - startedAt}ms, error: ${e instanceof Error ? e.message : String(e)})`,
+      );
+    }
+  } else {
+    console.log(
+      `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} state=${knownState}, starting without exec probe`,
+    );
+  }
+
+  let startTimeout = defaultTimeout;
+  const state = knownState ?? sandbox.state;
+  if (state === "archived" || state === "restoring") {
+    startTimeout = Math.max(
+      startTimeout,
+      ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
+    );
+    console.log(
+      `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} is ${state}, extending start timeout to ${startTimeout}s`,
+    );
+    if (options.onRestoring) await options.onRestoring();
+  } else if (
+    (state === "stopped" || state === "starting") &&
+    options.onRestoring
+  ) {
+    // Vercel maps stopped→stopped (not archived). Surface progress while
+    // start() waits on the first exec that resumes the snapshot.
+    console.log(
+      `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} is ${state}, waiting for resume`,
+    );
+    await options.onRestoring();
+  }
+
+  const startStartedAt = Date.now();
+  await sandbox.start(startTimeout);
+  console.log(
+    `[daytona] ensureSandboxRunning: sandbox.start() completed in ${Date.now() - startStartedAt}ms`,
+  );
+  if (!options.skipExecProbe) {
+    await execHandle(sandbox, "echo 1", 5);
+  }
+  console.log(
+    `[daytona] ensureSandboxRunning: sandbox ${sandbox.id} now running (total ${Date.now() - startedAt}ms${options.skipExecProbe ? ", exec probe skipped" : ""})`,
+  );
+
   // dockerd doesn't run as a system service, so it's lost on auto-stop/resume.
-  // Re-check (and restart if needed) on every ensureSandboxRunning call.
-  await ensureDockerDaemon(sandbox);
+  // Re-check (and restart if needed) on every ensureSandboxRunning call unless
+  // the caller wants to unlock the UI first (session reuse early-ready).
+  if (!options.skipDocker) {
+    await ensureDockerDaemon(sandbox);
+  }
 }
 
 /** Returns the value of a required environment variable, throwing if missing. */
@@ -376,6 +428,23 @@ export function errorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
+/**
+ * Cheap client-only resolve for resume/reuse. Does not decrypt the full env map
+ * or load snapshot metadata — those are only needed on the create path.
+ */
+export async function resolveSandboxClientOnly(
+  ctx: GenericActionCtx<DataModel>,
+  repoId: Id<"githubRepos">,
+): Promise<SandboxClient> {
+  const startedAt = Date.now();
+  const credentials = await resolveSandboxCredentialsOnly(ctx, repoId);
+  const client = getSandboxClient(credentials);
+  console.log(
+    `[daytona] resolveSandboxClientOnly repoId=${repoId} kind=${client.kind} elapsed=${Date.now() - startedAt}ms`,
+  );
+  return client;
+}
+
 /** Resolves the provider client, sandbox env vars, and snapshot name for a repo. */
 export async function resolveSandboxContext(
   ctx: GenericActionCtx<DataModel>,
@@ -385,6 +454,7 @@ export async function resolveSandboxContext(
   sandboxEnvVars: Record<string, string>;
   snapshotName: string | undefined;
 }> {
+  const startedAt = Date.now();
   const { credentials, sandboxEnvVars } = await resolveSandboxCredentials(
     ctx,
     repoId,
@@ -395,6 +465,9 @@ export async function resolveSandboxContext(
     { repoId },
   );
   const snapshotName = repoSnapshot?.snapshotName;
+  console.log(
+    `[daytona] resolveSandboxContext repoId=${repoId} kind=${client.kind} elapsed=${Date.now() - startedAt}ms`,
+  );
   return {
     client,
     sandboxEnvVars: { ...sandboxEnvVars, REPO_ID: repoId },

--- a/packages/backend/convex/_daytona/lifecycle.ts
+++ b/packages/backend/convex/_daytona/lifecycle.ts
@@ -8,7 +8,12 @@ import {
   getSandboxHandle,
   KILL_PRIOR_AGENT_PROCESSES_CMD,
 } from "./helpers";
-import { resolveSandboxCredentials } from "../envVarResolver";
+import {
+  resolveSandboxCredentials,
+  resolveSandboxCredentialsOnly,
+  resolveSandboxProviderKind,
+} from "../envVarResolver";
+import { getSandboxClient } from "../_sandbox/factory";
 
 /**
  * Short wait window for the start kick-off. A stopped→started fast resume
@@ -162,7 +167,7 @@ export const killSandboxProcess = internalAction({
   },
 });
 
-/** Stops a Daytona sandbox (preserves state, fast resume). Silently ignores already-stopped sandboxes. */
+/** Stops a Daytona/Vercel sandbox (preserves state, fast resume). */
 export const stopSandbox = internalAction({
   args: { sandboxId: v.string(), repoId: v.id("githubRepos") },
   returns: v.null(),
@@ -170,8 +175,26 @@ export const stopSandbox = internalAction({
     try {
       const sandbox = await getSandboxHandle(ctx, args.repoId, args.sandboxId);
       await sandbox.stop();
-    } catch {
-      // Sandbox may already be stopped, archived, or deleted
+      console.log(`[daytona] stopSandbox ok sandboxId=${args.sandboxId}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Already gone / already idle — treat as success so finalize can close.
+      const benign =
+        /already.?stopped|not found|does not exist|no active session|destroyed|gone/i.test(
+          message,
+        ) && !/did not reach a terminal stopped state/i.test(message);
+      if (benign) {
+        console.log(
+          `[daytona] stopSandbox ignored benign error for ${args.sandboxId}: ${message}`,
+        );
+        return null;
+      }
+      // Real stop failures must propagate — swallowing them made Eva mark the
+      // session closed while Vercel still showed running.
+      console.error(
+        `[daytona] stopSandbox failed for ${args.sandboxId}: ${message}`,
+      );
+      throw error instanceof Error ? error : new Error(message);
     }
     return null;
   },
@@ -306,8 +329,9 @@ export const getSandboxProviderKind = internalAction({
   args: { repoId: v.id("githubRepos") },
   returns: v.union(v.literal("daytona"), v.literal("vercel")),
   handler: async (ctx, args) => {
-    const { credentials } = await resolveSandboxCredentials(ctx, args.repoId);
-    return credentials.kind;
+    // Do not call resolveSandboxCredentials here — that decrypts the full env
+    // map and was the multi-second gap before kickoff on resume.
+    return resolveSandboxProviderKind(ctx, args.repoId);
   },
 });
 
@@ -318,11 +342,25 @@ export const startSandboxAsyncKickoff = internalAction({
     provider: v.union(v.literal("daytona"), v.literal("vercel")),
   }),
   handler: async (ctx, args) => {
-    const { credentials } = await resolveSandboxCredentials(ctx, args.repoId);
-    const sandbox = await getSandboxHandle(ctx, args.repoId, args.sandboxId);
+    const kickoffStartedAt = Date.now();
+    const credentials = await resolveSandboxCredentialsOnly(ctx, args.repoId);
+    const sandbox = await getSandboxClient(credentials).get(args.sandboxId);
     await sandbox.refresh();
     if (sandbox.state === "running") {
+      console.log(
+        `[daytona] startSandboxAsyncKickoff: sandbox ${args.sandboxId} already running (elapsed=${Date.now() - kickoffStartedAt}ms)`,
+      );
       return { state: "running", provider: credentials.kind };
+    }
+    // Vercel resumes on the first exec inside ensureSandboxRunning (with
+    // progress UI). Waiting here blocks the workflow step for the full restore
+    // (~10–30s) with no streaming activity — measured ~17s on carepulse resume.
+    if (credentials.kind === "vercel") {
+      const state: string = sandbox.state;
+      console.log(
+        `[daytona] startSandboxAsyncKickoff: vercel sandbox ${args.sandboxId} state=${state} (defer resume to ensureSandboxRunning, elapsed=${Date.now() - kickoffStartedAt}ms)`,
+      );
+      return { state, provider: "vercel" as const };
     }
     try {
       // start() POSTs the start request, then waits up to the given window. The
@@ -342,7 +380,7 @@ export const startSandboxAsyncKickoff = internalAction({
       );
     }
     console.log(
-      `[daytona] startSandboxAsyncKickoff: sandbox ${args.sandboxId} state after kick-off = ${state}`,
+      `[daytona] startSandboxAsyncKickoff: sandbox ${args.sandboxId} state after kick-off = ${state} (elapsed=${Date.now() - kickoffStartedAt}ms)`,
     );
     return { state, provider: credentials.kind };
   },

--- a/packages/backend/convex/_daytona/resumeSandboxSteps.ts
+++ b/packages/backend/convex/_daytona/resumeSandboxSteps.ts
@@ -49,6 +49,10 @@ export async function ensureSandboxStartedSteps(
   step: WorkflowCtx,
   args: EnsureSandboxStartedArgs,
 ): Promise<void> {
+  const thawStartedAt = Date.now();
+  console.log(
+    `[daytona] ensureSandboxStartedSteps begin repoId=${args.repoId} sandboxId=${args.sandboxId ?? "none"} vercelSandboxId=${args.vercelSandboxId ?? "none"} streamingEntityId=${args.streamingEntityId ?? "none"}`,
+  );
   const provider = await step.runAction(
     internal.daytona.getSandboxProviderKind,
     {
@@ -61,6 +65,31 @@ export async function ensureSandboxStartedSteps(
     vercelSandboxId: args.vercelSandboxId,
   });
   if (!thawId) {
+    console.log(
+      `[daytona] ensureSandboxStartedSteps no thaw id (provider=${provider}, elapsed=${Date.now() - thawStartedAt}ms)`,
+    );
+    return;
+  }
+
+  // Vercel: do not kickoff/poll here. Resume is ensureSandboxRunning in the
+  // start action; extra workflow steps were measured at ~6–8s of pure latency.
+  // Also skip cold-storage copy — that is Daytona archived restore only.
+  if (provider === "vercel") {
+    if (args.streamingEntityId) {
+      await step.runMutation(internal.streaming.internalSet, {
+        entityId: args.streamingEntityId,
+        currentActivity: JSON.stringify([
+          {
+            type: "tool",
+            label: "Resuming sandbox...",
+            status: "active",
+          },
+        ]),
+      });
+    }
+    console.log(
+      `[daytona] ensureSandboxStartedSteps vercel skip-kickoff thawId=${thawId} elapsed=${Date.now() - thawStartedAt}ms`,
+    );
     return;
   }
 
@@ -68,8 +97,10 @@ export async function ensureSandboxStartedSteps(
     internal.daytona.startSandboxAsyncKickoff,
     { sandboxId: thawId, repoId: args.repoId },
   );
+  console.log(
+    `[daytona] ensureSandboxStartedSteps kickoff done provider=${kickoff.provider} state=${kickoff.state} thawId=${thawId} elapsed=${Date.now() - thawStartedAt}ms`,
+  );
   if (kickoff.state === "running") return;
-  if (kickoff.provider === "vercel") return;
 
   if (args.streamingEntityId) {
     await step.runMutation(internal.streaming.internalSet, {

--- a/packages/backend/convex/_daytona/resumeSandboxSteps.ts
+++ b/packages/backend/convex/_daytona/resumeSandboxSteps.ts
@@ -2,6 +2,7 @@ import type { WorkflowCtx } from "@convex-dev/workflow";
 import type { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { resolveExistingSandboxId } from "../_sandbox/resolveExistingSandboxId";
+import type { SandboxProviderKind } from "../_sandbox/provider";
 
 // First poll fires sooner (a stopped→started resume that just missed the
 // kick-off window settles quickly); later polls are spaced wider. MAX_POLLS at
@@ -44,11 +45,15 @@ type EnsureSandboxStartedArgs = {
  *
  * Throws if the sandbox hits a terminal failure state or does not reach
  * "running" within the ceiling; callers wrap this to surface a retryable message.
+ *
+ * Returns the resolved `provider` and `thawId` (the id to reuse, or undefined
+ * when there is nothing to resume) so callers do not re-run `getSandboxProviderKind`
+ * — that is a durable step measured at ~6–8s of scheduling latency.
  */
 export async function ensureSandboxStartedSteps(
   step: WorkflowCtx,
   args: EnsureSandboxStartedArgs,
-): Promise<void> {
+): Promise<{ provider: SandboxProviderKind; thawId: string | undefined }> {
   const thawStartedAt = Date.now();
   console.log(
     `[daytona] ensureSandboxStartedSteps begin repoId=${args.repoId} sandboxId=${args.sandboxId ?? "none"} vercelSandboxId=${args.vercelSandboxId ?? "none"} streamingEntityId=${args.streamingEntityId ?? "none"}`,
@@ -68,7 +73,7 @@ export async function ensureSandboxStartedSteps(
     console.log(
       `[daytona] ensureSandboxStartedSteps no thaw id (provider=${provider}, elapsed=${Date.now() - thawStartedAt}ms)`,
     );
-    return;
+    return { provider, thawId };
   }
 
   // Vercel: do not kickoff/poll here. Resume is ensureSandboxRunning in the
@@ -90,7 +95,7 @@ export async function ensureSandboxStartedSteps(
     console.log(
       `[daytona] ensureSandboxStartedSteps vercel skip-kickoff thawId=${thawId} elapsed=${Date.now() - thawStartedAt}ms`,
     );
-    return;
+    return { provider, thawId };
   }
 
   const kickoff = await step.runAction(
@@ -100,7 +105,7 @@ export async function ensureSandboxStartedSteps(
   console.log(
     `[daytona] ensureSandboxStartedSteps kickoff done provider=${kickoff.provider} state=${kickoff.state} thawId=${thawId} elapsed=${Date.now() - thawStartedAt}ms`,
   );
-  if (kickoff.state === "running") return;
+  if (kickoff.state === "running") return { provider, thawId };
 
   if (args.streamingEntityId) {
     await step.runMutation(internal.streaming.internalSet, {
@@ -133,4 +138,5 @@ export async function ensureSandboxStartedSteps(
       `Sandbox ${thawId} restore from cold storage did not complete within ~20 minutes (last state: ${state}). The restore continues in the background — retry to resume.`,
     );
   }
+  return { provider, thawId };
 }

--- a/packages/backend/convex/_daytona/sessions.ts
+++ b/packages/backend/convex/_daytona/sessions.ts
@@ -8,8 +8,10 @@ import type { DataModel, Id } from "../_generated/dataModel";
 import {
   execHandle,
   resolveSandboxContext,
+  resolveSandboxClientOnly,
   getDaytona,
   ensureSandboxRunning,
+  ensureDockerDaemon,
   ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
   errorMessage,
   sleep,
@@ -542,10 +544,12 @@ async function prepareSessionSandboxInternal(
     completedSteps,
     "Resolving sandbox context...",
   );
-  const { client, sandboxEnvVars, snapshotName } = await runLoggedSessionStep(
-    "resolveSessionSandboxContext",
+  // Resume path: credentials-only client (no full env decrypt). Full context
+  // (env map + snapshot) loads only if reuse fails and we create.
+  const client = await runLoggedSessionStep(
+    "resolveSessionSandboxClient",
     actionDetails,
-    () => resolveSandboxContext(ctx, args.repoId),
+    () => resolveSandboxClientOnly(ctx, args.repoId),
   );
   // Sandbox reuse and persistence volumes remain Daytona-only; resolve a raw
   // Daytona client lazily (never invoked on the Vercel path) for those paths
@@ -559,7 +563,7 @@ async function prepareSessionSandboxInternal(
     vercelSandboxId: args.vercelSandboxId,
   });
   logSession(
-    `prepareSessionSandbox context resolved (${actionDetails}, snapshot=${snapshotName ?? "none"}, rootDir=${rootDir || "."})`,
+    `prepareSessionSandbox client resolved (${actionDetails}, rootDir=${rootDir || "."})`,
   );
   completedSteps.push({
     type: "tool",
@@ -579,108 +583,139 @@ async function prepareSessionSandboxInternal(
       "tryReuseSessionSandbox",
       actionDetails,
       () =>
-        tryReuseSandboxHandle(client, reuseId, async (handle) => {
-          const sandboxDetails = `${actionDetails}, sandboxId=${handle.id}`;
-          await runLoggedSessionStep(
-            "reuseSessionSandbox.prepare",
-            sandboxDetails,
-            async () => {
-              await ensureSandboxRunning(handle, {
-                timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
-                onRestoring: () =>
-                  emitSessionProgress(
-                    ctx,
-                    args.sessionId,
-                    completedSteps,
-                    "Restoring sandbox from cold storage (can take up to 10 minutes)...",
-                  ),
-              });
-              await ensureGitCredentialHelper(ctx, handle, args.installationId);
-              await checkoutSessionBranchWithRetry(
-                handle,
-                args.branchName,
-                args.baseBranch,
-              );
-            },
-          );
-          await runLoggedSessionStep(
-            "reuseSessionSandbox.setupBranch",
-            sandboxDetails,
-            () => setupBranch(handle, args.branchName, args.baseBranch),
-          );
-          await runLoggedSessionStep(
-            "reuseSessionSandbox.copyConfigFiles",
-            sandboxDetails,
-            () => copySandboxConfigFilesToWorkspace(handle),
-          );
-          const { port: devPort, devCommand } = await runLoggedSessionStep(
-            "reuseSessionSandbox.startSessionServices",
-            sandboxDetails,
-            () => startSessionServices(handle, rootDir, devOverrides(repo)),
-          );
-          if (args.startDesktop) {
+        tryReuseSandboxHandle(
+          client,
+          reuseId,
+          async (handle) => {
+            const sandboxDetails = `${actionDetails}, sandboxId=${handle.id}`;
+            let reuseEarlyReadyEmitted = false;
             await runLoggedSessionStep(
-              "reuseSessionSandbox.startDesktop",
+              "reuseSessionSandbox.prepare",
               sandboxDetails,
-              () => startDesktopWithChrome(handle),
+              async () => {
+                await ensureSandboxRunning(handle, {
+                  timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
+                  skipDocker: true,
+                  // Skip the ~14s post-resume exec probe: start() already
+                  // verified the session reports running, and the git/services
+                  // steps right after early-ready surface any real failure.
+                  skipExecProbe: true,
+                  onRestoring: () =>
+                    emitSessionProgress(
+                      ctx,
+                      args.sessionId,
+                      completedSteps,
+                      // Vercel resume is snapshot wake, not Daytona cold storage.
+                      "Resuming sandbox...",
+                    ),
+                });
+                // Unlock chat/tabs as soon as the VM is up — docker/git/services continue.
+                if (!reuseEarlyReadyEmitted) {
+                  reuseEarlyReadyEmitted = true;
+                  await ctx.runMutation(internal.sessions.sandboxReady, {
+                    sessionId: args.sessionId,
+                    sandboxId: handle.id,
+                    vercelSandboxId: handle.id,
+                    branchName: args.branchName,
+                    isNew: false,
+                    usedSnapshot: false,
+                  });
+                }
+                await ensureDockerDaemon(handle);
+                await ensureGitCredentialHelper(
+                  ctx,
+                  handle,
+                  args.installationId,
+                );
+                await checkoutSessionBranchWithRetry(
+                  handle,
+                  args.branchName,
+                  args.baseBranch,
+                );
+              },
             );
-          }
-          await emitSessionProgress(
-            ctx,
-            args.sessionId,
-            completedSteps,
-            "Launching background commands...",
-          );
-          let reuseBgRan = false;
-          await runLoggedSessionStep(
-            "reuseSessionSandbox.runBackgroundCommands",
-            sandboxDetails,
-            async () => {
-              const result = await ctx.runAction(
-                internal.daytona.runBackgroundCommands,
-                { sandboxId: handle.id, repoId: args.repoId },
+            await runLoggedSessionStep(
+              "reuseSessionSandbox.setupBranch",
+              sandboxDetails,
+              () => setupBranch(handle, args.branchName, args.baseBranch),
+            );
+            await runLoggedSessionStep(
+              "reuseSessionSandbox.copyConfigFiles",
+              sandboxDetails,
+              () => copySandboxConfigFilesToWorkspace(handle),
+            );
+            const { port: devPort, devCommand } = await runLoggedSessionStep(
+              "reuseSessionSandbox.startSessionServices",
+              sandboxDetails,
+              () => startSessionServices(handle, rootDir, devOverrides(repo)),
+            );
+            if (args.startDesktop) {
+              await runLoggedSessionStep(
+                "reuseSessionSandbox.startDesktop",
+                sandboxDetails,
+                () => startDesktopWithChrome(handle),
               );
-              reuseBgRan = result.ran;
-              if (result.ran && result.commandCount > 0) {
-                logSession(
-                  `Launched ${result.commandCount} background command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+            }
+            await emitSessionProgress(
+              ctx,
+              args.sessionId,
+              completedSteps,
+              "Launching background commands...",
+            );
+            let reuseBgRan = false;
+            await runLoggedSessionStep(
+              "reuseSessionSandbox.runBackgroundCommands",
+              sandboxDetails,
+              async () => {
+                const result = await ctx.runAction(
+                  internal.daytona.runBackgroundCommands,
+                  { sandboxId: handle.id, repoId: args.repoId },
                 );
-              }
-            },
-          );
-          if (reuseBgRan) {
-            completedSteps.push({
-              type: "tool",
-              label: "Launching background commands...",
-              status: "complete",
-            });
-          }
-          await runLoggedSessionStep(
-            "reuseSessionSandbox.runStartupCommands",
-            sandboxDetails,
-            async () => {
-              const result = await ctx.runAction(
-                internal.daytona.runStartupCommands,
-                { sandboxId: handle.id, repoId: args.repoId },
-              );
-              if (result.ran && result.commandCount > 0) {
-                logSession(
-                  `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+                reuseBgRan = result.ran;
+                if (result.ran && result.commandCount > 0) {
+                  logSession(
+                    `Launched ${result.commandCount} background command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+                  );
+                }
+              },
+            );
+            if (reuseBgRan) {
+              completedSteps.push({
+                type: "tool",
+                label: "Launching background commands...",
+                status: "complete",
+              });
+            }
+            await runLoggedSessionStep(
+              "reuseSessionSandbox.runStartupCommands",
+              sandboxDetails,
+              async () => {
+                const result = await ctx.runAction(
+                  internal.daytona.runStartupCommands,
+                  { sandboxId: handle.id, repoId: args.repoId },
                 );
-              }
-            },
-          );
-          reusedResult = {
-            sandbox: handle,
-            isNew: false,
-            usedSnapshot: false,
-            sandboxDetails,
-            branchName: args.branchName,
-            devPort,
-            devCommand,
-            vercelSandboxId: handle.id,
-          };
-        }),
+                if (result.ran && result.commandCount > 0) {
+                  logSession(
+                    `Ran ${result.commandCount} startup command(s)${result.errors.length > 0 ? ` with errors: ${result.errors.join("; ")}` : ""}`,
+                  );
+                }
+              },
+            );
+            reusedResult = {
+              sandbox: handle,
+              isNew: false,
+              usedSnapshot: false,
+              sandboxDetails,
+              branchName: args.branchName,
+              devPort,
+              devCommand,
+              vercelSandboxId: handle.id,
+            };
+          },
+          // Never silently create a replacement when the existing sandbox is
+          // still reachable — that orphans the old VM and loses workspace state.
+          { fallbackOnPrepareError: false },
+        ),
     );
     if (reusedHandle && reusedResult) {
       await completeSessionProgress(ctx, args.sessionId);
@@ -702,12 +737,17 @@ async function prepareSessionSandboxInternal(
               reuseId,
               async (sandbox) => {
                 const sandboxDetails = `${actionDetails}, sandboxId=${sandbox.id}`;
+                let reuseEarlyReadyEmitted = false;
                 await runLoggedSessionStep(
                   "reuseSessionSandbox.prepare",
                   sandboxDetails,
                   async () => {
                     await ensureSandboxRunning(wrapDaytonaSandbox(sandbox), {
                       timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
+                      skipDocker: true,
+                      // Same rationale as the vercel reuse path: the git steps
+                      // right after early-ready surface any exec failure.
+                      skipExecProbe: true,
                       onRestoring: () =>
                         emitSessionProgress(
                           ctx,
@@ -716,6 +756,18 @@ async function prepareSessionSandboxInternal(
                           "Restoring sandbox from cold storage (can take up to 10 minutes)...",
                         ),
                     });
+                    // Unlock chat/tabs as soon as the VM is up — docker/git/services continue.
+                    if (!reuseEarlyReadyEmitted) {
+                      reuseEarlyReadyEmitted = true;
+                      await ctx.runMutation(internal.sessions.sandboxReady, {
+                        sessionId: args.sessionId,
+                        sandboxId: sandbox.id,
+                        branchName: args.branchName,
+                        isNew: false,
+                        usedSnapshot: false,
+                      });
+                    }
+                    await ensureDockerDaemon(wrapDaytonaSandbox(sandbox));
                     // Self-heal: rotate the per-sandbox secret + reinstall the helper
                     // every resume so in-sandbox `git pull` and any subsequent fetch
                     // authenticate without relying on a stale URL-embedded token.
@@ -838,6 +890,7 @@ async function prepareSessionSandboxInternal(
                   vercelSandboxId: undefined,
                 };
               },
+              { fallbackOnPrepareError: false },
             ),
         );
   if (reused && reusedResult) {
@@ -852,6 +905,13 @@ async function prepareSessionSandboxInternal(
     label: "Checking existing sandbox...",
     status: "complete",
   });
+
+  // Create path needs full env map + snapshot — load only after reuse failed.
+  const { sandboxEnvVars, snapshotName } = await runLoggedSessionStep(
+    "resolveSessionSandboxContext",
+    actionDetails,
+    () => resolveSandboxContext(ctx, args.repoId),
+  );
 
   await emitSessionProgress(
     ctx,
@@ -1184,6 +1244,21 @@ export const startSessionSandbox = internalAction({
       if (!args.repoId) {
         throw new Error("repoId is required for startSessionSandbox");
       }
+      // User may have clicked Stop after this action was scheduled. Abort before
+      // any resume:true / create — otherwise we wake a VM the UI already left.
+      const sessionBefore = await ctx.runQuery(internal.sessions.getInternal, {
+        id: args.sessionId,
+      });
+      if (
+        sessionBefore &&
+        (sessionBefore.status === "stopping" ||
+          sessionBefore.status === "closed")
+      ) {
+        console.log(
+          `[daytona][sessions] startSessionSandbox aborted sessionId=${args.sessionId} status=${sessionBefore.status}`,
+        );
+        return null;
+      }
       const prepared = await prepareSessionSandboxInternal(ctx, {
         sessionId: args.sessionId,
         existingSandboxId: args.existingSandboxId,
@@ -1220,6 +1295,25 @@ export const startSessionSandbox = internalAction({
       console.error(
         `[daytona][sessions] startSessionSandbox failed after ${formatDurationMsShort(Date.now() - actionStartedAt)} (${actionDetails}): ${errorMessage(e, "Unknown error")}`,
       );
+      // Early-ready may have already marked the session active while the VM is
+      // still running. Stop the provider sandbox so UI "closed" matches reality
+      // and a later Start can resume cleanly instead of fighting a live orphan.
+      const stopId = args.vercelSandboxId ?? args.existingSandboxId;
+      if (args.repoId && stopId) {
+        try {
+          await ctx.runAction(internal.daytona.stopSandbox, {
+            sandboxId: stopId,
+            repoId: args.repoId,
+          });
+          console.log(
+            `[daytona][sessions] stopped sandbox ${stopId} after start failure`,
+          );
+        } catch (stopErr) {
+          console.log(
+            `[daytona][sessions] stop after start failure failed for ${stopId}: ${errorMessage(stopErr, "stop failed")}`,
+          );
+        }
+      }
       await ctx.runMutation(internal.sessions.sandboxError, {
         sessionId: args.sessionId,
         error: errorMessage(e, "Unknown error"),
@@ -1496,10 +1590,10 @@ async function prepareTaskPreviewSandboxInternal(
     completedSteps,
     "Resolving sandbox context...",
   );
-  const { client, sandboxEnvVars, snapshotName } = await runLoggedSessionStep(
-    "resolveTaskSandboxContext",
+  const client = await runLoggedSessionStep(
+    "resolveTaskSandboxClient",
     actionDetails,
-    () => resolveSandboxContext(ctx, args.repoId),
+    () => resolveSandboxClientOnly(ctx, args.repoId),
   );
   // Sandbox reuse and persistence volumes remain Daytona-only; resolve a raw
   // Daytona client lazily (never invoked on the Vercel path) for those paths
@@ -1511,7 +1605,7 @@ async function prepareTaskPreviewSandboxInternal(
     vercelSandboxId: args.vercelSandboxId,
   });
   logSession(
-    `prepareTaskPreviewSandbox context resolved (${actionDetails}, snapshot=${snapshotName ?? "none"}, rootDir=${rootDir || "."})`,
+    `prepareTaskPreviewSandbox client resolved (${actionDetails}, rootDir=${rootDir || "."})`,
   );
   completedSteps.push({
     type: "tool",
@@ -1542,14 +1636,27 @@ async function prepareTaskPreviewSandboxInternal(
       async () => {
         await ensureSandboxRunning(handle, {
           timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
+          skipDocker: true,
+          // Skip the post-resume exec probe (see session reuse path).
+          skipExecProbe: true,
           onRestoring: () =>
             emitTaskProgress(
               ctx,
               args.taskId,
               completedSteps,
-              "Restoring sandbox from cold storage (can take up to 10 minutes)...",
+              client.kind === "vercel"
+                ? "Resuming sandbox..."
+                : "Restoring sandbox from cold storage (can take up to 10 minutes)...",
             ),
         });
+        // Unlock UI as soon as the VM is up — docker/git/services continue.
+        await ctx.runMutation(internal.agentTasks.taskSandboxReady, {
+          taskId: args.taskId,
+          sandboxId: handle.id,
+          vercelSandboxId: client.kind === "vercel" ? handle.id : undefined,
+          isNew: false,
+        });
+        await ensureDockerDaemon(handle);
         // Self-heal: rotate the per-sandbox secret + reinstall the
         // helper every resume so in-sandbox `git pull` and any
         // subsequent fetch authenticate without a stale URL token.
@@ -1700,6 +1807,12 @@ async function prepareTaskPreviewSandboxInternal(
     label: "Checking existing sandbox...",
     status: "complete",
   });
+
+  const { sandboxEnvVars, snapshotName } = await runLoggedSessionStep(
+    "resolveTaskSandboxContext",
+    actionDetails,
+    () => resolveSandboxContext(ctx, args.repoId),
+  );
 
   await emitTaskProgress(
     ctx,
@@ -1983,10 +2096,10 @@ async function prepareProjectPreviewSandboxInternal(
     completedSteps,
     "Resolving sandbox context...",
   );
-  const { client, sandboxEnvVars, snapshotName } = await runLoggedSessionStep(
-    "resolveProjectSandboxContext",
+  const client = await runLoggedSessionStep(
+    "resolveProjectSandboxClient",
     actionDetails,
-    () => resolveSandboxContext(ctx, args.repoId),
+    () => resolveSandboxClientOnly(ctx, args.repoId),
   );
   // Sandbox reuse and persistence volumes remain Daytona-only; resolve a raw
   // Daytona client lazily (never invoked on the Vercel path) for those paths
@@ -1998,7 +2111,7 @@ async function prepareProjectPreviewSandboxInternal(
     vercelSandboxId: args.vercelSandboxId,
   });
   logSession(
-    `prepareProjectPreviewSandbox context resolved (${actionDetails}, snapshot=${snapshotName ?? "none"}, rootDir=${rootDir || "."})`,
+    `prepareProjectPreviewSandbox client resolved (${actionDetails}, rootDir=${rootDir || "."})`,
   );
   completedSteps.push({
     type: "tool",
@@ -2029,14 +2142,27 @@ async function prepareProjectPreviewSandboxInternal(
       async () => {
         await ensureSandboxRunning(handle, {
           timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
+          skipDocker: true,
+          // Skip the post-resume exec probe (see session reuse path).
+          skipExecProbe: true,
           onRestoring: () =>
             emitProjectProgress(
               ctx,
               args.projectId,
               completedSteps,
-              "Restoring sandbox from cold storage (can take up to 10 minutes)...",
+              client.kind === "vercel"
+                ? "Resuming sandbox..."
+                : "Restoring sandbox from cold storage (can take up to 10 minutes)...",
             ),
         });
+        // Unlock UI as soon as the VM is up — docker/git/services continue.
+        await ctx.runMutation(internal.projects.projectSandboxReady, {
+          projectId: args.projectId,
+          sandboxId: handle.id,
+          vercelSandboxId: client.kind === "vercel" ? handle.id : undefined,
+          isNew: false,
+        });
+        await ensureDockerDaemon(handle);
         // Self-heal: rotate the per-sandbox secret + reinstall the
         // helper every resume so in-sandbox `git pull` and any
         // subsequent fetch authenticate without a stale URL token.
@@ -2191,6 +2317,12 @@ async function prepareProjectPreviewSandboxInternal(
     label: "Checking existing sandbox...",
     status: "complete",
   });
+
+  const { sandboxEnvVars, snapshotName } = await runLoggedSessionStep(
+    "resolveProjectSandboxContext",
+    actionDetails,
+    () => resolveSandboxContext(ctx, args.repoId),
+  );
 
   await emitProjectProgress(
     ctx,

--- a/packages/backend/convex/_daytona/sessions.ts
+++ b/packages/backend/convex/_daytona/sessions.ts
@@ -154,6 +154,50 @@ async function checkoutSessionBranchWithRetry(
   }
 }
 
+/**
+ * Shared resume ordering for reused sandboxes across session/task/project
+ * reuse flows. Owns the drift-prone sequence so a fix lands in one place, not
+ * four: wait for the VM (skipping docker + the ~14s post-resume exec probe),
+ * unlock the UI via `onEarlyReady` as soon as it reports running, then start
+ * docker, self-heal the git credential helper, and check out the branch.
+ *
+ * Callers supply the entity-specific progress message (`onRestoring`) and
+ * early-ready mutation (`onEarlyReady`); the operational ordering lives here.
+ */
+async function resumeReusedSandbox(
+  ctx: GenericActionCtx<DataModel>,
+  handle: SandboxHandle,
+  opts: {
+    installationId: number;
+    branchName: string;
+    baseBranch: string;
+    onRestoring: () => Promise<void>;
+    onEarlyReady: () => Promise<void>;
+  },
+): Promise<void> {
+  await ensureSandboxRunning(handle, {
+    timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
+    skipDocker: true,
+    // Skip the ~14s post-resume exec probe: start() already verified the
+    // session reports running, and the git steps right after early-ready
+    // surface any real failure.
+    skipExecProbe: true,
+    onRestoring: opts.onRestoring,
+  });
+  // Unlock chat/tabs as soon as the VM is up — docker/git/services continue.
+  await opts.onEarlyReady();
+  await ensureDockerDaemon(handle);
+  // Self-heal: rotate the per-sandbox secret + reinstall the helper every
+  // resume so in-sandbox `git pull` and any subsequent fetch authenticate
+  // without relying on a stale URL-embedded token.
+  await ensureGitCredentialHelper(ctx, handle, opts.installationId);
+  await checkoutSessionBranchWithRetry(
+    handle,
+    opts.branchName,
+    opts.baseBranch,
+  );
+}
+
 /** Syncs remote refs for session restore, falling back to base branch if session branch is missing. */
 async function syncSessionRefsForRestore(
   sandbox: SandboxHandle,
@@ -588,18 +632,14 @@ async function prepareSessionSandboxInternal(
           reuseId,
           async (handle) => {
             const sandboxDetails = `${actionDetails}, sandboxId=${handle.id}`;
-            let reuseEarlyReadyEmitted = false;
             await runLoggedSessionStep(
               "reuseSessionSandbox.prepare",
               sandboxDetails,
-              async () => {
-                await ensureSandboxRunning(handle, {
-                  timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
-                  skipDocker: true,
-                  // Skip the ~14s post-resume exec probe: start() already
-                  // verified the session reports running, and the git/services
-                  // steps right after early-ready surface any real failure.
-                  skipExecProbe: true,
+              () =>
+                resumeReusedSandbox(ctx, handle, {
+                  installationId: args.installationId,
+                  branchName: args.branchName,
+                  baseBranch: args.baseBranch,
                   onRestoring: () =>
                     emitSessionProgress(
                       ctx,
@@ -608,31 +648,17 @@ async function prepareSessionSandboxInternal(
                       // Vercel resume is snapshot wake, not Daytona cold storage.
                       "Resuming sandbox...",
                     ),
-                });
-                // Unlock chat/tabs as soon as the VM is up — docker/git/services continue.
-                if (!reuseEarlyReadyEmitted) {
-                  reuseEarlyReadyEmitted = true;
-                  await ctx.runMutation(internal.sessions.sandboxReady, {
-                    sessionId: args.sessionId,
-                    sandboxId: handle.id,
-                    vercelSandboxId: handle.id,
-                    branchName: args.branchName,
-                    isNew: false,
-                    usedSnapshot: false,
-                  });
-                }
-                await ensureDockerDaemon(handle);
-                await ensureGitCredentialHelper(
-                  ctx,
-                  handle,
-                  args.installationId,
-                );
-                await checkoutSessionBranchWithRetry(
-                  handle,
-                  args.branchName,
-                  args.baseBranch,
-                );
-              },
+                  onEarlyReady: async () => {
+                    await ctx.runMutation(internal.sessions.sandboxReady, {
+                      sessionId: args.sessionId,
+                      sandboxId: handle.id,
+                      vercelSandboxId: handle.id,
+                      branchName: args.branchName,
+                      isNew: false,
+                      usedSnapshot: false,
+                    });
+                  },
+                }),
             );
             await runLoggedSessionStep(
               "reuseSessionSandbox.setupBranch",
@@ -737,17 +763,15 @@ async function prepareSessionSandboxInternal(
               reuseId,
               async (sandbox) => {
                 const sandboxDetails = `${actionDetails}, sandboxId=${sandbox.id}`;
-                let reuseEarlyReadyEmitted = false;
+                const handle = wrapDaytonaSandbox(sandbox);
                 await runLoggedSessionStep(
                   "reuseSessionSandbox.prepare",
                   sandboxDetails,
-                  async () => {
-                    await ensureSandboxRunning(wrapDaytonaSandbox(sandbox), {
-                      timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
-                      skipDocker: true,
-                      // Same rationale as the vercel reuse path: the git steps
-                      // right after early-ready surface any exec failure.
-                      skipExecProbe: true,
+                  () =>
+                    resumeReusedSandbox(ctx, handle, {
+                      installationId: args.installationId,
+                      branchName: args.branchName,
+                      baseBranch: args.baseBranch,
                       onRestoring: () =>
                         emitSessionProgress(
                           ctx,
@@ -755,33 +779,16 @@ async function prepareSessionSandboxInternal(
                           completedSteps,
                           "Restoring sandbox from cold storage (can take up to 10 minutes)...",
                         ),
-                    });
-                    // Unlock chat/tabs as soon as the VM is up — docker/git/services continue.
-                    if (!reuseEarlyReadyEmitted) {
-                      reuseEarlyReadyEmitted = true;
-                      await ctx.runMutation(internal.sessions.sandboxReady, {
-                        sessionId: args.sessionId,
-                        sandboxId: sandbox.id,
-                        branchName: args.branchName,
-                        isNew: false,
-                        usedSnapshot: false,
-                      });
-                    }
-                    await ensureDockerDaemon(wrapDaytonaSandbox(sandbox));
-                    // Self-heal: rotate the per-sandbox secret + reinstall the helper
-                    // every resume so in-sandbox `git pull` and any subsequent fetch
-                    // authenticate without relying on a stale URL-embedded token.
-                    await ensureGitCredentialHelper(
-                      ctx,
-                      wrapDaytonaSandbox(sandbox),
-                      args.installationId,
-                    );
-                    await checkoutSessionBranchWithRetry(
-                      wrapDaytonaSandbox(sandbox),
-                      args.branchName,
-                      args.baseBranch,
-                    );
-                  },
+                      onEarlyReady: async () => {
+                        await ctx.runMutation(internal.sessions.sandboxReady, {
+                          sessionId: args.sessionId,
+                          sandboxId: sandbox.id,
+                          branchName: args.branchName,
+                          isNew: false,
+                          usedSnapshot: false,
+                        });
+                      },
+                    }),
                 );
                 await runLoggedSessionStep(
                   "reuseSessionSandbox.setupBranch",
@@ -1630,43 +1637,29 @@ async function prepareTaskPreviewSandboxInternal(
       completedSteps,
       "Resuming existing sandbox...",
     );
-    await runLoggedSessionStep(
-      "reuseTaskSandbox.prepare",
-      sandboxDetails,
-      async () => {
-        await ensureSandboxRunning(handle, {
-          timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
-          skipDocker: true,
-          // Skip the post-resume exec probe (see session reuse path).
-          skipExecProbe: true,
-          onRestoring: () =>
-            emitTaskProgress(
-              ctx,
-              args.taskId,
-              completedSteps,
-              client.kind === "vercel"
-                ? "Resuming sandbox..."
-                : "Restoring sandbox from cold storage (can take up to 10 minutes)...",
-            ),
-        });
-        // Unlock UI as soon as the VM is up — docker/git/services continue.
-        await ctx.runMutation(internal.agentTasks.taskSandboxReady, {
-          taskId: args.taskId,
-          sandboxId: handle.id,
-          vercelSandboxId: client.kind === "vercel" ? handle.id : undefined,
-          isNew: false,
-        });
-        await ensureDockerDaemon(handle);
-        // Self-heal: rotate the per-sandbox secret + reinstall the
-        // helper every resume so in-sandbox `git pull` and any
-        // subsequent fetch authenticate without a stale URL token.
-        await ensureGitCredentialHelper(ctx, handle, args.installationId);
-        await checkoutSessionBranchWithRetry(
-          handle,
-          args.branchName,
-          args.baseBranch,
-        );
-      },
+    await runLoggedSessionStep("reuseTaskSandbox.prepare", sandboxDetails, () =>
+      resumeReusedSandbox(ctx, handle, {
+        installationId: args.installationId,
+        branchName: args.branchName,
+        baseBranch: args.baseBranch,
+        onRestoring: () =>
+          emitTaskProgress(
+            ctx,
+            args.taskId,
+            completedSteps,
+            client.kind === "vercel"
+              ? "Resuming sandbox..."
+              : "Restoring sandbox from cold storage (can take up to 10 minutes)...",
+          ),
+        onEarlyReady: async () => {
+          await ctx.runMutation(internal.agentTasks.taskSandboxReady, {
+            taskId: args.taskId,
+            sandboxId: handle.id,
+            vercelSandboxId: client.kind === "vercel" ? handle.id : undefined,
+            isNew: false,
+          });
+        },
+      }),
     );
     completedSteps.push({
       type: "tool",
@@ -2139,12 +2132,11 @@ async function prepareProjectPreviewSandboxInternal(
     await runLoggedSessionStep(
       "reuseProjectSandbox.prepare",
       sandboxDetails,
-      async () => {
-        await ensureSandboxRunning(handle, {
-          timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
-          skipDocker: true,
-          // Skip the post-resume exec probe (see session reuse path).
-          skipExecProbe: true,
+      () =>
+        resumeReusedSandbox(ctx, handle, {
+          installationId: args.installationId,
+          branchName: args.branchName,
+          baseBranch: args.baseBranch,
           onRestoring: () =>
             emitProjectProgress(
               ctx,
@@ -2154,25 +2146,15 @@ async function prepareProjectPreviewSandboxInternal(
                 ? "Resuming sandbox..."
                 : "Restoring sandbox from cold storage (can take up to 10 minutes)...",
             ),
-        });
-        // Unlock UI as soon as the VM is up — docker/git/services continue.
-        await ctx.runMutation(internal.projects.projectSandboxReady, {
-          projectId: args.projectId,
-          sandboxId: handle.id,
-          vercelSandboxId: client.kind === "vercel" ? handle.id : undefined,
-          isNew: false,
-        });
-        await ensureDockerDaemon(handle);
-        // Self-heal: rotate the per-sandbox secret + reinstall the
-        // helper every resume so in-sandbox `git pull` and any
-        // subsequent fetch authenticate without a stale URL token.
-        await ensureGitCredentialHelper(ctx, handle, args.installationId);
-        await checkoutSessionBranchWithRetry(
-          handle,
-          args.branchName,
-          args.baseBranch,
-        );
-      },
+          onEarlyReady: async () => {
+            await ctx.runMutation(internal.projects.projectSandboxReady, {
+              projectId: args.projectId,
+              sandboxId: handle.id,
+              vercelSandboxId: client.kind === "vercel" ? handle.id : undefined,
+              isNew: false,
+            });
+          },
+        }),
     );
     completedSteps.push({
       type: "tool",

--- a/packages/backend/convex/_daytona/sessions.ts
+++ b/packages/backend/convex/_daytona/sessions.ts
@@ -155,14 +155,45 @@ async function checkoutSessionBranchWithRetry(
 }
 
 /**
+ * Thrown by a resume/start when the user has requested a stop mid-flight. The
+ * start action catches it, ensures the (possibly woken) VM is stopped, and
+ * defers the terminal status to the stop flow — so a Stop that races a Start
+ * never leaves a live orphan VM, a stuck `stopping` row, or a false
+ * "Sandbox Error" for what was really a stop.
+ */
+class SandboxStartAbortedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SandboxStartAbortedError";
+  }
+}
+
+/** True once the user has requested this session stop/close (Stop clicked). */
+async function sessionStopRequested(
+  ctx: GenericActionCtx<DataModel>,
+  sessionId: Id<"sessions">,
+): Promise<boolean> {
+  const session = await ctx.runQuery(internal.sessions.getInternal, {
+    id: sessionId,
+  });
+  return (
+    !session || session.status === "stopping" || session.status === "closed"
+  );
+}
+
+/**
  * Shared resume ordering for reused sandboxes across session/task/project
  * reuse flows. Owns the drift-prone sequence so a fix lands in one place, not
  * four: wait for the VM (skipping docker + the ~14s post-resume exec probe),
  * unlock the UI via `onEarlyReady` as soon as it reports running, then start
  * docker, self-heal the git credential helper, and check out the branch.
  *
- * Callers supply the entity-specific progress message (`onRestoring`) and
- * early-ready mutation (`onEarlyReady`); the operational ordering lives here.
+ * Callers supply the entity-specific progress message (`onRestoring`), the
+ * early-ready mutation (`onEarlyReady`), and a `shouldAbort` predicate that
+ * reports the user's stop intent. `shouldAbort` is polled before waking the VM
+ * and before each post-wake exec, so a Stop that races this resume aborts
+ * (throwing {@link SandboxStartAbortedError}) instead of running commands
+ * against a stopping sandbox (which 422s) or resurrecting a stopped one.
  */
 async function resumeReusedSandbox(
   ctx: GenericActionCtx<DataModel>,
@@ -173,8 +204,18 @@ async function resumeReusedSandbox(
     baseBranch: string;
     onRestoring: () => Promise<void>;
     onEarlyReady: () => Promise<void>;
+    shouldAbort?: () => Promise<boolean>;
   },
 ): Promise<void> {
+  const abortIfStopRequested = async (): Promise<void> => {
+    if (opts.shouldAbort && (await opts.shouldAbort())) {
+      throw new SandboxStartAbortedError(
+        `resume aborted: stop requested for sandbox ${handle.id}`,
+      );
+    }
+  };
+  // Don't wake a VM the user has already asked to stop.
+  await abortIfStopRequested();
   await ensureSandboxRunning(handle, {
     timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
     skipDocker: true,
@@ -184,9 +225,13 @@ async function resumeReusedSandbox(
     skipExecProbe: true,
     onRestoring: opts.onRestoring,
   });
+  // A Stop may have landed while start() was waking the VM — bail before the
+  // exec steps rather than run commands against a now-stopping sandbox.
+  await abortIfStopRequested();
   // Unlock chat/tabs as soon as the VM is up — docker/git/services continue.
   await opts.onEarlyReady();
   await ensureDockerDaemon(handle);
+  await abortIfStopRequested();
   // Self-heal: rotate the per-sandbox secret + reinstall the helper every
   // resume so in-sandbox `git pull` and any subsequent fetch authenticate
   // without relying on a stale URL-embedded token.
@@ -658,6 +703,7 @@ async function prepareSessionSandboxInternal(
                       usedSnapshot: false,
                     });
                   },
+                  shouldAbort: () => sessionStopRequested(ctx, args.sessionId),
                 }),
             );
             await runLoggedSessionStep(
@@ -788,6 +834,8 @@ async function prepareSessionSandboxInternal(
                           usedSnapshot: false,
                         });
                       },
+                      shouldAbort: () =>
+                        sessionStopRequested(ctx, args.sessionId),
                     }),
                 );
                 await runLoggedSessionStep(
@@ -1299,13 +1347,36 @@ export const startSessionSandbox = internalAction({
         `startSessionSandbox completed in ${formatDurationMsShort(Date.now() - actionStartedAt)} (${prepared.sandboxDetails})`,
       );
     } catch (e) {
+      const stopId = args.vercelSandboxId ?? args.existingSandboxId;
+      // A Stop that raced this Start. The resume may have briefly woken the VM,
+      // so still stop it (idempotent with finalizeStopSandbox), but leave the
+      // session status to the stop flow's markSandboxClosed — do NOT mark a
+      // start error, or Eva shows a false "Sandbox Error" and the row can stick
+      // in `stopping` while the two paths fight over status.
+      if (e instanceof SandboxStartAbortedError) {
+        console.log(
+          `[daytona][sessions] startSessionSandbox aborted by stop sessionId=${args.sessionId}: ${e.message}`,
+        );
+        if (args.repoId && stopId) {
+          try {
+            await ctx.runAction(internal.daytona.stopSandbox, {
+              sandboxId: stopId,
+              repoId: args.repoId,
+            });
+          } catch (stopErr) {
+            console.log(
+              `[daytona][sessions] stop after aborted start failed for ${stopId}: ${errorMessage(stopErr, "stop failed")}`,
+            );
+          }
+        }
+        return null;
+      }
       console.error(
         `[daytona][sessions] startSessionSandbox failed after ${formatDurationMsShort(Date.now() - actionStartedAt)} (${actionDetails}): ${errorMessage(e, "Unknown error")}`,
       );
       // Early-ready may have already marked the session active while the VM is
       // still running. Stop the provider sandbox so UI "closed" matches reality
       // and a later Start can resume cleanly instead of fighting a live orphan.
-      const stopId = args.vercelSandboxId ?? args.existingSandboxId;
       if (args.repoId && stopId) {
         try {
           await ctx.runAction(internal.daytona.stopSandbox, {

--- a/packages/backend/convex/_designSessions/sandbox.ts
+++ b/packages/backend/convex/_designSessions/sandbox.ts
@@ -4,7 +4,10 @@ import { internal } from "../_generated/api";
 import { workflow } from "../workflowManager";
 import { authMutation } from "../functions";
 import { FALLBACK_GIT_BASE_BRANCH } from "@conductor/shared";
-import { preferPersistedSandboxId } from "../_sandbox/resolveExistingSandboxId";
+import {
+  preferPersistedSandboxId,
+  resolveReusableVercelSandboxId,
+} from "../_sandbox/resolveExistingSandboxId";
 
 /** Updates the sandbox ID and/or branch name for a design session (internal). */
 export const updateSandbox = internalMutation({
@@ -44,21 +47,33 @@ export const startSandbox = authMutation({
       status: "starting",
       updatedAt: Date.now(),
     });
-    await workflow.start(
-      ctx,
-      internal.designSessions.designSandboxStartupWorkflow,
-      {
-        designSessionId: args.id,
-        existingSandboxId: session.sandboxId,
-        vercelSandboxId: session.vercelSandboxId,
-        installationId: repo.installationId,
-        repoOwner: repo.owner,
-        repoName: repo.name,
-        branchName,
-        baseBranch,
-        repoId: session.repoId,
-      },
-    );
+    const vercelSandboxId = resolveReusableVercelSandboxId(session);
+    const startArgs = {
+      designSessionId: args.id,
+      existingSandboxId: session.sandboxId,
+      vercelSandboxId: vercelSandboxId ?? session.vercelSandboxId,
+      installationId: repo.installationId,
+      repoOwner: repo.owner,
+      repoName: repo.name,
+      branchName,
+      baseBranch,
+      repoId: session.repoId,
+    };
+    // Vercel: schedule the start action directly (skip ~6s workflow scheduling).
+    // Daytona still needs the multi-step thaw workflow for archived restores.
+    if (vercelSandboxId) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.daytona.startDesignSandbox,
+        startArgs,
+      );
+    } else {
+      await workflow.start(
+        ctx,
+        internal.designSessions.designSandboxStartupWorkflow,
+        startArgs,
+      );
+    }
     return null;
   },
 });

--- a/packages/backend/convex/_designSessions/sandbox.ts
+++ b/packages/backend/convex/_designSessions/sandbox.ts
@@ -119,9 +119,8 @@ export const stopSandbox = authMutation({
 });
 
 /**
- * Awaits the Daytona stop and finalizes the design session status to `"closed"`.
- * Always flips status, even if Daytona errors — a stuck `"stopping"` state
- * would leave the user unable to Start.
+ * Awaits provider stop and finalizes design session status. Only marks
+ * `"closed"` after a successful stop — on failure reverts to `"active"`.
  */
 export const finalizeStopSandbox = internalAction({
   args: {
@@ -131,28 +130,41 @@ export const finalizeStopSandbox = internalAction({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    let stopError: string | undefined;
     try {
       await ctx.runAction(internal.daytona.stopSandbox, {
         sandboxId: args.sandboxId,
         repoId: args.repoId,
       });
-    } finally {
-      await ctx.runMutation(internal.designSessions.markSandboxClosed, {
-        designSessionId: args.designSessionId,
-      });
+    } catch (err) {
+      stopError = err instanceof Error ? err.message : String(err);
     }
+    await ctx.runMutation(internal.designSessions.markSandboxClosed, {
+      designSessionId: args.designSessionId,
+      error: stopError,
+    });
     return null;
   },
 });
 
-/** Internal: flips design session status from `"stopping"` to `"closed"` after Daytona stop completes. */
+/** Internal: close on success, revert to active on stop failure. */
 export const markSandboxClosed = internalMutation({
-  args: { designSessionId: v.id("designSessions") },
+  args: {
+    designSessionId: v.id("designSessions"),
+    error: v.optional(v.string()),
+  },
   returns: v.null(),
   handler: async (ctx, args) => {
     const session = await ctx.db.get(args.designSessionId);
     if (!session) return null;
     if (session.status !== "stopping") return null;
+    if (args.error) {
+      await ctx.db.patch(args.designSessionId, {
+        status: "active",
+        updatedAt: Date.now(),
+      });
+      return null;
+    }
     await ctx.db.patch(args.designSessionId, {
       status: "closed",
       updatedAt: Date.now(),

--- a/packages/backend/convex/_designSessions/sandbox.ts
+++ b/packages/backend/convex/_designSessions/sandbox.ts
@@ -101,14 +101,9 @@ export const stopSandbox = authMutation({
       return null;
     }
 
-    await ctx.db.insert("messages", {
-      parentId: args.id,
-      role: "assistant",
-      content: "Sandbox stopped",
-      timestamp: Date.now(),
-      userId: ctx.userId,
-      isSystemAlert: true,
-    });
+    // The "Sandbox stopped" / "Failed to stop sandbox" divider is inserted by
+    // `markSandboxClosed` once the stop call settles, so the divider matches the
+    // actual outcome rather than being optimistic.
     await ctx.db.patch(args.id, {
       // Keep sandboxId so we can resume the stopped sandbox later.
       status: "stopping",
@@ -159,12 +154,28 @@ export const markSandboxClosed = internalMutation({
     if (!session) return null;
     if (session.status !== "stopping") return null;
     if (args.error) {
+      await ctx.db.insert("messages", {
+        parentId: args.designSessionId,
+        role: "assistant",
+        content: "Failed to stop sandbox",
+        timestamp: Date.now(),
+        isSystemAlert: true,
+        errorDetail: args.error,
+      });
+      // VM is still running — keep UI active so Stop can be retried.
       await ctx.db.patch(args.designSessionId, {
         status: "active",
         updatedAt: Date.now(),
       });
       return null;
     }
+    await ctx.db.insert("messages", {
+      parentId: args.designSessionId,
+      role: "assistant",
+      content: "Sandbox stopped",
+      timestamp: Date.now(),
+      isSystemAlert: true,
+    });
     await ctx.db.patch(args.designSessionId, {
       status: "closed",
       updatedAt: Date.now(),

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -112,6 +112,7 @@ import type * as _sandbox_daytonaProvider from "../_sandbox/daytonaProvider.js";
 import type * as _sandbox_factory from "../_sandbox/factory.js";
 import type * as _sandbox_provider from "../_sandbox/provider.js";
 import type * as _sandbox_resolveExistingSandboxId from "../_sandbox/resolveExistingSandboxId.js";
+import type * as _sandbox_startupActivity from "../_sandbox/startupActivity.js";
 import type * as _sandbox_vercelProvider from "../_sandbox/vercelProvider.js";
 import type * as _sessions_chatEntries from "../_sessions/chatEntries.js";
 import type * as _sessions_execution from "../_sessions/execution.js";
@@ -372,6 +373,7 @@ declare const fullApi: ApiFromModules<{
   "_sandbox/factory": typeof _sandbox_factory;
   "_sandbox/provider": typeof _sandbox_provider;
   "_sandbox/resolveExistingSandboxId": typeof _sandbox_resolveExistingSandboxId;
+  "_sandbox/startupActivity": typeof _sandbox_startupActivity;
   "_sandbox/vercelProvider": typeof _sandbox_vercelProvider;
   "_sessions/chatEntries": typeof _sessions_chatEntries;
   "_sessions/execution": typeof _sessions_execution;

--- a/packages/backend/convex/_projects/mutations.ts
+++ b/packages/backend/convex/_projects/mutations.ts
@@ -14,6 +14,7 @@ import {
   softDeleteAgentTask,
 } from "../functions";
 import { allocateNumId } from "../numId";
+import { preferPersistedSandboxId } from "../_sandbox/resolveExistingSandboxId";
 import {
   getProjectConversation,
   setProjectConversation,
@@ -258,7 +259,10 @@ export const clearProjectSandbox = authMutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     const project = await getProjectWithAccess(ctx.db, args.id, ctx.userId);
-    const deleteId = project.vercelSandboxId ?? project.sandboxId;
+    const deleteId = preferPersistedSandboxId({
+      sandboxId: project.sandboxId,
+      vercelSandboxId: project.vercelSandboxId,
+    });
     if (deleteId) {
       await ctx.scheduler.runAfter(0, internal.daytona.deleteSandbox, {
         sandboxId: deleteId,

--- a/packages/backend/convex/_projects/queries.ts
+++ b/packages/backend/convex/_projects/queries.ts
@@ -146,7 +146,6 @@ export const getActive = authQuery({
         .collect(),
     );
     return projects
-      .filter((p) => p.deletedAt === undefined)
       .map((p) => ({
         _id: p._id,
         numId: p.numId,
@@ -286,10 +285,12 @@ export const listTaskProgress = authQuery({
     );
     return await Promise.all(
       projects.map(async (project) => {
-        const tasks = await ctx.db
-          .query("agentTasks")
-          .withIndex("by_project", (q) => q.eq("projectId", project._id))
-          .collect();
+        const tasks = filterActiveEntities(
+          await ctx.db
+            .query("agentTasks")
+            .withIndex("by_project", (q) => q.eq("projectId", project._id))
+            .collect(),
+        );
         return { projectId: project._id, ...computeTaskProgress(tasks) };
       }),
     );

--- a/packages/backend/convex/_projects/sandbox.ts
+++ b/packages/backend/convex/_projects/sandbox.ts
@@ -5,6 +5,11 @@ import { authMutation, getProjectWithAccess, hasActiveRun } from "../functions";
 import { workflow } from "../workflowManager";
 import { FALLBACK_GIT_BASE_BRANCH } from "@conductor/shared";
 import { buildProjectBranchName } from "./helpers";
+import { resolveReusableVercelSandboxId } from "../_sandbox/resolveExistingSandboxId";
+import {
+  seedSandboxStartupActivity,
+  clearSandboxStartupActivity,
+} from "../_sandbox/startupActivity";
 
 const PREVIEW_ALLOWED_PHASES = [
   "in_progress",
@@ -48,38 +53,11 @@ export const startProjectSandbox = authMutation({
     });
     // Seed startup streaming immediately so the UI shows a real step instead of
     // the random "Eva is inferring…" spinner while the workflow schedules.
-    const startupEntityId = `project-sandbox-startup-${args.projectId}`;
-    const startupActivity = JSON.stringify([
-      { type: "tool", label: "Starting sandbox...", status: "active" },
-    ]);
-    const existingStreaming = await ctx.db
-      .query("streamingActivity")
-      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
-      .first();
-    if (existingStreaming) {
-      await ctx.db.patch(existingStreaming._id, {
-        currentActivity: startupActivity,
-        currentContent: "",
-        lastUpdatedAt: Date.now(),
-      });
-    } else {
-      await ctx.db.insert("streamingActivity", {
-        entityId: startupEntityId,
-        currentActivity: startupActivity,
-        currentContent: "",
-        lastUpdatedAt: Date.now(),
-      });
-    }
-    const looksLikeDaytonaUuid =
-      typeof project.sandboxId === "string" &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        project.sandboxId,
-      );
-    const vercelSandboxId =
-      project.vercelSandboxId ??
-      (project.sandboxId && !looksLikeDaytonaUuid
-        ? project.sandboxId
-        : undefined);
+    await seedSandboxStartupActivity(
+      ctx.db,
+      `project-sandbox-startup-${args.projectId}`,
+    );
+    const vercelSandboxId = resolveReusableVercelSandboxId(project);
     console.log(
       `[projects] startProjectSandbox projectId=${args.projectId} existingSandboxId=${project.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
@@ -374,12 +352,10 @@ export const stopProjectSandbox = authMutation({
     );
 
     // Clear leftover start steps so stop does not re-show startup activity.
-    const startupEntityId = `project-sandbox-startup-${args.projectId}`;
-    const startupStreaming = await ctx.db
-      .query("streamingActivity")
-      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
-      .first();
-    if (startupStreaming) await ctx.db.delete(startupStreaming._id);
+    await clearSandboxStartupActivity(
+      ctx.db,
+      `project-sandbox-startup-${args.projectId}`,
+    );
 
     // Keep sandboxId so we can resume the stopped sandbox later.
     await ctx.db.patch(args.projectId, {

--- a/packages/backend/convex/_projects/sandbox.ts
+++ b/packages/backend/convex/_projects/sandbox.ts
@@ -62,38 +62,29 @@ export const startProjectSandbox = authMutation({
       `[projects] startProjectSandbox projectId=${args.projectId} existingSandboxId=${project.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
 
+    const startArgs = {
+      projectId: args.projectId,
+      existingSandboxId: project.sandboxId,
+      vercelSandboxId: vercelSandboxId ?? project.vercelSandboxId,
+      installationId: repo.installationId,
+      repoOwner: repo.owner,
+      repoName: repo.name,
+      branchName,
+      baseBranch,
+      repoId: project.repoId,
+    };
     // Vercel: schedule start action directly (skip ~6s workflow scheduling).
     if (vercelSandboxId) {
       await ctx.scheduler.runAfter(
         0,
         internal.daytona.startProjectPreviewSandbox,
-        {
-          projectId: args.projectId,
-          existingSandboxId: project.sandboxId,
-          vercelSandboxId,
-          installationId: repo.installationId,
-          repoOwner: repo.owner,
-          repoName: repo.name,
-          branchName,
-          baseBranch,
-          repoId: project.repoId,
-        },
+        startArgs,
       );
     } else {
       await workflow.start(
         ctx,
         internal.projectSandboxWorkflow.projectPreviewSandboxStartupWorkflow,
-        {
-          projectId: args.projectId,
-          existingSandboxId: project.sandboxId,
-          vercelSandboxId: project.vercelSandboxId,
-          installationId: repo.installationId,
-          repoOwner: repo.owner,
-          repoName: repo.name,
-          branchName,
-          baseBranch,
-          repoId: project.repoId,
-        },
+        startArgs,
       );
     }
 

--- a/packages/backend/convex/_projects/sandbox.ts
+++ b/packages/backend/convex/_projects/sandbox.ts
@@ -46,22 +46,78 @@ export const startProjectSandbox = authMutation({
     await ctx.db.patch(args.projectId, {
       reviewProjectSandboxStatus: "starting",
     });
-
-    await workflow.start(
-      ctx,
-      internal.projectSandboxWorkflow.projectPreviewSandboxStartupWorkflow,
-      {
-        projectId: args.projectId,
-        existingSandboxId: project.sandboxId,
-        vercelSandboxId: project.vercelSandboxId,
-        installationId: repo.installationId,
-        repoOwner: repo.owner,
-        repoName: repo.name,
-        branchName,
-        baseBranch,
-        repoId: project.repoId,
-      },
+    // Seed startup streaming immediately so the UI shows a real step instead of
+    // the random "Eva is inferring…" spinner while the workflow schedules.
+    const startupEntityId = `project-sandbox-startup-${args.projectId}`;
+    const startupActivity = JSON.stringify([
+      { type: "tool", label: "Starting sandbox...", status: "active" },
+    ]);
+    const existingStreaming = await ctx.db
+      .query("streamingActivity")
+      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
+      .first();
+    if (existingStreaming) {
+      await ctx.db.patch(existingStreaming._id, {
+        currentActivity: startupActivity,
+        currentContent: "",
+        lastUpdatedAt: Date.now(),
+      });
+    } else {
+      await ctx.db.insert("streamingActivity", {
+        entityId: startupEntityId,
+        currentActivity: startupActivity,
+        currentContent: "",
+        lastUpdatedAt: Date.now(),
+      });
+    }
+    const looksLikeDaytonaUuid =
+      typeof project.sandboxId === "string" &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        project.sandboxId,
+      );
+    const vercelSandboxId =
+      project.vercelSandboxId ??
+      (project.sandboxId && !looksLikeDaytonaUuid
+        ? project.sandboxId
+        : undefined);
+    console.log(
+      `[projects] startProjectSandbox projectId=${args.projectId} existingSandboxId=${project.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
+
+    // Vercel: schedule start action directly (skip ~6s workflow scheduling).
+    if (vercelSandboxId) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.daytona.startProjectPreviewSandbox,
+        {
+          projectId: args.projectId,
+          existingSandboxId: project.sandboxId,
+          vercelSandboxId,
+          installationId: repo.installationId,
+          repoOwner: repo.owner,
+          repoName: repo.name,
+          branchName,
+          baseBranch,
+          repoId: project.repoId,
+        },
+      );
+    } else {
+      await workflow.start(
+        ctx,
+        internal.projectSandboxWorkflow.projectPreviewSandboxStartupWorkflow,
+        {
+          projectId: args.projectId,
+          existingSandboxId: project.sandboxId,
+          vercelSandboxId: project.vercelSandboxId,
+          installationId: repo.installationId,
+          repoOwner: repo.owner,
+          repoName: repo.name,
+          branchName,
+          baseBranch,
+          repoId: project.repoId,
+        },
+      );
+    }
 
     return null;
   },
@@ -317,6 +373,14 @@ export const stopProjectSandbox = authMutation({
       },
     );
 
+    // Clear leftover start steps so stop does not re-show startup activity.
+    const startupEntityId = `project-sandbox-startup-${args.projectId}`;
+    const startupStreaming = await ctx.db
+      .query("streamingActivity")
+      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
+      .first();
+    if (startupStreaming) await ctx.db.delete(startupStreaming._id);
+
     // Keep sandboxId so we can resume the stopped sandbox later.
     await ctx.db.patch(args.projectId, {
       reviewProjectSandboxStatus: "stopping",
@@ -327,9 +391,8 @@ export const stopProjectSandbox = authMutation({
 });
 
 /**
- * Awaits the Daytona stop and finalizes the project sandbox status to `"closed"`.
- * Always flips status, even if Daytona errors — a stuck `"stopping"` state
- * would leave the user unable to Start.
+ * Awaits provider stop and finalizes project sandbox status. Only marks
+ * `"closed"` after a successful stop — on failure reverts to `"active"`.
  */
 export const finalizeStopProjectSandbox = internalAction({
   args: {
@@ -357,8 +420,8 @@ export const finalizeStopProjectSandbox = internalAction({
 });
 
 /**
- * Internal: flips project sandbox status from `"stopping"` to `"closed"` after
- * Daytona stop completes, and posts a sandbox stop divider to the chat.
+ * Internal: after stop settles, either close (success) or revert to active
+ * (failure) so Eva never shows off while Vercel is still running.
  */
 export const markProjectSandboxClosed = internalMutation({
   args: {
@@ -371,13 +434,26 @@ export const markProjectSandboxClosed = internalMutation({
     if (!project) return null;
     // Only flip if still stopping — don't overwrite a fresh start.
     if (project.reviewProjectSandboxStatus !== "stopping") return null;
+    if (args.error) {
+      await ctx.db.insert("messages", {
+        parentId: args.projectId,
+        role: "assistant",
+        content: "Failed to stop sandbox",
+        timestamp: Date.now(),
+        isSystemAlert: true,
+        errorDetail: args.error,
+      });
+      await ctx.db.patch(args.projectId, {
+        reviewProjectSandboxStatus: "active",
+      });
+      return null;
+    }
     await ctx.db.insert("messages", {
       parentId: args.projectId,
       role: "assistant",
-      content: args.error ? "Failed to stop sandbox" : "Sandbox stopped",
+      content: "Sandbox stopped",
       timestamp: Date.now(),
       isSystemAlert: true,
-      errorDetail: args.error,
     });
     await ctx.db.patch(args.projectId, {
       reviewProjectSandboxStatus: "closed",
@@ -401,14 +477,31 @@ export const projectSandboxReady = internalMutation({
     const project = await ctx.db.get(args.projectId);
     if (!project) return null;
 
-    const content = args.isNew ? "Sandbox started" : "Sandbox reconnected";
-    await ctx.db.insert("messages", {
-      parentId: args.projectId,
-      role: "assistant",
-      content,
-      timestamp: Date.now(),
-      isSystemAlert: true,
-    });
+    if (
+      project.reviewProjectSandboxStatus === "stopping" ||
+      project.reviewProjectSandboxStatus === "closed"
+    ) {
+      console.log(
+        `[projects] projectSandboxReady ignored projectId=${args.projectId} status=${project.reviewProjectSandboxStatus} sandboxId=${args.sandboxId}`,
+      );
+      return null;
+    }
+
+    // Early-ready (VM up) + final-ready (after services) both call this. Only
+    // emit the system alert once; still patch latest sandbox/dev metadata.
+    const alreadyActive =
+      project.reviewProjectSandboxStatus === "active" &&
+      project.sandboxId === args.sandboxId;
+    if (!alreadyActive) {
+      const content = args.isNew ? "Sandbox started" : "Sandbox reconnected";
+      await ctx.db.insert("messages", {
+        parentId: args.projectId,
+        role: "assistant",
+        content,
+        timestamp: Date.now(),
+        isSystemAlert: true,
+      });
+    }
     await ctx.db.patch(args.projectId, {
       sandboxId: args.sandboxId,
       ...(args.vercelSandboxId !== undefined
@@ -416,8 +509,8 @@ export const projectSandboxReady = internalMutation({
         : {}),
       reviewProjectSandboxStatus: "active",
       lastSandboxActivity: Date.now(),
-      devPort: args.devPort,
-      devCommand: args.devCommand,
+      ...(args.devPort !== undefined ? { devPort: args.devPort } : {}),
+      ...(args.devCommand !== undefined ? { devCommand: args.devCommand } : {}),
     });
 
     return null;

--- a/packages/backend/convex/_sandbox/resolveExistingSandboxId.ts
+++ b/packages/backend/convex/_sandbox/resolveExistingSandboxId.ts
@@ -29,3 +29,24 @@ export function preferPersistedSandboxId(args: {
 }): string | undefined {
   return args.vercelSandboxId ?? args.sandboxId;
 }
+
+const DAYTONA_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolves the reusable Vercel sandbox id from a persisted entity's fields for a
+ * start/resume flow. Prefers `vercelSandboxId`; falls back to `sandboxId` when it
+ * is a Vercel name (not a Daytona UUID). A missing `vercelSandboxId` used to skip
+ * reuse and create a second sandbox while still logging the old `sandboxId`.
+ */
+export function resolveReusableVercelSandboxId(args: {
+  sandboxId?: string;
+  vercelSandboxId?: string;
+}): string | undefined {
+  const looksLikeDaytonaUuid =
+    typeof args.sandboxId === "string" && DAYTONA_UUID.test(args.sandboxId);
+  return (
+    args.vercelSandboxId ??
+    (args.sandboxId && !looksLikeDaytonaUuid ? args.sandboxId : undefined)
+  );
+}

--- a/packages/backend/convex/_sandbox/resolveExistingSandboxId.ts
+++ b/packages/backend/convex/_sandbox/resolveExistingSandboxId.ts
@@ -1,13 +1,19 @@
 import type { SandboxProviderKind } from "./provider";
 
-/** When provider is vercel, only reuse vercelSandboxId (never Daytona sandboxId). */
+/**
+ * When provider is vercel, prefer `vercelSandboxId`. Fall back to `sandboxId`
+ * for legacy rows that only persisted the Vercel name on `sandboxId` — without
+ * that fallback, resume skips reuse and creates a second sandbox.
+ * Never treat a Daytona `sandboxId` as reusable when provider is vercel and
+ * `vercelSandboxId` is set (caller already prefers the vercel field).
+ */
 export function resolveExistingSandboxId(args: {
   providerKind: SandboxProviderKind;
   sandboxId: string | undefined;
   vercelSandboxId: string | undefined;
 }): string | undefined {
   if (args.providerKind === "vercel") {
-    return args.vercelSandboxId;
+    return args.vercelSandboxId ?? args.sandboxId;
   }
   return args.sandboxId;
 }

--- a/packages/backend/convex/_sandbox/startupActivity.ts
+++ b/packages/backend/convex/_sandbox/startupActivity.ts
@@ -1,0 +1,52 @@
+import type { GenericDatabaseWriter } from "convex/server";
+import type { DataModel } from "../_generated/dataModel";
+
+type DatabaseWriter = GenericDatabaseWriter<DataModel>;
+
+const STARTUP_ACTIVITY = JSON.stringify([
+  { type: "tool", label: "Starting sandbox...", status: "active" },
+]);
+
+/**
+ * Seeds a "Starting sandbox..." streaming step for an entity so the UI shows a
+ * real step instead of the random "Eva is inferring…" spinner while the start
+ * action / workflow schedules. Patches the existing row or inserts a new one.
+ */
+export async function seedSandboxStartupActivity(
+  db: DatabaseWriter,
+  entityId: string,
+): Promise<void> {
+  const existing = await db
+    .query("streamingActivity")
+    .withIndex("by_entity", (q) => q.eq("entityId", entityId))
+    .first();
+  if (existing) {
+    await db.patch(existing._id, {
+      currentActivity: STARTUP_ACTIVITY,
+      currentContent: "",
+      lastUpdatedAt: Date.now(),
+    });
+  } else {
+    await db.insert("streamingActivity", {
+      entityId,
+      currentActivity: STARTUP_ACTIVITY,
+      currentContent: "",
+      lastUpdatedAt: Date.now(),
+    });
+  }
+}
+
+/**
+ * Clears any leftover startup streaming step for an entity so a stop does not
+ * re-show "Starting sandbox..." / cold-storage copy while status is stopping.
+ */
+export async function clearSandboxStartupActivity(
+  db: DatabaseWriter,
+  entityId: string,
+): Promise<void> {
+  const existing = await db
+    .query("streamingActivity")
+    .withIndex("by_entity", (q) => q.eq("entityId", entityId))
+    .first();
+  if (existing) await db.delete(existing._id);
+}

--- a/packages/backend/convex/_sandbox/vercelProvider.ts
+++ b/packages/backend/convex/_sandbox/vercelProvider.ts
@@ -63,6 +63,8 @@ export function renderEvaEnvFile(env: Record<string, string>): string {
 const SOURCE_ENV = `[ -f ${EVA_ENV_FILE} ] && . ${EVA_ENV_FILE};`;
 /** Vercel exposes at most 4 ports; default to the eva dev + proxy range if unset. */
 const MAX_PORTS = 4;
+const STOP_CONFIRMATION_TIMEOUT_MS = 180_000;
+const STOP_CONFIRMATION_POLL_MS = 1_000;
 export const VERCEL_DEFAULT_EXPOSED_PORTS: ReadonlyArray<number> = [
   3000, 8080, 6080, 54321,
 ];
@@ -73,9 +75,13 @@ function normalizeState(raw: string | undefined): SandboxState {
     case "running":
       return "running";
     case "stopped":
+      return "stopped";
+    // Mid-stop / snapshot must NOT look like idle-stopped. Callers that treat
+    // "stopped" as "safe to resume" (ensureSandboxRunning → start) would wait
+    // the stop out and then wake the VM — the auto-restart bug after Stop.
     case "stopping":
     case "snapshotting":
-      return "stopped";
+      return "starting";
     case "starting":
     case "pending":
       return "starting";
@@ -117,22 +123,30 @@ function extractApiErrorDetail(e: unknown): string {
   }
 }
 
+/** True when the Vercel command NDJSON stream died while the VM is still up. */
+function isVercelCommandStreamClosed(detail: string): boolean {
+  const lower = detail.toLowerCase();
+  return (
+    lower.includes("stream was closed") ||
+    lower.includes("not accepting commands") ||
+    lower.includes("stream_ended_early") ||
+    lower.includes("stream ended before")
+  );
+}
+
 /** Vercel git operations, implemented over the shell (no native git client). */
 class VercelGit implements SandboxGit {
-  constructor(private readonly sandbox: Sandbox) {}
+  constructor(private readonly handle: VercelSandboxHandle) {}
 
   private async sh(cmd: string): Promise<string> {
-    const c = await this.sandbox.runCommand({
-      cmd: "bash",
-      args: ["-lc", cmd],
-    });
-    if (c.exitCode !== 0) {
-      const err = await c.output("both").catch(() => "");
+    // Goes through handle.exec so stream-closed refresh+retry applies.
+    const result = await this.handle.exec(cmd);
+    if (result.exitCode !== 0) {
       throw new Error(
-        `git shell failed (exit ${c.exitCode}): ${cmd}\n${err.slice(-2000)}`,
+        `git shell failed (exit ${result.exitCode}): ${cmd}\n${result.output.slice(-2000)}`,
       );
     }
-    return await c.stdout().catch(() => "");
+    return result.output;
   }
 
   async branches(workspaceDir: string): Promise<{ branches: string[] }> {
@@ -307,7 +321,7 @@ class VercelSandboxHandle implements SandboxHandle {
 
   /** Fresh git facade bound to the current session (refresh() swaps the sandbox). */
   get git(): SandboxGit {
-    return new VercelGit(this.sandbox);
+    return new VercelGit(this);
   }
 
   /** Migration escape hatch (see unwrapVercelSandbox). */
@@ -329,39 +343,249 @@ class VercelSandboxHandle implements SandboxHandle {
     return undefined;
   }
   get state(): SandboxState {
-    return normalizeState(this.sandbox.status);
+    // `Sandbox.status` reads currentSession(), which THROWS when the record
+    // was fetched with resume:false and the sandbox has no live session.
+    // Do NOT map that throw to "stopped": mid-stop Vercel often omits the
+    // session from get(), and treating it as idle-stopped made
+    // ensureSandboxRunning → start(resume:true) wait out the stop and wake
+    // the VM. Prefer "starting" so callers go through start(), which polls
+    // listSessions and refuses resume while stop is in flight.
+    try {
+      return normalizeState(this.sandbox.status);
+    } catch {
+      return "starting";
+    }
   }
   get errorReason(): string | null {
     // Vercel surfaces failure via status, not a reason string.
     return null;
   }
 
+  /**
+   * Returns Vercel's un-normalized session status, or `null` when the SDK
+   * throws (common for `resume: false` mid-transition). Never invent
+   * `"stopped"` from a throw — that made stop confirmation exit while Vercel
+   * was still `stopping` / snapshotting, so Eva UI flipped to stopped early.
+   */
+  private rawStatus(): string | null {
+    try {
+      return this.sandbox.status;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Latest session via listSessions. `get(resume:false)` often omits the
+   * session object while Vercel is still stopping/snapshotting — the attached
+   * handle then throws "No active session", which must not be treated as idle
+   * stopped (that caused early UI closed + resume:true auto-restart).
+   *
+   * Returns:
+   * - `{ kind: "status", status, sessionId }` when a session row exists
+   * - `{ kind: "empty" }` when the sandbox has no sessions (fully idle)
+   * - `{ kind: "error" }` when the list call failed (keep polling)
+   */
+  private async latestListedSession(): Promise<
+    | { kind: "status"; status: string; sessionId: string }
+    | { kind: "empty" }
+    | { kind: "error" }
+  > {
+    try {
+      const page = await this.sandbox.listSessions({ limit: 1 });
+      const sessions = page.sessions;
+      if (!sessions || sessions.length === 0) return { kind: "empty" };
+      const latest = sessions[0];
+      if (
+        !latest ||
+        typeof latest.status !== "string" ||
+        typeof latest.id !== "string"
+      ) {
+        return { kind: "empty" };
+      }
+      return {
+        kind: "status",
+        status: latest.status,
+        sessionId: latest.id,
+      };
+    } catch (e) {
+      console.log(
+        `[vercel] listSessions failed sandbox=${this.sandbox.name}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return { kind: "error" };
+    }
+  }
+
+  /**
+   * Stops a session by id via the Vercel REST API. Needed when
+   * `get(resume:false)` left this handle without an attached session — SDK
+   * `sandbox.stop()` then throws "No active session to stop" and our old path
+   * only waited, so the VM stayed `running` while Eva eventually marked closed.
+   */
+  private async stopSessionById(sessionId: string): Promise<void> {
+    const url = new URL(
+      `https://vercel.com/api/v2/sandboxes/sessions/${sessionId}/stop`,
+    );
+    url.searchParams.set("teamId", this.creds.teamId);
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.creds.token}`,
+        "content-type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `vercel stopSession failed sessionId=${sessionId} status=${response.status}${body ? `: ${body.slice(0, 300)}` : ""}`,
+      );
+    }
+  }
+
+  /**
+   * Prefer attached session status; fall back to listSessions when missing.
+   * Distinguishes "truly idle" from "unknown / still stopping".
+   */
+  private async resolveSessionStatus(): Promise<
+    { kind: "status"; status: string } | { kind: "empty" } | { kind: "unknown" }
+  > {
+    const attached = this.rawStatus();
+    if (attached !== null) return { kind: "status", status: attached };
+    const listed = await this.latestListedSession();
+    if (listed.kind === "status") return listed;
+    if (listed.kind === "empty") return { kind: "empty" };
+    return { kind: "unknown" };
+  }
+
+  private isTerminalStopStatus(status: string): boolean {
+    return (
+      status === "stopped" ||
+      status === "failed" ||
+      status === "error" ||
+      status === "aborted" ||
+      status === "destroyed"
+    );
+  }
+
+  private isStopInFlightStatus(status: string): boolean {
+    return status === "stopping" || status === "snapshotting";
+  }
+
+  private shouldReissueStop(status: string): boolean {
+    return (
+      status === "running" || status === "pending" || status === "starting"
+    );
+  }
+
+  /** Waits for Vercel to finish stopping and snapshotting without resuming it. */
+  private async waitForStopConfirmation(): Promise<void> {
+    const deadline = Date.now() + STOP_CONFIRMATION_TIMEOUT_MS;
+    let resolved = await this.resolveSessionStatus();
+    let lastKnown =
+      resolved.kind === "status" ? resolved.status : resolved.kind;
+    // Require a few consecutive idle readings before treating "no session" as
+    // done — a single empty listSessions mid-stop would flip Eva UI early.
+    let consecutiveIdle = 0;
+    let lastStopReissueAt = 0;
+
+    while (Date.now() < deadline) {
+      if (
+        resolved.kind === "status" &&
+        this.isTerminalStopStatus(resolved.status)
+      ) {
+        consecutiveIdle += 1;
+        lastKnown = resolved.status;
+        if (consecutiveIdle >= 2) {
+          console.log(
+            `[vercel] stop confirmed sandbox=${this.sandbox.name} status=${resolved.status}`,
+          );
+          return;
+        }
+      } else if (resolved.kind === "empty") {
+        consecutiveIdle += 1;
+        lastKnown = "empty";
+        if (consecutiveIdle >= 3) {
+          console.log(
+            `[vercel] stop confirmed sandbox=${this.sandbox.name} status=none (no session)`,
+          );
+          return;
+        }
+      } else {
+        consecutiveIdle = 0;
+        if (resolved.kind === "status") lastKnown = resolved.status;
+        else lastKnown = resolved.kind;
+        if (
+          resolved.kind === "status" &&
+          this.shouldReissueStop(resolved.status) &&
+          Date.now() - lastStopReissueAt >= 5_000
+        ) {
+          const listed = await this.latestListedSession();
+          if (
+            listed.kind === "status" &&
+            this.shouldReissueStop(listed.status)
+          ) {
+            lastStopReissueAt = Date.now();
+            console.log(
+              `[vercel] stop reissued sandbox=${this.sandbox.name} sessionId=${listed.sessionId} status=${listed.status}`,
+            );
+            await this.stopSessionById(listed.sessionId);
+          }
+        }
+      }
+
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, STOP_CONFIRMATION_POLL_MS);
+      });
+      await this.refresh();
+      resolved = await this.resolveSessionStatus();
+    }
+
+    throw new Error(
+      `vercel stop: sandbox ${this.sandbox.name} did not reach a terminal stopped state within ${STOP_CONFIRMATION_TIMEOUT_MS}ms (last status: ${lastKnown})`,
+    );
+  }
+
   async exec(
     cmd: string,
     opts?: SandboxExecOptions,
   ): Promise<SandboxExecResult> {
-    try {
-      const finished = await this.sandbox.runCommand({
-        cmd: "bash",
-        args: ["-lc", `${SOURCE_ENV} ${cmd}`],
-        ...(opts?.cwd ? { cwd: opts.cwd } : {}),
-        ...(opts?.env ? { env: opts.env } : {}),
-        ...(opts?.sudo ? { sudo: true } : {}),
-        ...(opts?.timeoutSeconds
-          ? { timeoutMs: opts.timeoutSeconds * 1000 }
-          : {}),
-      });
-      const output = await finished.output("both").catch(() => "");
-      return { exitCode: finished.exitCode, output };
-    } catch (e) {
-      // The Vercel SDK throws APIError whose .json / .text fields carry the
-      // actual API response body — surface them so 400/422 failures are
-      // diagnosable in Convex logs instead of just "Status code 4xx is not ok".
-      const detail = extractApiErrorDetail(e);
-      throw new Error(
-        `vercel exec failed (cwd=${opts?.cwd ?? "(default)"}, cmd=${cmd.slice(0, 120)}): ${detail}`,
-      );
+    // One refresh+retry on "stream was closed" — common after resume when the
+    // SDK's command stream dies while the VM is still running.
+    const maxAttempts = 2;
+    let lastError: Error | undefined;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const finished = await this.sandbox.runCommand({
+          cmd: "bash",
+          args: ["-lc", `${SOURCE_ENV} ${cmd}`],
+          ...(opts?.cwd ? { cwd: opts.cwd } : {}),
+          ...(opts?.env ? { env: opts.env } : {}),
+          ...(opts?.sudo ? { sudo: true } : {}),
+          ...(opts?.timeoutSeconds
+            ? { timeoutMs: opts.timeoutSeconds * 1000 }
+            : {}),
+        });
+        const output = await finished.output("both").catch(() => "");
+        return { exitCode: finished.exitCode, output };
+      } catch (e) {
+        // The Vercel SDK throws APIError whose .json / .text fields carry the
+        // actual API response body — surface them so 400/422 failures are
+        // diagnosable in Convex logs instead of just "Status code 4xx is not ok".
+        const detail = extractApiErrorDetail(e);
+        lastError = new Error(
+          `vercel exec failed (cwd=${opts?.cwd ?? "(default)"}, cmd=${cmd.slice(0, 120)}): ${detail}`,
+        );
+        if (attempt < maxAttempts && isVercelCommandStreamClosed(detail)) {
+          console.log(
+            `[vercel] exec stream closed on ${this.id}; refreshing and retrying (attempt ${attempt}/${maxAttempts})`,
+          );
+          await this.refresh();
+          continue;
+        }
+        throw lastError;
+      }
     }
+    throw lastError ?? new Error("vercel exec failed");
   }
 
   async execDetached(cmd: string, opts?: SandboxExecOptions): Promise<void> {
@@ -381,29 +605,173 @@ class VercelSandboxHandle implements SandboxHandle {
   }
 
   async start(timeoutSeconds: number): Promise<void> {
-    // Vercel persistent sandboxes resume when a command is run. A plain get()
-    // only returns the saved sandbox record, so kick it with a tiny command.
+    // Explicit resume via get(resume:true) — the SDK's native resume path (one
+    // getSandbox API call that provisions a fresh session, sub-second on warm
+    // hosts). The previous exec("true") kick went through withResume, which on
+    // a stopping/snapshotting session POLLS THE STOP TO COMPLETION first and
+    // paid full command-stream setup — observed ~32s resumes vs ~1s native.
     await this.refresh();
-    if (this.state !== "running") {
-      await this.exec("true", { timeoutSeconds });
+    // Read state into locals: TS narrows the `this.state` getter across the
+    // whole function (reassigning this.sandbox does not reset it).
+    let observed: SandboxState = this.state;
+    if (observed === "running") return;
+
+    // If a stop is in flight, NEVER issue resume:true — the SDK waits the stop
+    // out and then wakes the VM (auto-restart after the user clicked Stop).
+    // Wait for a terminal stopped state with resume:false, then refuse to start
+    // so in-flight resume/start callers fail cleanly instead of resurrecting.
+    let resolved = await this.resolveSessionStatus();
+    if (
+      resolved.kind === "status" &&
+      this.isStopInFlightStatus(resolved.status)
+    ) {
+      console.log(
+        `[vercel] start refused while ${resolved.status} sandbox=${this.sandbox.name}; waiting for stop to finish`,
+      );
+      await this.waitForStopConfirmation();
+      throw new Error(
+        `vercel start: sandbox ${this.sandbox.name} was stopped while a start was in progress`,
+      );
+    }
+
+    // Retry loop: a resume issued while a previous stop is still snapshotting
+    // is rejected by the API (the SDK's waitForStopAndResume exists for this),
+    // so keep re-issuing until the session reports running or we time out.
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    let lastError: string | null = null;
+    while (Date.now() < deadline) {
+      resolved = await this.resolveSessionStatus();
+      if (
+        resolved.kind === "status" &&
+        this.isStopInFlightStatus(resolved.status)
+      ) {
+        console.log(
+          `[vercel] start aborted — stop began mid-resume sandbox=${this.sandbox.name}`,
+        );
+        await this.waitForStopConfirmation();
+        throw new Error(
+          `vercel start: sandbox ${this.sandbox.name} was stopped while a start was in progress`,
+        );
+      }
+      // Still resolving (listSessions error / race) — do not resume yet.
+      if (resolved.kind === "unknown") {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        await this.refresh();
+        continue;
+      }
+      try {
+        this.sandbox = await Sandbox.get({
+          ...this.creds,
+          name: this.sandbox.name,
+          resume: true,
+        });
+        observed = this.state;
+        if (observed === "running") return;
+      } catch (e) {
+        lastError = e instanceof Error ? e.message : String(e);
+        // SDK may reject resume while stop finishes even if listSessions lagged.
+        if (
+          lastError.includes("sandbox_stopping") ||
+          lastError.includes("sandbox_snapshotting") ||
+          lastError.includes("stopping") ||
+          lastError.includes("snapshotting")
+        ) {
+          console.log(
+            `[vercel] start hit stop-in-flight API error sandbox=${this.sandbox.name}: ${lastError}`,
+          );
+          await this.waitForStopConfirmation();
+          throw new Error(
+            `vercel start: sandbox ${this.sandbox.name} was stopped while a start was in progress`,
+          );
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
       await this.refresh();
     }
+    throw new Error(
+      `vercel start: sandbox ${this.sandbox.name} did not reach running within ${timeoutSeconds}s (state: ${observed}${lastError ? `, last error: ${lastError}` : ""})`,
+    );
   }
   async stop(): Promise<void> {
-    await this.sandbox.stop();
+    // Prefer the stop API (not runCommand) so a dead command stream cannot
+    // block shutdown. Refresh first so we target the current session record.
+    // A successful stop request only means Vercel accepted it: the session can
+    // remain `stopping` while its snapshot is written. Do not let callers mark
+    // the session closed until a side-effect-free `resume: false` read confirms
+    // that transition has actually completed.
+    await this.refresh();
+    const resolved = await this.resolveSessionStatus();
+    if (
+      resolved.kind === "empty" ||
+      (resolved.kind === "status" && this.isTerminalStopStatus(resolved.status))
+    ) {
+      return;
+    }
+    // Already mid-stop (user double-clicked, or concurrent stop) — just wait.
+    if (
+      resolved.kind === "status" &&
+      this.isStopInFlightStatus(resolved.status)
+    ) {
+      console.log(
+        `[vercel] stop already in progress sandbox=${this.sandbox.name} status=${resolved.status}`,
+      );
+      await this.waitForStopConfirmation();
+      return;
+    }
+    // Prefer SDK stop when this handle still has an attached session.
+    const attached = this.rawStatus();
+    if (attached !== null) {
+      console.log(
+        `[vercel] stop requested sandbox=${this.sandbox.name} status=${attached}`,
+      );
+      await this.sandbox.stop();
+      await this.waitForStopConfirmation();
+      return;
+    }
+    // get(resume:false) dropped the session object, but listSessions still
+    // shows a live/pending session. SDK stop() throws "No active session to
+    // stop" here — stop by session id instead of waiting forever on `running`.
+    const listed = await this.latestListedSession();
+    if (listed.kind !== "status") {
+      console.log(
+        `[vercel] stop: no attached session and no listed session sandbox=${this.sandbox.name} listed=${listed.kind}; waiting`,
+      );
+      await this.waitForStopConfirmation();
+      return;
+    }
+    if (this.isTerminalStopStatus(listed.status)) {
+      return;
+    }
+    if (this.isStopInFlightStatus(listed.status)) {
+      console.log(
+        `[vercel] stop already in progress (listed) sandbox=${this.sandbox.name} status=${listed.status}`,
+      );
+      await this.waitForStopConfirmation();
+      return;
+    }
+    console.log(
+      `[vercel] stop via sessionId sandbox=${this.sandbox.name} sessionId=${listed.sessionId} status=${listed.status}`,
+    );
+    await this.stopSessionById(listed.sessionId);
+    await this.waitForStopConfirmation();
   }
   async archive(): Promise<void> {
     // No separate cold-storage archive on Vercel — stop() auto-snapshots.
-    await this.sandbox.stop();
+    await this.stop();
   }
   async delete(): Promise<void> {
     await this.sandbox.delete();
   }
   async refresh(): Promise<void> {
-    // Re-fetch the sandbox to pick up current status (resumes if stopped).
+    // Re-fetch the sandbox to pick up current status. resume:false is CRITICAL:
+    // the SDK's `resume` param defaults to TRUE, so a bare get() on a stopped
+    // sandbox silently resumes it server-side — status polls (preview checks,
+    // stop preflights) were waking sandboxes the user had just stopped. Reads
+    // must be side-effect free; only start() resumes explicitly.
     this.sandbox = await Sandbox.get({
       ...this.creds,
       name: this.sandbox.name,
+      resume: false,
     });
   }
 
@@ -499,7 +867,15 @@ class VercelSandboxClient implements SandboxClient {
   }
 
   async get(sandboxId: string): Promise<SandboxHandle> {
-    const sandbox = await Sandbox.get({ ...this.creds, name: sandboxId });
+    // resume:false — the SDK default (true) silently RESUMES a stopped sandbox
+    // on lookup, so status checks / preview polls were waking sandboxes the
+    // user had just stopped. Resume happens only via handle.start() or lazily
+    // on the first exec (the SDK's withResume).
+    const sandbox = await Sandbox.get({
+      ...this.creds,
+      name: sandboxId,
+      resume: false,
+    });
     return new VercelSandboxHandle(sandbox, this.creds);
   }
 

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -68,21 +68,78 @@ export const startSandbox = authMutation({
       status: "starting",
       updatedAt: Date.now(),
     });
-    await workflow.start(
-      ctx,
-      internal.sessionWorkflow.sessionSandboxStartupWorkflow,
-      {
+    // Seed startup streaming immediately so the UI shows a real step instead of
+    // the random "Eva is inferring…" spinner while the workflow schedules.
+    const startupEntityId = `session-startup-${args.sessionId}`;
+    const startupActivity = JSON.stringify([
+      { type: "tool", label: "Starting sandbox...", status: "active" },
+    ]);
+    const existingStreaming = await ctx.db
+      .query("streamingActivity")
+      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
+      .first();
+    if (existingStreaming) {
+      await ctx.db.patch(existingStreaming._id, {
+        currentActivity: startupActivity,
+        currentContent: "",
+        lastUpdatedAt: Date.now(),
+      });
+    } else {
+      await ctx.db.insert("streamingActivity", {
+        entityId: startupEntityId,
+        currentActivity: startupActivity,
+        currentContent: "",
+        lastUpdatedAt: Date.now(),
+      });
+    }
+    // Prefer vercelSandboxId; fall back to sandboxId when it is a Vercel name
+    // (not a Daytona UUID). Missing vercelSandboxId used to skip reuse and
+    // create a second sandbox while still logging the old existingSandboxId.
+    const looksLikeDaytonaUuid =
+      typeof session.sandboxId === "string" &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        session.sandboxId,
+      );
+    const vercelSandboxId =
+      session.vercelSandboxId ??
+      (session.sandboxId && !looksLikeDaytonaUuid
+        ? session.sandboxId
+        : undefined);
+    console.log(
+      `[sessions] startSandbox sessionId=${args.sessionId} existingSandboxId=${session.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
+    );
+    // Vercel: schedule the start action directly. Workflow step scheduling was
+    // measured at ~6s before the first action ran — Daytona still needs the
+    // multi-step thaw workflow for archived restores.
+    if (vercelSandboxId) {
+      await ctx.scheduler.runAfter(0, internal.daytona.startSessionSandbox, {
         sessionId: args.sessionId,
         existingSandboxId: session.sandboxId,
-        vercelSandboxId: session.vercelSandboxId,
+        vercelSandboxId,
         installationId: repo.installationId,
         repoOwner: repo.owner,
         repoName: repo.name,
         branchName,
         baseBranch,
         repoId: session.repoId,
-      },
-    );
+      });
+    } else {
+      await workflow.start(
+        ctx,
+        internal.sessionWorkflow.sessionSandboxStartupWorkflow,
+        {
+          sessionId: args.sessionId,
+          existingSandboxId: session.sandboxId,
+          vercelSandboxId: session.vercelSandboxId,
+          installationId: repo.installationId,
+          repoOwner: repo.owner,
+          repoName: repo.name,
+          branchName,
+          baseBranch,
+          repoId: session.repoId,
+        },
+      );
+    }
     return null;
   },
 });
@@ -104,6 +161,10 @@ export const stopSandbox = authMutation({
     const session = await ctx.db.get(args.sessionId);
     if (!session) throw new Error("Session not found");
 
+    // Allow stop from closed when a sandboxId remains — start can early-ready
+    // then fail and leave a live Vercel VM while UI shows inactive.
+    if (session.status === "stopping") return null;
+
     if (session.sandboxId) {
       await ctx.scheduler.runAfter(
         0,
@@ -124,6 +185,15 @@ export const stopSandbox = authMutation({
       return null;
     }
 
+    // Clear leftover start steps so the chat does not re-show "Starting
+    // sandbox..." / cold-storage copy while status is stopping.
+    const startupEntityId = `session-startup-${args.sessionId}`;
+    const startupStreaming = await ctx.db
+      .query("streamingActivity")
+      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
+      .first();
+    if (startupStreaming) await ctx.db.delete(startupStreaming._id);
+
     // The "Sandbox stopped" / "Failed to stop sandbox" divider is inserted by
     // `markSandboxClosed` once Daytona's stop call settles, so the divider
     // matches the actual outcome rather than being optimistic.
@@ -138,10 +208,9 @@ export const stopSandbox = authMutation({
 });
 
 /**
- * Awaits the Daytona stop and finalizes the session status to `"closed"`.
- * Always flips status, even if Daytona errors — a stuck `"stopping"` state
- * would leave the user unable to Start. Captures any Daytona error so the
- * mutation can post a "Failed to stop sandbox" alert with full detail.
+ * Awaits provider stop and finalizes session status. Only marks `"closed"`
+ * after a successful stop — on failure reverts to `"active"` so the UI matches
+ * a still-running Vercel VM and the user can retry Stop.
  */
 export const finalizeStopSandbox = internalAction({
   args: {
@@ -169,9 +238,8 @@ export const finalizeStopSandbox = internalAction({
 });
 
 /**
- * Internal: flips session status from `"stopping"` to `"closed"` after Daytona
- * stop completes, and posts a "Sandbox stopped" (success) or "Failed to stop
- * sandbox" (with error detail) divider to the chat.
+ * Internal: after stop settles, either close the session (success) or revert
+ * to active (failure) so Eva never shows "off" while Vercel is still running.
  */
 export const markSandboxClosed = internalMutation({
   args: {
@@ -184,13 +252,28 @@ export const markSandboxClosed = internalMutation({
     if (!session) return null;
     // Only flip if still stopping — don't overwrite a fresh start.
     if (session.status !== "stopping") return null;
+    if (args.error) {
+      await ctx.db.insert("messages", {
+        parentId: args.sessionId,
+        role: "assistant",
+        content: "Failed to stop sandbox",
+        timestamp: Date.now(),
+        isSystemAlert: true,
+        errorDetail: args.error,
+      });
+      // VM is still running — keep UI active so Stop can be retried.
+      await ctx.db.patch(args.sessionId, {
+        status: "active",
+        updatedAt: Date.now(),
+      });
+      return null;
+    }
     await ctx.db.insert("messages", {
       parentId: args.sessionId,
       role: "assistant",
-      content: args.error ? "Failed to stop sandbox" : "Sandbox stopped",
+      content: "Sandbox stopped",
       timestamp: Date.now(),
       isSystemAlert: true,
-      errorDetail: args.error,
     });
     await ctx.db.patch(args.sessionId, {
       status: "closed",
@@ -216,6 +299,15 @@ export const sandboxReady = internalMutation({
   handler: async (ctx, args) => {
     const session = await ctx.db.get(args.sessionId);
     if (!session) return null;
+    // User may have clicked Stop while start/resume was still running. Never
+    // flip closed/stopping back to active — that left Vercel running with UI
+    // showing stopped, or re-activated after stop confirmation.
+    if (session.status === "stopping" || session.status === "closed") {
+      console.log(
+        `[sessions] sandboxReady ignored sessionId=${args.sessionId} status=${session.status} sandboxId=${args.sandboxId}`,
+      );
+      return null;
+    }
     // Early-ready (right after Sandbox.create) + final-ready (after services)
     // both call this. Only emit the system alert once; still patch latest
     // sandbox/dev metadata on every call.

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -133,7 +133,29 @@ export const stopSandbox = authMutation({
 
     // Allow stop from closed when a sandboxId remains — start can early-ready
     // then fail and leave a live Vercel VM while UI shows inactive.
-    if (session.status === "stopping") return null;
+    if (session.status === "stopping") {
+      // Already stopping — but a previous finalize may have stalled (e.g. its
+      // action was killed while a racing resume held the VM). Re-issue the
+      // idempotent finalize so clicking Stop again recovers a stuck `stopping`
+      // row instead of being a no-op that leaves it wedged forever.
+      if (session.sandboxId) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal._sessions.sandbox.finalizeStopSandbox,
+          {
+            sessionId: args.sessionId,
+            sandboxId: session.sandboxId,
+            repoId: session.repoId,
+          },
+        );
+      } else {
+        await ctx.db.patch(args.sessionId, {
+          status: "closed",
+          updatedAt: Date.now(),
+        });
+      }
+      return null;
+    }
 
     if (session.sandboxId) {
       await ctx.scheduler.runAfter(

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -4,6 +4,11 @@ import { internalAction, internalMutation } from "../_generated/server";
 import { authMutation } from "../functions";
 import { workflow } from "../workflowManager";
 import { FALLBACK_GIT_BASE_BRANCH } from "@conductor/shared";
+import { resolveReusableVercelSandboxId } from "../_sandbox/resolveExistingSandboxId";
+import {
+  seedSandboxStartupActivity,
+  clearSandboxStartupActivity,
+} from "../_sandbox/startupActivity";
 
 /** Updates sandbox-related fields (sandbox ID, branch, PR URL) on a session. */
 export const updateSandbox = authMutation({
@@ -70,41 +75,11 @@ export const startSandbox = authMutation({
     });
     // Seed startup streaming immediately so the UI shows a real step instead of
     // the random "Eva is inferring…" spinner while the workflow schedules.
-    const startupEntityId = `session-startup-${args.sessionId}`;
-    const startupActivity = JSON.stringify([
-      { type: "tool", label: "Starting sandbox...", status: "active" },
-    ]);
-    const existingStreaming = await ctx.db
-      .query("streamingActivity")
-      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
-      .first();
-    if (existingStreaming) {
-      await ctx.db.patch(existingStreaming._id, {
-        currentActivity: startupActivity,
-        currentContent: "",
-        lastUpdatedAt: Date.now(),
-      });
-    } else {
-      await ctx.db.insert("streamingActivity", {
-        entityId: startupEntityId,
-        currentActivity: startupActivity,
-        currentContent: "",
-        lastUpdatedAt: Date.now(),
-      });
-    }
-    // Prefer vercelSandboxId; fall back to sandboxId when it is a Vercel name
-    // (not a Daytona UUID). Missing vercelSandboxId used to skip reuse and
-    // create a second sandbox while still logging the old existingSandboxId.
-    const looksLikeDaytonaUuid =
-      typeof session.sandboxId === "string" &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        session.sandboxId,
-      );
-    const vercelSandboxId =
-      session.vercelSandboxId ??
-      (session.sandboxId && !looksLikeDaytonaUuid
-        ? session.sandboxId
-        : undefined);
+    await seedSandboxStartupActivity(
+      ctx.db,
+      `session-startup-${args.sessionId}`,
+    );
+    const vercelSandboxId = resolveReusableVercelSandboxId(session);
     console.log(
       `[sessions] startSandbox sessionId=${args.sessionId} existingSandboxId=${session.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
@@ -187,12 +162,10 @@ export const stopSandbox = authMutation({
 
     // Clear leftover start steps so the chat does not re-show "Starting
     // sandbox..." / cold-storage copy while status is stopping.
-    const startupEntityId = `session-startup-${args.sessionId}`;
-    const startupStreaming = await ctx.db
-      .query("streamingActivity")
-      .withIndex("by_entity", (q) => q.eq("entityId", startupEntityId))
-      .first();
-    if (startupStreaming) await ctx.db.delete(startupStreaming._id);
+    await clearSandboxStartupActivity(
+      ctx.db,
+      `session-startup-${args.sessionId}`,
+    );
 
     // The "Sandbox stopped" / "Failed to stop sandbox" divider is inserted by
     // `markSandboxClosed` once Daytona's stop call settles, so the divider

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -83,36 +83,31 @@ export const startSandbox = authMutation({
     console.log(
       `[sessions] startSandbox sessionId=${args.sessionId} existingSandboxId=${session.sandboxId ?? "none"} vercelSandboxId=${vercelSandboxId ?? "none"}`,
     );
+    const startArgs = {
+      sessionId: args.sessionId,
+      existingSandboxId: session.sandboxId,
+      vercelSandboxId: vercelSandboxId ?? session.vercelSandboxId,
+      installationId: repo.installationId,
+      repoOwner: repo.owner,
+      repoName: repo.name,
+      branchName,
+      baseBranch,
+      repoId: session.repoId,
+    };
     // Vercel: schedule the start action directly. Workflow step scheduling was
     // measured at ~6s before the first action ran — Daytona still needs the
     // multi-step thaw workflow for archived restores.
     if (vercelSandboxId) {
-      await ctx.scheduler.runAfter(0, internal.daytona.startSessionSandbox, {
-        sessionId: args.sessionId,
-        existingSandboxId: session.sandboxId,
-        vercelSandboxId,
-        installationId: repo.installationId,
-        repoOwner: repo.owner,
-        repoName: repo.name,
-        branchName,
-        baseBranch,
-        repoId: session.repoId,
-      });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.daytona.startSessionSandbox,
+        startArgs,
+      );
     } else {
       await workflow.start(
         ctx,
         internal.sessionWorkflow.sessionSandboxStartupWorkflow,
-        {
-          sessionId: args.sessionId,
-          existingSandboxId: session.sandboxId,
-          vercelSandboxId: session.vercelSandboxId,
-          installationId: repo.installationId,
-          repoOwner: repo.owner,
-          repoName: repo.name,
-          branchName,
-          baseBranch,
-          repoId: session.repoId,
-        },
+        startArgs,
       );
     }
     return null;

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -4,7 +4,6 @@ import { internal } from "../_generated/api";
 import { defineEvent } from "@convex-dev/workflow";
 import { workflow } from "../workflowManager";
 import { ensureSandboxStartedSteps } from "../_daytona/resumeSandboxSteps";
-import { resolveExistingSandboxId } from "../_sandbox/resolveExistingSandboxId";
 import { authMutation, hasRepoAccess } from "../functions";
 import {
   aiModelValidator,
@@ -132,8 +131,9 @@ export const sessionExecuteWorkflow = workflow.define({
       // steps first, so a multi-minute cold-storage thaw doesn't blow the
       // per-action 10-minute limit inside validateSandbox. Once started, the
       // validate below hits its fast (echo) path.
+      let started: Awaited<ReturnType<typeof ensureSandboxStartedSteps>>;
       try {
-        await ensureSandboxStartedSteps(step, {
+        started = await ensureSandboxStartedSteps(step, {
           sandboxId: data.sandboxId,
           vercelSandboxId: data.vercelSandboxId,
           repoId: data.repoId,
@@ -153,15 +153,7 @@ export const sessionExecuteWorkflow = workflow.define({
         return;
       }
 
-      const provider = await step.runAction(
-        internal.daytona.getSandboxProviderKind,
-        { repoId: data.repoId },
-      );
-      const thawId = resolveExistingSandboxId({
-        providerKind: provider,
-        sandboxId: data.sandboxId,
-        vercelSandboxId: data.vercelSandboxId,
-      });
+      const thawId = started.thawId;
       if (thawId) {
         const validation = await step.runAction(
           internal.daytona.validateSandbox,

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -63,16 +63,18 @@ export const sessionSandboxStartupWorkflow = workflow.define({
     repoId: v.id("githubRepos"),
   },
   handler: async (step, args): Promise<void> => {
-    // Thaw an archived/stopped sandbox across polling steps before the start
-    // action, so a multi-minute cold-storage restore doesn't blow the
-    // per-action 10-minute limit inside startSessionSandbox →
-    // ensureSandboxRunning.
-    if (args.existingSandboxId || args.vercelSandboxId) {
+    // Daytona-only pre-thaw: archived restores can exceed the 10-minute action
+    // limit, so poll across workflow steps first. Vercel resume is handled
+    // inside startSessionSandbox → ensureSandboxRunning; running kickoff here
+    // only added ~6–8s of workflow step-scheduling latency (measured).
+    if (args.existingSandboxId && !args.vercelSandboxId) {
       try {
         await ensureSandboxStartedSteps(step, {
           sandboxId: args.existingSandboxId,
           vercelSandboxId: args.vercelSandboxId,
           repoId: args.repoId,
+          // Must match SessionDetailClient + startSandbox seed entity.
+          streamingEntityId: `session-startup-${args.sessionId}`,
         });
       } catch (error) {
         await step.runMutation(internal.sessions.sandboxError, {

--- a/packages/backend/convex/agentTaskChatWorkflow.ts
+++ b/packages/backend/convex/agentTaskChatWorkflow.ts
@@ -4,7 +4,6 @@ import { internal } from "./_generated/api";
 import { defineEvent } from "@convex-dev/workflow";
 import { workflow, cancelTrackedWorkflow } from "./workflowManager";
 import { ensureSandboxStartedSteps } from "./_daytona/resumeSandboxSteps";
-import { resolveExistingSandboxId } from "./_sandbox/resolveExistingSandboxId";
 import { authMutation, hasRepoAccess } from "./functions";
 import {
   aiModelValidator,
@@ -235,8 +234,9 @@ export const agentTaskChatExecuteWorkflow = workflow.define({
     // Bring an archived/stopped sandbox back to "started" via durable polling
     // steps before validating, so a multi-minute cold-storage thaw doesn't blow
     // the per-action 10-minute limit. Once started, validate hits its fast path.
+    let started: Awaited<ReturnType<typeof ensureSandboxStartedSteps>>;
     try {
-      await ensureSandboxStartedSteps(step, {
+      started = await ensureSandboxStartedSteps(step, {
         sandboxId: data.sandboxId,
         vercelSandboxId: data.vercelSandboxId,
         repoId: data.repoId,
@@ -256,15 +256,7 @@ export const agentTaskChatExecuteWorkflow = workflow.define({
       return;
     }
 
-    const provider = await step.runAction(
-      internal.daytona.getSandboxProviderKind,
-      { repoId: data.repoId },
-    );
-    const activeSandboxId = resolveExistingSandboxId({
-      providerKind: provider,
-      sandboxId: data.sandboxId,
-      vercelSandboxId: data.vercelSandboxId,
-    });
+    const activeSandboxId = started.thawId;
     if (!activeSandboxId) {
       await step.runMutation(internal.agentTaskChatWorkflow.saveResult, {
         taskId: args.taskId,

--- a/packages/backend/convex/auditFixWorkflow.ts
+++ b/packages/backend/convex/auditFixWorkflow.ts
@@ -2,7 +2,6 @@ import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { workflow } from "./workflowManager";
 import { ensureSandboxStartedSteps } from "./_daytona/resumeSandboxSteps";
-import { resolveExistingSandboxId } from "./_sandbox/resolveExistingSandboxId";
 import { auditFailureValidator } from "./validators";
 
 /**
@@ -38,20 +37,12 @@ export const auditFixWorkflow = workflow.define({
     let resumeVercelSandboxId = args.vercelSandboxId;
     if (resumeSandboxId || resumeVercelSandboxId) {
       try {
-        await ensureSandboxStartedSteps(step, {
+        const started = await ensureSandboxStartedSteps(step, {
           sandboxId: resumeSandboxId,
           vercelSandboxId: resumeVercelSandboxId,
           repoId: args.repoId,
         });
-        const provider = await step.runAction(
-          internal.daytona.getSandboxProviderKind,
-          { repoId: args.repoId },
-        );
-        resumeSandboxId = resolveExistingSandboxId({
-          providerKind: provider,
-          sandboxId: resumeSandboxId,
-          vercelSandboxId: resumeVercelSandboxId,
-        });
+        resumeSandboxId = started.thawId;
       } catch {
         // Thaw exhausted its ceiling or the sandbox is gone — fall back to a
         // fresh sandbox (launchSelectedAuditFixes creates one when sandboxId is

--- a/packages/backend/convex/docs.ts
+++ b/packages/backend/convex/docs.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { authQuery, authMutation, hasRepoAccess } from "./functions";
-import { allocateNumId, entityVisible } from "./numId";
+import { allocateNumId, entityVisible, isEntityDeleted } from "./numId";
 import {
   internalMutation,
   internalQuery,
@@ -66,7 +66,7 @@ export const list = authQuery({
         const isCurrentRepo = siblingId === args.repoId;
         const isSharedRecap = doc.kind === "pr-recap";
         if (!isCurrentRepo && !isSharedRecap) continue;
-        if (doc.deletedAt !== undefined) continue;
+        if (isEntityDeleted(doc)) continue;
         seen.add(doc._id);
         docs.push(doc);
       }

--- a/packages/backend/convex/envVarResolver.ts
+++ b/packages/backend/convex/envVarResolver.ts
@@ -100,6 +100,125 @@ function readProviderKind(
 }
 
 /**
+ * Cheap provider-kind lookup for workflow thaw routing. Only decrypts the
+ * `SANDBOX_PROVIDER` key (repo overrides team) instead of the full env map —
+ * measured `getSandboxProviderKind` was spending multi-seconds decrypting
+ * every team/repo var before kickoff, which left the UI on "Eva is inferring…".
+ */
+export async function resolveSandboxProviderKind(
+  ctx: GenericActionCtx<DataModel>,
+  repoId: Id<"githubRepos">,
+): Promise<SandboxProviderKind> {
+  const startedAt = Date.now();
+  const teamId = await ctx.runQuery(internal.githubRepos.getTeamIdForRepo, {
+    repoId,
+  });
+  let kind: SandboxProviderKind = "daytona";
+  if (teamId) {
+    const teamVars = await ctx.runQuery(internal.teamEnvVars.getAllInternal, {
+      teamId,
+    });
+    const teamEntry = teamVars.find(
+      (entry) => entry.key === "SANDBOX_PROVIDER",
+    );
+    if (teamEntry && decryptValue(teamEntry.value) === "vercel") {
+      kind = "vercel";
+    }
+  }
+  const repoVars = await ctx.runQuery(internal.repoEnvVars.getAllInternal, {
+    repoId,
+  });
+  const repoEntry = repoVars.find((entry) => entry.key === "SANDBOX_PROVIDER");
+  if (repoEntry) {
+    kind = decryptValue(repoEntry.value) === "vercel" ? "vercel" : "daytona";
+  }
+  console.log(
+    `[env] resolveSandboxProviderKind repoId=${repoId} kind=${kind} elapsed=${Date.now() - startedAt}ms`,
+  );
+  return kind;
+}
+
+const CREDENTIAL_ENV_KEYS = [
+  "SANDBOX_PROVIDER",
+  "VERCEL_TOKEN",
+  "VERCEL_TEAM_ID",
+  "VERCEL_PROJECT_ID",
+  "DAYTONA_API_KEY",
+] as const;
+
+/**
+ * Decrypts only provider credential keys from an encrypted env-var list.
+ * Kickoff/thaw must not pay for decrypting the full team+repo env map.
+ */
+function decryptCredentialKeys(
+  vars: Array<{ key: string; value: string }>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of vars) {
+    for (const key of CREDENTIAL_ENV_KEYS) {
+      if (entry.key === key) {
+        out[key] = decryptValue(entry.value);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolves only the selected provider's credentials (no full sandbox env map).
+ * Used by kickoff/thaw paths that only need to call the provider SDK.
+ */
+export async function resolveSandboxCredentialsOnly(
+  ctx: GenericActionCtx<DataModel>,
+  repoId: Id<"githubRepos">,
+): Promise<SandboxCredentials> {
+  const startedAt = Date.now();
+  const teamId = await ctx.runQuery(internal.githubRepos.getTeamIdForRepo, {
+    repoId,
+  });
+  const teamVars: Record<string, string> = {};
+  if (teamId) {
+    const vars = await ctx.runQuery(internal.teamEnvVars.getAllInternal, {
+      teamId,
+    });
+    Object.assign(teamVars, decryptCredentialKeys(vars));
+  }
+  const repoVarsRaw = await ctx.runQuery(internal.repoEnvVars.getAllInternal, {
+    repoId,
+  });
+  const allVars = {
+    ...teamVars,
+    ...decryptCredentialKeys(repoVarsRaw),
+  };
+  const kind = readProviderKind(allVars);
+  if (kind === "vercel") {
+    const token = allVars.VERCEL_TOKEN;
+    const vercelTeamId = allVars.VERCEL_TEAM_ID;
+    const projectId = allVars.VERCEL_PROJECT_ID;
+    if (!token || !vercelTeamId || !projectId) {
+      throw new Error(
+        "SANDBOX_PROVIDER=vercel requires VERCEL_TOKEN, VERCEL_TEAM_ID and VERCEL_PROJECT_ID in team or repo environment variables.",
+      );
+    }
+    console.log(
+      `[env] resolveSandboxCredentialsOnly repoId=${repoId} kind=vercel elapsed=${Date.now() - startedAt}ms`,
+    );
+    return { kind: "vercel", token, teamId: vercelTeamId, projectId };
+  }
+  const apiKey = allVars.DAYTONA_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "DAYTONA_API_KEY not found in team or repo environment variables. Please add it to your team or repo env vars.",
+    );
+  }
+  console.log(
+    `[env] resolveSandboxCredentialsOnly repoId=${repoId} kind=daytona elapsed=${Date.now() - startedAt}ms`,
+  );
+  return { kind: "daytona", apiKey };
+}
+
+/**
  * Resolves the active provider and its credentials for a repo, alongside the
  * sandbox-eligible env vars passed into the sandbox. This is the single seam
  * the provider factory uses to pick Daytona vs Vercel; existing callers that

--- a/packages/backend/convex/envVarResolver.ts
+++ b/packages/backend/convex/envVarResolver.ts
@@ -110,9 +110,12 @@ export async function resolveSandboxProviderKind(
   repoId: Id<"githubRepos">,
 ): Promise<SandboxProviderKind> {
   const startedAt = Date.now();
-  const teamId = await ctx.runQuery(internal.githubRepos.getTeamIdForRepo, {
-    repoId,
-  });
+  // repoVars depends only on repoId, so fetch it alongside the team-id lookup
+  // rather than serialized behind the whole team chain.
+  const [teamId, repoVars] = await Promise.all([
+    ctx.runQuery(internal.githubRepos.getTeamIdForRepo, { repoId }),
+    ctx.runQuery(internal.repoEnvVars.getAllInternal, { repoId }),
+  ]);
   let kind: SandboxProviderKind = "daytona";
   if (teamId) {
     const teamVars = await ctx.runQuery(internal.teamEnvVars.getAllInternal, {
@@ -125,9 +128,6 @@ export async function resolveSandboxProviderKind(
       kind = "vercel";
     }
   }
-  const repoVars = await ctx.runQuery(internal.repoEnvVars.getAllInternal, {
-    repoId,
-  });
   const repoEntry = repoVars.find((entry) => entry.key === "SANDBOX_PROVIDER");
   if (repoEntry) {
     kind = decryptValue(repoEntry.value) === "vercel" ? "vercel" : "daytona";
@@ -174,9 +174,12 @@ export async function resolveSandboxCredentialsOnly(
   repoId: Id<"githubRepos">,
 ): Promise<SandboxCredentials> {
   const startedAt = Date.now();
-  const teamId = await ctx.runQuery(internal.githubRepos.getTeamIdForRepo, {
-    repoId,
-  });
+  // repoVars depends only on repoId, so fetch it alongside the team-id lookup
+  // rather than serialized behind the whole team chain.
+  const [teamId, repoVarsRaw] = await Promise.all([
+    ctx.runQuery(internal.githubRepos.getTeamIdForRepo, { repoId }),
+    ctx.runQuery(internal.repoEnvVars.getAllInternal, { repoId }),
+  ]);
   const teamVars: Record<string, string> = {};
   if (teamId) {
     const vars = await ctx.runQuery(internal.teamEnvVars.getAllInternal, {
@@ -184,9 +187,6 @@ export async function resolveSandboxCredentialsOnly(
     });
     Object.assign(teamVars, decryptCredentialKeys(vars));
   }
-  const repoVarsRaw = await ctx.runQuery(internal.repoEnvVars.getAllInternal, {
-    repoId,
-  });
   const allVars = {
     ...teamVars,
     ...decryptCredentialKeys(repoVarsRaw),

--- a/packages/backend/convex/functions.ts
+++ b/packages/backend/convex/functions.ts
@@ -22,6 +22,7 @@ import { internal } from "./_generated/api";
 import { getCurrentUserId } from "./auth";
 import type { DataModel, Doc, Id } from "./_generated/dataModel";
 import { scheduleProjectPrSync } from "./_projects/prSync";
+import { isEntityDeleted } from "./numId";
 
 /** Checks if a user has access to a repo — either as the connector or via team membership. */
 export async function hasRepoAccess(
@@ -327,7 +328,7 @@ export async function softDeleteAgentTask(
   taskId: Id<"agentTasks">,
 ): Promise<void> {
   const task = await ctx.db.get(taskId);
-  if (!task || task.deletedAt !== undefined) return;
+  if (!task || isEntityDeleted(task)) return;
   if (task.scheduledFunctionId) {
     try {
       await ctx.scheduler.cancel(task.scheduledFunctionId);

--- a/packages/backend/convex/githubWebhook.ts
+++ b/packages/backend/convex/githubWebhook.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import { notifySubscribers } from "./taskSubscribers";
 import { logTaskActivity } from "./taskActivity";
 import type { Doc } from "./_generated/dataModel";
+import { preferPersistedSandboxId } from "./_sandbox/resolveExistingSandboxId";
 import { buildProjectBranchName } from "./_projects/helpers";
 import {
   deriveProjectPhaseFromPrEvent,
@@ -242,7 +243,10 @@ export const handlePrClosed = internalMutation({
       const newPhase = args.merged ? "completed" : "cancelled";
       if (args.merged && project) {
         const nextVersion = (project.branchVersion ?? 1) + 1;
-        const deleteId = project.vercelSandboxId ?? project.sandboxId;
+        const deleteId = preferPersistedSandboxId({
+          sandboxId: project.sandboxId,
+          vercelSandboxId: project.vercelSandboxId,
+        });
         if (deleteId) {
           await ctx.scheduler.runAfter(0, internal.daytona.deleteSandbox, {
             sandboxId: deleteId,

--- a/packages/backend/convex/projectChatWorkflow.ts
+++ b/packages/backend/convex/projectChatWorkflow.ts
@@ -4,7 +4,6 @@ import { internal } from "./_generated/api";
 import { defineEvent } from "@convex-dev/workflow";
 import { workflow, cancelTrackedWorkflow } from "./workflowManager";
 import { ensureSandboxStartedSteps } from "./_daytona/resumeSandboxSteps";
-import { resolveExistingSandboxId } from "./_sandbox/resolveExistingSandboxId";
 import { authMutation, hasRepoAccess } from "./functions";
 import {
   aiModelValidator,
@@ -227,8 +226,9 @@ export const projectChatExecuteWorkflow = workflow.define({
     // Bring an archived/stopped sandbox back to "started" via durable polling
     // steps before validating, so a multi-minute cold-storage thaw doesn't blow
     // the per-action 10-minute limit. Once started, validate hits its fast path.
+    let started: Awaited<ReturnType<typeof ensureSandboxStartedSteps>>;
     try {
-      await ensureSandboxStartedSteps(step, {
+      started = await ensureSandboxStartedSteps(step, {
         sandboxId: data.sandboxId,
         vercelSandboxId: data.vercelSandboxId,
         repoId: data.repoId,
@@ -248,15 +248,7 @@ export const projectChatExecuteWorkflow = workflow.define({
       return;
     }
 
-    const provider = await step.runAction(
-      internal.daytona.getSandboxProviderKind,
-      { repoId: data.repoId },
-    );
-    const activeSandboxId = resolveExistingSandboxId({
-      providerKind: provider,
-      sandboxId: data.sandboxId,
-      vercelSandboxId: data.vercelSandboxId,
-    });
+    const activeSandboxId = started.thawId;
     if (!activeSandboxId) {
       await step.runMutation(internal.projectChatWorkflow.saveResult, {
         projectId: args.projectId,

--- a/packages/backend/convex/projectSandboxWorkflow.ts
+++ b/packages/backend/convex/projectSandboxWorkflow.ts
@@ -18,16 +18,16 @@ export const projectPreviewSandboxStartupWorkflow = workflow.define({
     forceStartupCommands: v.optional(v.boolean()),
   },
   handler: async (step, args): Promise<void> => {
-    // Thaw an archived/stopped sandbox across polling steps before the start
-    // action, so a multi-minute cold-storage restore doesn't blow the
-    // per-action 10-minute limit inside startProjectPreviewSandbox →
-    // ensureSandboxRunning.
-    if (args.existingSandboxId || args.vercelSandboxId) {
+    // Daytona-only pre-thaw (see sessionSandboxStartupWorkflow). Vercel resume
+    // runs inside startProjectPreviewSandbox — skip kickoff to avoid ~6–8s of
+    // empty workflow step latency before sandbox.start().
+    if (args.existingSandboxId && !args.vercelSandboxId) {
       try {
         await ensureSandboxStartedSteps(step, {
           sandboxId: args.existingSandboxId,
           vercelSandboxId: args.vercelSandboxId,
           repoId: args.repoId,
+          streamingEntityId: `project-sandbox-startup-${args.projectId}`,
         });
       } catch (error) {
         await step.runMutation(internal.projects.projectSandboxError, {

--- a/packages/backend/convex/taskSandboxWorkflow.ts
+++ b/packages/backend/convex/taskSandboxWorkflow.ts
@@ -18,16 +18,16 @@ export const taskPreviewSandboxStartupWorkflow = workflow.define({
     forceStartupCommands: v.optional(v.boolean()),
   },
   handler: async (step, args): Promise<void> => {
-    // Thaw an archived/stopped sandbox across polling steps before the start
-    // action, so a multi-minute cold-storage restore doesn't blow the
-    // per-action 10-minute limit inside startTaskPreviewSandbox →
-    // ensureSandboxRunning.
-    if (args.existingSandboxId || args.vercelSandboxId) {
+    // Daytona-only pre-thaw (see sessionSandboxStartupWorkflow). Vercel resume
+    // runs inside startTaskPreviewSandbox — skip kickoff to avoid ~6–8s of
+    // empty workflow step latency before sandbox.start().
+    if (args.existingSandboxId && !args.vercelSandboxId) {
       try {
         await ensureSandboxStartedSteps(step, {
           sandboxId: args.existingSandboxId,
           vercelSandboxId: args.vercelSandboxId,
           repoId: args.repoId,
+          streamingEntityId: `task-sandbox-startup-${args.taskId}`,
         });
       } catch (error) {
         await step.runMutation(internal.agentTasks.taskSandboxError, {

--- a/packages/ui/src/ai-elements/activity-tasks.tsx
+++ b/packages/ui/src/ai-elements/activity-tasks.tsx
@@ -129,25 +129,24 @@ function ActivityBlockList({
       : blocks.slice(0, MAX_VISIBLE_BLOCKS)
     : blocks;
 
+  // Streaming turns show the toggle above the list (newest kept at the
+  // bottom); settled turns show it below. Same element either way.
+  const toggle =
+    overflow > 0 ? (
+      <OverflowToggle
+        expanded={expanded}
+        overflow={overflow}
+        onToggle={() => setExpanded((v) => !v)}
+      />
+    ) : null;
+
   return (
     <>
-      {overflow > 0 && isStreaming && (
-        <OverflowToggle
-          expanded={expanded}
-          overflow={overflow}
-          onToggle={() => setExpanded((v) => !v)}
-        />
-      )}
+      {isStreaming && toggle}
       {visible.map((block, i) => (
         <ActivityBlockRow key={i} block={block} />
       ))}
-      {overflow > 0 && !isStreaming && (
-        <OverflowToggle
-          expanded={expanded}
-          overflow={overflow}
-          onToggle={() => setExpanded((v) => !v)}
-        />
-      )}
+      {!isStreaming && toggle}
     </>
   );
 }

--- a/packages/ui/src/ai-elements/activity-tasks.tsx
+++ b/packages/ui/src/ai-elements/activity-tasks.tsx
@@ -194,9 +194,18 @@ export const ActivityTasks = memo(
 
     void finalText;
 
-    const headerText = `${name ?? "Eva"} is ${verb.toLowerCase()}...${
-      startedAt ? ` (${formatElapsed(elapsed)})` : ""
-    }`;
+    // When real tool/file blocks exist, they already shimmer their own titles —
+    // don't also show the random "Eva is inferring…" header above them.
+    // When only hidden steps (thinking) remain, prefer that step's label over
+    // a random verb so sandbox startup can say "Starting sandbox..." immediately.
+    const activeStep =
+      steps.find((step) => step.status === "active") ?? steps[0];
+    const headerText =
+      blocks.length > 0
+        ? null
+        : `${
+            activeStep?.label ?? `${name ?? "Eva"} is ${verb.toLowerCase()}...`
+          }${startedAt ? ` (${formatElapsed(elapsed)})` : ""}`;
 
     // Settled turn with a known per-turn duration (P1): collapse the whole
     // turn's activity behind one "Worked for Ns" trigger, default closed.
@@ -220,14 +229,14 @@ export const ActivityTasks = memo(
 
     return (
       <div className={cn("space-y-1.5 text-sm", className)} {...props}>
-        {isStreaming && (
+        {isStreaming && headerText ? (
           <div className="flex items-center gap-2 text-muted-foreground text-sm">
             <Spinner size="sm" />
             <Shimmer as="span" duration={2.5} spread={1.5}>
               {headerText}
             </Shimmer>
           </div>
-        )}
+        ) : null}
         <ActivityBlockList blocks={blocks} isStreaming={isStreaming} />
       </div>
     );

--- a/packages/ui/src/ai-elements/queue.tsx
+++ b/packages/ui/src/ai-elements/queue.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ComponentProps, ReactNode } from "react";
-import { ChevronDownIcon, PaperclipIcon } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import {
   Collapsible,
@@ -9,26 +9,6 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import { cn } from "../utils/cn";
-
-export interface QueueMessagePart {
-  type: string;
-  text?: string;
-  url?: string;
-  filename?: string;
-  mediaType?: string;
-}
-
-export interface QueueMessage {
-  id: string;
-  parts: QueueMessagePart[];
-}
-
-export interface QueueTodo {
-  id: string;
-  title: string;
-  description?: string;
-  status?: "pending" | "completed";
-}
 
 export type QueueProps = ComponentProps<"div">;
 
@@ -176,27 +156,6 @@ export const QueueItemContent = ({
   />
 );
 
-export type QueueItemDescriptionProps = ComponentProps<"div"> & {
-  completed?: boolean;
-};
-
-export const QueueItemDescription = ({
-  completed = false,
-  className,
-  ...props
-}: QueueItemDescriptionProps) => (
-  <div
-    className={cn(
-      "ml-6 text-xs",
-      completed
-        ? "text-muted-foreground/40 line-through"
-        : "text-muted-foreground",
-      className,
-    )}
-    {...props}
-  />
-);
-
 export type QueueItemActionsProps = ComponentProps<"div">;
 
 export const QueueItemActions = ({
@@ -225,47 +184,4 @@ export const QueueItemAction = ({
     variant="ghost"
     {...props}
   />
-);
-
-export type QueueItemAttachmentProps = ComponentProps<"div">;
-
-export const QueueItemAttachment = ({
-  className,
-  ...props
-}: QueueItemAttachmentProps) => (
-  <div className={cn("mt-1 flex flex-wrap gap-2", className)} {...props} />
-);
-
-export type QueueItemImageProps = ComponentProps<"img">;
-
-export const QueueItemImage = ({
-  className,
-  ...props
-}: QueueItemImageProps) => (
-  <img
-    alt=""
-    className={cn("h-8 w-8 rounded border object-cover", className)}
-    height={32}
-    width={32}
-    {...props}
-  />
-);
-
-export type QueueItemFileProps = ComponentProps<"span">;
-
-export const QueueItemFile = ({
-  children,
-  className,
-  ...props
-}: QueueItemFileProps) => (
-  <span
-    className={cn(
-      "flex items-center gap-1 rounded border bg-muted px-2 py-1 text-xs",
-      className,
-    )}
-    {...props}
-  >
-    <PaperclipIcon size={12} />
-    <span className="max-w-[100px] truncate">{children}</span>
-  </span>
 );


### PR DESCRIPTION
## Summary
- Fix Vercel stop path: stop by session id when SDK has no attached session, poll until terminal state (up to 180s), and reissue stop while session stays running
- Only mark sessions/tasks/projects closed after confirmed stop; revert to active with error on failure instead of silent closed state
- Prevent resume/auto-restart during stop: abort startSessionSandbox and sandboxReady when stopping/closed; stop preview polling from resuming stopped sandboxes
- UI: Vercel-specific stop/resume activity copy; SessionDetailClient and ChatPanel updates

## Test plan
- [ ] Stop a single Vercel session and confirm UI stays on stopping until Eva confirms, then closed (no orphan VM in Vercel dashboard)
- [ ] Stop two+ sessions concurrently; confirm no 180s timeout and no stuck active/stopping mismatch
- [ ] Stop then wait 45s+; confirm no auto-restart or second sandbox created
- [ ] Resume a stopped session and confirm preview loads without cold-storage/Daytona-only copy on Vercel