### PR TITLE
feat(snapshots): vercel base image snap_* builds

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -136,6 +136,8 @@ export function SnapshotsClient({
     seededApps?.find((app) => app.seededSnapshotName !== null)
       ?.seededSnapshotName ?? null;
   const hasSeedableApps = (seededApps?.length ?? 0) > 0;
+  const activeBaseSnapshotId =
+    snapshot?.baseSnapshotId ?? snapshot?.snapshotName ?? null;
   const baseImageReady =
     lastBuild?.status === "success" && !isRunning && !isSeeding;
 
@@ -267,8 +269,12 @@ export function SnapshotsClient({
           </div>
 
           <p className="text-[11px] text-muted-foreground">
-            Requires <code className="font-mono">DAYTONA_API_KEY</code> in team
-            or repo environment variables.
+            Requires sandbox provider credentials in team or repo environment
+            variables: set <code className="font-mono">SANDBOX_PROVIDER</code>{" "}
+            to <code className="font-mono">daytona</code> (
+            <code className="font-mono">DAYTONA_API_KEY</code>) or{" "}
+            <code className="font-mono">vercel</code> (
+            <code className="font-mono">VERCEL_TOKEN</code>, team, and project).
           </p>
         </TabsContent>
 
@@ -355,11 +361,13 @@ export function SnapshotsClient({
               <div className="rounded-surface border border-border bg-card p-4 space-y-3">
                 <h3 className="text-sm font-medium">Base Image</h3>
                 <p className="text-xs text-muted-foreground">
-                  Declarative snapshot with toolchain,{" "}
+                  Provider-native base snapshot with toolchain,{" "}
                   <code className="font-mono text-[11px]">pnpm install</code>,
-                  and your build commands. This is what sandboxes boot from
-                  unless a seeded snapshot exists. Rebuild Now always refreshes
-                  this — no seed file needed.
+                  and your build commands. Daytona builds a declarative Image;
+                  Vercel captures a running sandbox as{" "}
+                  <code className="font-mono text-[11px]">snap_*</code>. This is
+                  what sandboxes boot from unless a seeded snapshot exists.
+                  Rebuild Now always refreshes this — no seed file needed.
                 </p>
                 {baseImageReady ? (
                   <div className="flex items-start gap-1 text-xs text-green-500">
@@ -369,7 +377,7 @@ export function SnapshotsClient({
                         Active:
                       </span>
                       <span className="font-mono break-all text-foreground">
-                        {snapshot.snapshotName}
+                        {activeBaseSnapshotId}
                       </span>
                     </span>
                   </div>
@@ -380,6 +388,16 @@ export function SnapshotsClient({
                   </span>
                 ) : (
                   <p className="text-xs text-muted-foreground">
+                    {snapshot.baseSnapshotId ? (
+                      <>
+                        Last active:{" "}
+                        <span className="font-mono">
+                          {snapshot.baseSnapshotId}
+                        </span>
+                        {" — "}
+                      </>
+                    ) : null}
+                    Config name:{" "}
                     <span className="font-mono">{snapshot.snapshotName}</span>
                     {lastBuild?.status === "error"
                       ? " — last build failed; click Rebuild Now to retry."

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Vercel base Image snapshot builds - 2026-07-10
+
+- Rebuild Now is provider-aware: Daytona keeps the declarative Image path; when `SANDBOX_PROVIDER=vercel`, the workflow builds a fresh sandbox, runs toolchain/install/build commands, captures `snap_*`, and stores it on `repoSnapshots.baseSnapshotId` for sandbox boot.
+- Reason for change: eva on Vercel-only credentials could not rebuild its base snapshot because the image-only path always called Daytona APIs.
+
 ## Snapshot build falls back to base Image when no seedable apps - 2026-07-10
 
 - Snapshot rebuild no longer errors with "No seedable apps configured"; repos without app Stop Commands rebuild the declarative base Image only, with UI copy explaining how to enable seeded snapshots.

--- a/packages/backend/convex/_repoSnapshots/config.ts
+++ b/packages/backend/convex/_repoSnapshots/config.ts
@@ -61,6 +61,7 @@ export const getRepoSnapshot = authQuery({
       workflowRef: v.optional(v.string()),
       buildCommands: v.optional(v.array(v.string())),
       imageFingerprint: v.optional(v.string()),
+      baseSnapshotId: v.optional(v.string()),
       createdAt: v.number(),
       updatedAt: v.number(),
     }),
@@ -89,6 +90,11 @@ export const getRepoSnapshotName = internalQuery({
 
     const snapshot = await findSnapshotForRepo(ctx.db, args.repoId);
     if (!snapshot) return null;
+
+    // Vercel base Image (`snap_*`) — written by the provider-aware rebuild path.
+    if (snapshot.baseSnapshotId) {
+      return { snapshotName: snapshot.baseSnapshotId };
+    }
 
     const latestSuccessfulBuild = await ctx.db
       .query("snapshotBuilds")
@@ -385,6 +391,7 @@ export const getRepoSnapshotInternal = internalQuery({
       workflowRef: v.optional(v.string()),
       buildCommands: v.optional(v.array(v.string())),
       imageFingerprint: v.optional(v.string()),
+      baseSnapshotId: v.optional(v.string()),
     }),
     v.null(),
   ),
@@ -397,7 +404,24 @@ export const getRepoSnapshotInternal = internalQuery({
       workflowRef: doc.workflowRef,
       buildCommands: doc.buildCommands,
       imageFingerprint: doc.imageFingerprint,
+      baseSnapshotId: doc.baseSnapshotId,
     };
+  },
+});
+
+/** Stores the Vercel base Image snapshot id (`snap_*`) after a successful capture. */
+export const setBaseSnapshotId = internalMutation({
+  args: {
+    repoSnapshotId: v.id("repoSnapshots"),
+    baseSnapshotId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.repoSnapshotId, {
+      baseSnapshotId: args.baseSnapshotId,
+      updatedAt: Date.now(),
+    });
+    return null;
   },
 });
 

--- a/packages/backend/convex/repoSnapshots.ts
+++ b/packages/backend/convex/repoSnapshots.ts
@@ -12,6 +12,7 @@ export {
   setSeededSnapshotNameForAll,
   getSeedFingerprint,
   setImageFingerprint,
+  setBaseSnapshotId,
   getPrimarySeedAppRepo,
 } from "./_repoSnapshots/config";
 

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -265,6 +265,9 @@ const schema = defineSchema(
       // last successful Image build. When unchanged, the build workflow skips the
       // ~11-15m image rebuild — its output would be byte-identical.
       imageFingerprint: v.optional(v.string()),
+      // Vercel base Image capture (`snap_*`) from a running sandbox — separate
+      // from Daytona `snapshotName` and per-app `seededSnapshotName`.
+      baseSnapshotId: v.optional(v.string()),
       createdAt: v.number(),
       updatedAt: v.number(),
     }).index("by_repo", ["repoId"]),

--- a/packages/backend/convex/snapshotWorkflow.ts
+++ b/packages/backend/convex/snapshotWorkflow.ts
@@ -156,50 +156,235 @@ export const snapshotBuildWorkflow = workflow.define({
       }
     }
 
-    // Bootstrap / toolchain path: rebuild the declarative base Image first
+    // Bootstrap / toolchain path: rebuild the base Image first
     // (serial — captures contending with the Image builder slow both down).
     if (rebuildBaseImage) {
-      await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
-        snapshotName: config.snapshotName,
-        repoId: config.repoId,
-        buildId: args.buildId,
-      });
-      const kickOffResult = await step.runAction(
-        internal.snapshotActions.kickOffSnapshotBuild,
-        { buildId: args.buildId, repoSnapshotId: args.repoSnapshotId },
+      const providerKind = await step.runAction(
+        internal.daytona.getSandboxProviderKind,
+        { repoId: config.repoId },
       );
-      // Kick-off failure already recorded completeBuild(error).
-      if (!kickOffResult) return;
-      let attempt = 0;
-      let state = "";
-      while (attempt < MAX_POLLS) {
-        attempt++;
-        state = await step.runAction(
-          internal.snapshotActions.pollSnapshotProgress,
-          {
+
+      if (providerKind === "vercel") {
+        const baseSnapshotLabel = `base-${config.repoId}`;
+        let prepSandboxId: string | null = null;
+
+        if (config.baseSnapshotId) {
+          try {
+            await step.runAction(
+              internal.snapshotActions.deleteSeededSnapshot,
+              {
+                snapshotName: config.baseSnapshotId,
+                repoId: config.repoId,
+              },
+            );
+          } catch (e) {
+            console.error(
+              `[snapshot] failed to delete previous Vercel base snapshot ${config.baseSnapshotId}: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
+            );
+          }
+        }
+
+        await step.runMutation(internal.repoSnapshots.appendLogs, {
+          buildId: args.buildId,
+          chunk:
+            "Vercel base Image build: fresh sandbox → toolchain + pnpm install + build commands → snap_* capture...\n",
+        });
+
+        try {
+          const created = await step.runAction(
+            internal.snapshotActions.createSeedPrepSandbox,
+            { repoId: config.repoId, imageSnapshot: config.snapshotName },
+            { retry: { maxAttempts: 4, initialBackoffMs: 15000, base: 2 } },
+          );
+          prepSandboxId = created.sandboxId;
+
+          await step.runAction(
+            internal.daytona.fetchBaseBranch,
+            {
+              sandboxId: prepSandboxId,
+              installationId: repo.installationId,
+              repoOwner: repo.owner,
+              repoName: repo.name,
+              baseBranch: branch,
+              repoId: config.repoId,
+            },
+            { retry: { maxAttempts: 3, initialBackoffMs: 10000, base: 2 } },
+          );
+
+          await step.runAction(
+            internal.snapshotActions.launchSeedRun,
+            {
+              sandboxId: prepSandboxId,
+              repoId: config.repoId,
+              branch,
+              buildCommands: config.buildCommands ?? [],
+            },
+            { retry: { maxAttempts: 3, initialBackoffMs: 10000, base: 2 } },
+          );
+
+          let seedState = "running";
+          for (
+            let pollAttempt = 1;
+            pollAttempt <= MAX_SEED_RUN_POLLS && seedState === "running";
+            pollAttempt++
+          ) {
+            seedState = await step.runAction(
+              internal.snapshotActions.pollSeedRun,
+              { sandboxId: prepSandboxId, repoId: config.repoId },
+              { runAfter: SEED_RUN_POLL_DELAY_MS },
+            );
+          }
+          if (seedState !== "done") {
+            const diagnostics = await step.runAction(
+              internal.snapshotActions.fetchSeedDiagnostics,
+              { sandboxId: prepSandboxId, repoId: config.repoId },
+            );
+            await step.runMutation(internal.repoSnapshots.appendLogs, {
+              buildId: args.buildId,
+              chunk: `[Vercel base image] prep FAILED (${seedState}) — diagnostics:\n${diagnostics}\n`,
+            });
+            await step.runAction(
+              internal.snapshotActions.deleteSeedPrepSandbox,
+              { sandboxId: prepSandboxId, repoId: config.repoId },
+            );
+            prepSandboxId = null;
+            await step.runMutation(internal.repoSnapshots.completeBuild, {
+              buildId: args.buildId,
+              status: "error",
+              logs: "",
+              error: `Vercel base Image prep did not complete (state: ${seedState}) — see logs for diagnostics`,
+            });
+            return;
+          }
+
+          const { snapshotId: effectiveBaseId } = await step.runAction(
+            internal.snapshotActions.triggerSeededSnapshot,
+            {
+              repoId: config.repoId,
+              sandboxId: prepSandboxId,
+              seededName: baseSnapshotLabel,
+            },
+          );
+
+          let snapState = "pending";
+          for (
+            let pollAttempt = 1;
+            pollAttempt <= MAX_SEED_SNAPSHOT_POLLS &&
+            !isTerminalSnapshotState(snapState);
+            pollAttempt++
+          ) {
+            snapState = await step.runAction(
+              internal.snapshotActions.pollSeededSnapshotState,
+              { repoId: config.repoId, seededName: effectiveBaseId },
+              {
+                runAfter:
+                  pollAttempt === 1 ? 10_000 : SEED_SNAPSHOT_POLL_DELAY_MS,
+              },
+            );
+          }
+          if (snapState !== "active") {
+            await step.runAction(
+              internal.snapshotActions.deleteSeedPrepSandbox,
+              { sandboxId: prepSandboxId, repoId: config.repoId },
+            );
+            prepSandboxId = null;
+            await step.runAction(
+              internal.snapshotActions.deleteSeededSnapshot,
+              {
+                snapshotName: effectiveBaseId,
+                repoId: config.repoId,
+              },
+            );
+            await step.runMutation(internal.repoSnapshots.completeBuild, {
+              buildId: args.buildId,
+              status: "error",
+              logs: "",
+              error: `Vercel base Image did not reach active (last state: ${snapState})`,
+            });
+            return;
+          }
+
+          await step.runAction(internal.snapshotActions.deleteSeedPrepSandbox, {
+            sandboxId: prepSandboxId,
+            repoId: config.repoId,
+          });
+          prepSandboxId = null;
+
+          await step.runMutation(internal.repoSnapshots.setBaseSnapshotId, {
+            repoSnapshotId: args.repoSnapshotId,
+            baseSnapshotId: effectiveBaseId,
+          });
+          await step.runMutation(internal.repoSnapshots.completeBuild, {
             buildId: args.buildId,
-            snapshotName: kickOffResult.snapshotName,
-            repoId: kickOffResult.repoId,
-            attempt,
-          },
-          { runAfter: attempt === 1 ? 10_000 : POLL_DELAY_MS },
-        );
-        if (isTerminalSnapshotState(state)) break;
-      }
-      if (state !== "active") {
-        // pollSnapshotProgress recorded the error terminal states; timeouts
-        // need recording here. Either way there is no bootable image to seed
-        // from, so stop.
-        if (!isTerminalSnapshotState(state)) {
+            status: "success",
+            logs: `Vercel base Image ${effectiveBaseId} built successfully.\n`,
+          });
+        } catch (e) {
+          if (prepSandboxId) {
+            await step.runAction(
+              internal.snapshotActions.deleteSeedPrepSandbox,
+              {
+                sandboxId: prepSandboxId,
+                repoId: config.repoId,
+              },
+            );
+          }
           await step.runMutation(internal.repoSnapshots.completeBuild, {
             buildId: args.buildId,
             status: "error",
-            logs: `Max poll attempts (${MAX_POLLS}) reached.\n`,
+            logs: "",
             error:
-              "Snapshot build did not complete within polling window (~30 minutes)",
+              e instanceof Error
+                ? e.message
+                : "Vercel base Image build failed unexpectedly",
           });
+          return;
         }
-        return;
+      } else {
+        await step.runAction(internal.snapshotActions.deleteExistingSnapshot, {
+          snapshotName: config.snapshotName,
+          repoId: config.repoId,
+          buildId: args.buildId,
+        });
+        const kickOffResult = await step.runAction(
+          internal.snapshotActions.kickOffSnapshotBuild,
+          { buildId: args.buildId, repoSnapshotId: args.repoSnapshotId },
+        );
+        // Kick-off failure already recorded completeBuild(error).
+        if (!kickOffResult) return;
+        let attempt = 0;
+        let state = "";
+        while (attempt < MAX_POLLS) {
+          attempt++;
+          state = await step.runAction(
+            internal.snapshotActions.pollSnapshotProgress,
+            {
+              buildId: args.buildId,
+              snapshotName: kickOffResult.snapshotName,
+              repoId: kickOffResult.repoId,
+              attempt,
+            },
+            { runAfter: attempt === 1 ? 10_000 : POLL_DELAY_MS },
+          );
+          if (isTerminalSnapshotState(state)) break;
+        }
+        if (state !== "active") {
+          // pollSnapshotProgress recorded the error terminal states; timeouts
+          // need recording here. Either way there is no bootable image to seed
+          // from, so stop.
+          if (!isTerminalSnapshotState(state)) {
+            await step.runMutation(internal.repoSnapshots.completeBuild, {
+              buildId: args.buildId,
+              status: "error",
+              logs: `Max poll attempts (${MAX_POLLS}) reached.\n`,
+              error:
+                "Snapshot build did not complete within polling window (~30 minutes)",
+            });
+          }
+          return;
+        }
       }
     } else {
       await step.runMutation(internal.repoSnapshots.appendLogs, {


### PR DESCRIPTION
Rebuild Now branches on SANDBOX_PROVIDER so Vercel repos capture snap_* via toolchain/install/build instead of calling Daytona.