### PR TITLE
perf(sandbox): confirm stop on first terminal status reading

### DIFF
--- a/packages/backend/convex/_daytona/sessions.ts
+++ b/packages/backend/convex/_daytona/sessions.ts
@@ -181,6 +181,49 @@ async function sessionStopRequested(
   );
 }
 
+/** True once the user has requested this task's sandbox stop/close. */
+async function taskStopRequested(
+  ctx: GenericActionCtx<DataModel>,
+  taskId: Id<"agentTasks">,
+): Promise<boolean> {
+  const task = await ctx.runQuery(internal.agentTasks.getInternal, {
+    id: taskId,
+  });
+  return (
+    !task ||
+    task.reviewTaskSandboxStatus === "stopping" ||
+    task.reviewTaskSandboxStatus === "closed"
+  );
+}
+
+/** True once the user has requested this project's sandbox stop/close. */
+async function projectStopRequested(
+  ctx: GenericActionCtx<DataModel>,
+  projectId: Id<"projects">,
+): Promise<boolean> {
+  const project = await ctx.runQuery(internal.projects.getInternal, {
+    id: projectId,
+  });
+  return (
+    !project ||
+    project.reviewProjectSandboxStatus === "stopping" ||
+    project.reviewProjectSandboxStatus === "closed"
+  );
+}
+
+/** True once the user has requested this design session's sandbox stop/close. */
+async function designStopRequested(
+  ctx: GenericActionCtx<DataModel>,
+  designSessionId: Id<"designSessions">,
+): Promise<boolean> {
+  const session = await ctx.runQuery(internal.designSessions.getInternal, {
+    id: designSessionId,
+  });
+  return (
+    !session || session.status === "stopping" || session.status === "closed"
+  );
+}
+
 /**
  * Shared resume ordering for reused sandboxes across session/task/project
  * reuse flows. Owns the drift-prone sequence so a fix lands in one place, not
@@ -1497,9 +1540,19 @@ export const startDesignSandbox = internalAction({
         // sandbox fell through to a fresh rebuild). designSandboxStartupWorkflow
         // pre-thaws archived sandboxes across polling steps first, so this
         // fast-paths instead of blocking the action on a cold-storage restore.
+        if (await designStopRequested(ctx, args.designSessionId)) {
+          throw new SandboxStartAbortedError(
+            `resume aborted: stop requested for sandbox ${handle.id}`,
+          );
+        }
         await ensureSandboxRunning(handle, {
           timeoutSeconds: ARCHIVED_SANDBOX_READY_TIMEOUT_SECONDS,
         });
+        if (await designStopRequested(ctx, args.designSessionId)) {
+          throw new SandboxStartAbortedError(
+            `resume aborted: stop requested for sandbox ${handle.id}`,
+          );
+        }
         // Self-heal: rotate the per-sandbox secret + reinstall the helper
         // before any git network op so resumed sandboxes pick up the new
         // credential flow without carrying a stale URL-embedded token.
@@ -1602,6 +1655,21 @@ export const startDesignSandbox = internalAction({
         devPort,
       });
     } catch (e) {
+      if (e instanceof SandboxStartAbortedError) {
+        console.log(
+          `[daytona][sessions] startDesignSandbox aborted by stop designSessionId=${args.designSessionId}: ${e.message}`,
+        );
+        const stopId = args.vercelSandboxId ?? args.existingSandboxId;
+        if (args.repoId && stopId) {
+          try {
+            await ctx.runAction(internal.daytona.stopSandbox, {
+              sandboxId: stopId,
+              repoId: args.repoId,
+            });
+          } catch {}
+        }
+        return null;
+      }
       if (newSandbox) {
         console.warn(
           `[daytona][sessions] deleting failed new design sandbox ${newSandbox.id}: ${errorMessage(e, "setup failed")}`,
@@ -1730,6 +1798,7 @@ async function prepareTaskPreviewSandboxInternal(
             isNew: false,
           });
         },
+        shouldAbort: () => taskStopRequested(ctx, args.taskId),
       }),
     );
     completedSteps.push({
@@ -2225,6 +2294,7 @@ async function prepareProjectPreviewSandboxInternal(
               isNew: false,
             });
           },
+          shouldAbort: () => projectStopRequested(ctx, args.projectId),
         }),
     );
     completedSteps.push({
@@ -2661,6 +2731,22 @@ export const startProjectPreviewSandbox = internalAction({
       );
       return { sandboxId: prepared.sandbox.id };
     } catch (e) {
+      if (e instanceof SandboxStartAbortedError) {
+        console.log(
+          `[daytona][sessions] startProjectPreviewSandbox aborted by stop projectId=${args.projectId}: ${e.message}`,
+        );
+        await completeProjectProgress(ctx, args.projectId);
+        const stopId = args.vercelSandboxId ?? args.existingSandboxId;
+        if (stopId) {
+          try {
+            await ctx.runAction(internal.daytona.stopSandbox, {
+              sandboxId: stopId,
+              repoId: args.repoId,
+            });
+          } catch {}
+        }
+        return { sandboxId: stopId ?? "" };
+      }
       console.error(
         `[daytona][sessions] startProjectPreviewSandbox failed after ${formatDurationMsShort(Date.now() - actionStartedAt)} (${actionDetails}): ${errorMessage(e, "Unknown error")}`,
       );
@@ -2726,6 +2812,22 @@ export const startTaskPreviewSandbox = internalAction({
         `startTaskPreviewSandbox completed in ${formatDurationMsShort(Date.now() - actionStartedAt)} (${prepared.sandboxDetails})`,
       );
     } catch (e) {
+      if (e instanceof SandboxStartAbortedError) {
+        console.log(
+          `[daytona][sessions] startTaskPreviewSandbox aborted by stop taskId=${args.taskId}: ${e.message}`,
+        );
+        await completeTaskProgress(ctx, args.taskId);
+        const stopId = args.vercelSandboxId ?? args.existingSandboxId;
+        if (stopId) {
+          try {
+            await ctx.runAction(internal.daytona.stopSandbox, {
+              sandboxId: stopId,
+              repoId: args.repoId,
+            });
+          } catch {}
+        }
+        return null;
+      }
       console.error(
         `[daytona][sessions] startTaskPreviewSandbox failed after ${formatDurationMsShort(Date.now() - actionStartedAt)} (${actionDetails}): ${errorMessage(e, "Unknown error")}`,
       );

--- a/packages/backend/convex/_designSessions/queries.ts
+++ b/packages/backend/convex/_designSessions/queries.ts
@@ -1,12 +1,22 @@
 import { v } from "convex/values";
 import { designSessionFields } from "../validators";
 import { authQuery, hasRepoAccess } from "../functions";
+import { internalQuery } from "../_generated/server";
 import { entityVisible, filterActiveEntities } from "../numId";
 
 export const designSessionValidator = v.object({
   _id: v.id("designSessions"),
   _creationTime: v.number(),
   ...designSessionFields,
+});
+
+/** Internal fetch of a design session by id (status checks in node actions). */
+export const getInternal = internalQuery({
+  args: { id: v.id("designSessions") },
+  returns: v.union(designSessionValidator, v.null()),
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
 });
 
 /** Lists active (non-archived) design sessions for a repo, sorted by most recently updated. */

