### PR TITLE
fix(snapshots): rebuild base image when no app stop commands exist

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -369,6 +369,12 @@ export function SnapshotsClient({
                       </span>
                     </span>
                   </div>
+                ) : seededApps.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No seedable apps yet — configure Stop Commands on an app
+                    (Settings → App) to capture a seeded snapshot. Rebuild Now
+                    refreshes the base Image only.
+                  </p>
                 ) : (
                   <p className="text-xs text-muted-foreground">
                     Using base Image

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Snapshot build falls back to base Image when no seedable apps - 2026-07-10
+
+- Snapshot rebuild no longer errors with "No seedable apps configured"; repos without app Stop Commands rebuild the declarative base Image only, with UI copy explaining how to enable seeded snapshots.
+- Reason for change: eva prod snapshot builds failed immediately because no app repos had stop commands configured.
+
 ## Deduplicate sandbox start/resume mechanics across entity flows - 2026-07-09
 
 - Extracted `resolveReusableVercelSandboxId`, `seedSandboxStartupActivity`/`clearSandboxStartupActivity`, and `resumeReusedSandbox` so the Vercel-id fallback, startup streaming seed/clear, and reuse ordering live in one place instead of being copy-pasted across the session, task, and project sandbox flows.

--- a/packages/backend/convex/snapshotWorkflow.ts
+++ b/packages/backend/convex/snapshotWorkflow.ts
@@ -99,14 +99,16 @@ export const snapshotBuildWorkflow = workflow.define({
       internal.repoSnapshots.getPrimarySeedAppRepo,
       { repoSnapshotId: args.repoSnapshotId },
     );
-    if (!primary && !args.forceImageRebuild) {
-      await step.runMutation(internal.repoSnapshots.completeBuild, {
+    // Repos with no app stop commands cannot run the seeded-snapshot path; rebuild
+    // the declarative base Image instead (same outcome as forceImageRebuild).
+    const imageOnlyBuild = primary === null && args.forceImageRebuild !== true;
+    const rebuildBaseImage = args.forceImageRebuild === true || imageOnlyBuild;
+    if (imageOnlyBuild) {
+      await step.runMutation(internal.repoSnapshots.appendLogs, {
         buildId: args.buildId,
-        status: "error",
-        logs: "",
-        error: "No seedable apps configured for this repo",
+        chunk:
+          "No seedable apps configured (add Stop Commands on at least one app repo to enable seeded snapshots). Rebuilding base Image snapshot only.\n",
       });
-      return;
     }
     const seedableRepoIds = primary?.seedableRepoIds ?? [];
 
@@ -156,7 +158,7 @@ export const snapshotBuildWorkflow = workflow.define({
 
     // Bootstrap / toolchain path: rebuild the declarative base Image first
     // (serial — captures contending with the Image builder slow both down).
-    if (args.forceImageRebuild) {
+    if (rebuildBaseImage) {
       await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
         snapshotName: config.snapshotName,
         repoId: config.repoId,


### PR DESCRIPTION
Repos like eva had no seedable apps on prod, so snapshot builds failed immediately instead of refreshing the declarative base Image.