--- a/packages/backend/convex/_pty/owners.ts
+++ b/packages/backend/convex/_pty/owners.ts
@@ -32,6 +32,13 @@ export interface ResolvedOwner {
   setDefaultPtyId: ((nextPtyId: string) => Promise<void>) | undefined;
   /** Stable suffix used to derive the legacy default PTY name when missing. */
   ownerIdSuffix: string;
+  /**
+   * True when the owner is `stopping`/`closed`. A terminal connect must not
+   * exec on the sandbox in this state — on Vercel any exec lazily resumes a
+   * stopped VM (SDK withResume), which resurrects a sandbox the user stopped
+   * (invisible to the session status) and defeats a manual stop.
+   */
+  isStoppingOrClosed: boolean;
 }
 
 export async function resolveOwner(
@@ -58,6 +65,8 @@ export async function resolveOwner(
         });
       },
       ownerIdSuffix: String(owner.sessionId).slice(-8),
+      isStoppingOrClosed:
+        session.status === "stopping" || session.status === "closed",
     };
   }
 
@@ -74,6 +83,9 @@ export async function resolveOwner(
       defaultPtyId: undefined,
       setDefaultPtyId: undefined,
       ownerIdSuffix: String(owner.taskId).slice(-8),
+      isStoppingOrClosed:
+        task.reviewTaskSandboxStatus === "stopping" ||
+        task.reviewTaskSandboxStatus === "closed",
     };
   }
 
@@ -88,5 +100,8 @@ export async function resolveOwner(
     defaultPtyId: undefined,
     setDefaultPtyId: undefined,
     ownerIdSuffix: String(owner.projectId).slice(-8),
+    isStoppingOrClosed:
+      project.reviewProjectSandboxStatus === "stopping" ||
+      project.reviewProjectSandboxStatus === "closed",
   };
 }

--- a/packages/backend/convex/_sandbox/vercelProvider.ts
+++ b/packages/backend/convex/_sandbox/vercelProvider.ts
@@ -493,14 +493,15 @@ class VercelSandboxHandle implements SandboxHandle {
         resolved.kind === "status" &&
         this.isTerminalStopStatus(resolved.status)
       ) {
-        consecutiveIdle += 1;
-        lastKnown = resolved.status;
-        if (consecutiveIdle >= 2) {
-          console.log(
-            `[vercel] stop confirmed sandbox=${this.sandbox.name} status=${resolved.status}`,
-          );
-          return;
-        }
+        // A terminal status reading is unambiguous — confirm on the first one.
+        // (The consecutive-read guard below is only for "empty" listSessions,
+        // which can transiently drop the session mid-stop.) Waiting for a
+        // second read added a full poll interval of UI lag after Vercel
+        // already reported stopped.
+        console.log(
+          `[vercel] stop confirmed sandbox=${this.sandbox.name} status=${resolved.status}`,
+        );
+        return;
       } else if (resolved.kind === "empty") {
         consecutiveIdle += 1;
         lastKnown = "empty";

--- a/packages/backend/convex/designSessions.ts
+++ b/packages/backend/convex/designSessions.ts
@@ -4,6 +4,7 @@ export {
   countActive,
   get,
   getByNumId,
+  getInternal,
 } from "./_designSessions/queries";
 
 export {

--- a/packages/backend/convex/pty.ts
+++ b/packages/backend/convex/pty.ts
@@ -51,6 +51,14 @@ export const connectPty = action({
     if (!identity) throw new Error("Not authenticated");
 
     const resolved = await resolveOwner(ctx, args.owner);
+    // Never open a terminal against a stopping/closed sandbox: the setup exec
+    // (ensureVercelSharedTerminal) would lazily resume a stopped Vercel VM,
+    // resurrecting a sandbox the user stopped and defeating a manual stop. A
+    // reconnecting terminal tab is what kept an idle sandbox running with no
+    // active session.
+    if (resolved.isStoppingOrClosed) {
+      throw new Error("Sandbox is not running. Start the sandbox first.");
+    }
     const { credentials } = await resolveSandboxCredentials(
       ctx,
       resolved.repoId,


### PR DESCRIPTION
waitForStopConfirmation required two consecutive terminal readings at the 1s poll before flipping the session closed, adding a poll interval of pure UI lag after Vercel already reported stopped. A terminal status reading is unambiguous — the consecutive-read guard exists only for transient empty listSessions responses, which keep the 3-read requirement. Measured: UI now flips closed in the same second Vercel reaches stopped.