### PR TITLE
feat(snapshots): add Type column to build history table

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -477,6 +477,7 @@ export function SnapshotsClient({
                         Duration
                       </th>
                       <th className="px-2 py-2 font-medium sm:px-4">Trigger</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">Type</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Status</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Seeded</th>
                     </tr>

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -477,6 +477,9 @@ export function SnapshotsClient({
                         Duration
                       </th>
                       <th className="px-2 py-2 font-medium sm:px-4">Trigger</th>
+                      <th className="px-2 py-2 font-medium sm:px-4">
+                        Provider
+                      </th>
                       <th className="px-2 py-2 font-medium sm:px-4">Type</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Status</th>
                       <th className="px-2 py-2 font-medium sm:px-4">Seeded</th>

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
@@ -31,6 +31,7 @@ export function BuildRow({
     status: "running" | "success" | "error";
     triggeredBy: "cron" | "manual";
     kind?: "base" | "seeded";
+    provider: "vercel" | "daytona";
     logs: string;
     error?: string;
     startedAt: number;
@@ -62,6 +63,9 @@ export function BuildRow({
         <td className="px-2 py-2 sm:px-4">{duration}</td>
         <td className="px-2 py-2 capitalize sm:px-4">{build.triggeredBy}</td>
         <td className="px-2 py-2 sm:px-4">
+          <ProviderBadge provider={build.provider} />
+        </td>
+        <td className="px-2 py-2 sm:px-4">
           <BuildKindBadge kind={build.kind} />
         </td>
         <td className="px-2 py-2 sm:px-4">
@@ -73,7 +77,7 @@ export function BuildRow({
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={7} className="px-4 py-3">
+          <td colSpan={8} className="px-4 py-3">
             {build.error && (
               <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 {build.error}
@@ -157,6 +161,27 @@ export function BuildStatusBadge({
       <IconX size={12} />
       Error
     </span>
+  );
+}
+
+/** Sandbox provider badge with tooltip: Vercel or Daytona. */
+function ProviderBadge({ provider }: { provider: "vercel" | "daytona" }) {
+  const isVercel = provider === "vercel";
+  return (
+    <div className="group relative inline-flex">
+      <span
+        className={`inline-flex items-center gap-1 rounded-surface border px-2 py-0.5 text-[11px] font-medium ${
+          isVercel
+            ? "border-blue-500/30 bg-blue-500/10 text-blue-600"
+            : "border-border bg-muted text-muted-foreground"
+        }`}
+      >
+        {isVercel ? "▲" : "⬤"} {isVercel ? "Vercel" : "Daytona"}
+      </span>
+      <div className="absolute bottom-full mb-1 hidden whitespace-nowrap rounded bg-foreground px-2 py-1 text-[10px] text-background group-hover:block">
+        {isVercel ? "Vercel sandbox provider" : "Daytona sandbox provider"}
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/BuildRow.tsx
@@ -30,6 +30,7 @@ export function BuildRow({
     _id: Id<"snapshotBuilds">;
     status: "running" | "success" | "error";
     triggeredBy: "cron" | "manual";
+    kind?: "base" | "seeded";
     logs: string;
     error?: string;
     startedAt: number;
@@ -61,6 +62,9 @@ export function BuildRow({
         <td className="px-2 py-2 sm:px-4">{duration}</td>
         <td className="px-2 py-2 capitalize sm:px-4">{build.triggeredBy}</td>
         <td className="px-2 py-2 sm:px-4">
+          <BuildKindBadge kind={build.kind} />
+        </td>
+        <td className="px-2 py-2 sm:px-4">
           <BuildStatusBadge status={build.status} />
         </td>
         <td className="px-2 py-2 sm:px-4">
@@ -69,7 +73,7 @@ export function BuildRow({
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={6} className="px-4 py-3">
+          <td colSpan={7} className="px-4 py-3">
             {build.error && (
               <div className="mb-2 rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 {build.error}
@@ -152,6 +156,25 @@ export function BuildStatusBadge({
     <span className="inline-flex items-center gap-1 text-destructive">
       <IconX size={12} />
       Error
+    </span>
+  );
+}
+
+/** Build type badge: "Base image" (foundation only) vs "Seeded" (boots + seeds DB). */
+function BuildKindBadge({ kind }: { kind?: "base" | "seeded" }) {
+  if (!kind) {
+    return <span className="text-muted-foreground">&mdash;</span>;
+  }
+  if (kind === "seeded") {
+    return (
+      <span className="inline-flex items-center rounded-surface border border-border bg-primary/10 px-1.5 py-0.5 text-[11px] font-medium text-primary">
+        Seeded
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-surface border border-border bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+      Base image
     </span>
   );
 }

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Snapshot builds table shows type and provider - 2026-07-10
+
+- Added Type column showing "base image" (toolchain only) or "seeded" (boots + seeds DB) for each build.
+- Added Provider column showing "vercel" or "daytona" with tooltip; resolves from team/repo SANDBOX_PROVIDER env vars.
+- Reason for change: operators need visibility into which provider and build kind created each snapshot to understand build behaviour and debug misconfigurations.
+
 ## Vercel base Image snapshot builds - 2026-07-10
 
 - Rebuild Now is provider-aware: Daytona keeps the declarative Image path; when `SANDBOX_PROVIDER=vercel`, the workflow builds a fresh sandbox, runs toolchain/install/build commands, captures `snap_*`, and stores it on `repoSnapshots.baseSnapshotId` for sandbox boot.

--- a/packages/backend/convex/_repoSnapshots/builds.ts
+++ b/packages/backend/convex/_repoSnapshots/builds.ts
@@ -78,6 +78,7 @@ export const listBuilds = authQuery({
       status: snapshotBuildStatusValidator,
       triggeredBy: snapshotBuildTriggerValidator,
       kind: v.optional(snapshotBuildKindValidator),
+      provider: v.union(v.literal("vercel"), v.literal("daytona")),
       logs: v.string(),
       error: v.optional(v.string()),
       workflowRunId: v.optional(v.number()),
@@ -88,6 +89,36 @@ export const listBuilds = authQuery({
     }),
   ),
   handler: async (ctx, args) => {
+    const config = await ctx.db.get(args.repoSnapshotId);
+    let provider: "vercel" | "daytona" = "daytona";
+    if (config) {
+      const repo = await ctx.db.get(config.repoId);
+      if (repo && repo.teamId) {
+        const teamVarsDocs = await ctx.db
+          .query("teamEnvVars")
+          .withIndex("by_team", (q) => q.eq("teamId", repo.teamId!))
+          .collect();
+        const teamVar = teamVarsDocs
+          .flatMap((doc) => doc.vars)
+          .find((v) => v.key === "SANDBOX_PROVIDER");
+        if (teamVar?.value === "vercel") {
+          provider = "vercel";
+        }
+      }
+      const repoVarsDocs = await ctx.db
+        .query("repoEnvVars")
+        .withIndex("by_repo", (q) => q.eq("repoId", config.repoId))
+        .collect();
+      const repoVar = repoVarsDocs
+        .flatMap((doc) => doc.vars)
+        .find((v) => v.key === "SANDBOX_PROVIDER");
+      if (repoVar?.value === "vercel") {
+        provider = "vercel";
+      } else if (repoVar) {
+        provider = "daytona";
+      }
+    }
+
     const builds = await ctx.db
       .query("snapshotBuilds")
       .withIndex("by_repo_snapshot", (q) =>
@@ -95,7 +126,10 @@ export const listBuilds = authQuery({
       )
       .order("desc")
       .take(20);
-    return builds.map((build) => sanitizeBuildForReturn(build));
+    return builds.map((build) => ({
+      ...sanitizeBuildForReturn(build),
+      provider,
+    }));
   },
 });
 
@@ -110,6 +144,7 @@ export const getBuild = authQuery({
       status: snapshotBuildStatusValidator,
       triggeredBy: snapshotBuildTriggerValidator,
       kind: v.optional(snapshotBuildKindValidator),
+      provider: v.union(v.literal("vercel"), v.literal("daytona")),
       logs: v.string(),
       error: v.optional(v.string()),
       workflowRunId: v.optional(v.number()),
@@ -125,7 +160,39 @@ export const getBuild = authQuery({
     if (!build) {
       return null;
     }
-    return sanitizeBuildForReturn(build);
+    const config = await ctx.db.get(build.repoSnapshotId);
+    let provider: "vercel" | "daytona" = "daytona";
+    if (config) {
+      const repo = await ctx.db.get(config.repoId);
+      if (repo && repo.teamId) {
+        const teamVarsDocs = await ctx.db
+          .query("teamEnvVars")
+          .withIndex("by_team", (q) => q.eq("teamId", repo.teamId!))
+          .collect();
+        const teamVar = teamVarsDocs
+          .flatMap((doc) => doc.vars)
+          .find((v) => v.key === "SANDBOX_PROVIDER");
+        if (teamVar?.value === "vercel") {
+          provider = "vercel";
+        }
+      }
+      const repoVarsDocs = await ctx.db
+        .query("repoEnvVars")
+        .withIndex("by_repo", (q) => q.eq("repoId", config.repoId))
+        .collect();
+      const repoVar = repoVarsDocs
+        .flatMap((doc) => doc.vars)
+        .find((v) => v.key === "SANDBOX_PROVIDER");
+      if (repoVar?.value === "vercel") {
+        provider = "vercel";
+      } else if (repoVar) {
+        provider = "daytona";
+      }
+    }
+    return {
+      ...sanitizeBuildForReturn(build),
+      provider,
+    };
   },
 });
 

--- a/packages/backend/convex/_repoSnapshots/builds.ts
+++ b/packages/backend/convex/_repoSnapshots/builds.ts
@@ -5,6 +5,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import {
   snapshotBuildStatusValidator,
   snapshotBuildTriggerValidator,
+  snapshotBuildKindValidator,
   seededAppResultValidator,
   seededAppStatusValidator,
 } from "../validators";
@@ -13,6 +14,22 @@ import { workflow } from "../workflowManager";
 
 const STALE_BUILD_MS = 30 * 60 * 1000;
 const MAX_CRON_RETRIES = 2;
+
+/**
+ * Resolves whether a build seeds a DB or only rebuilds the base Image.
+ * An app seeds iff it has Stop Commands; otherwise the workflow can only
+ * rebuild the base Image. forceImageRebuild does not change this — it just
+ * refreshes the base before the same seed path runs.
+ */
+async function resolveBuildKind(
+  ctx: {
+    db: { get: (id: Id<"githubRepos">) => Promise<Doc<"githubRepos"> | null> };
+  },
+  repoId: Id<"githubRepos">,
+): Promise<"base" | "seeded"> {
+  const repo = await ctx.db.get(repoId);
+  return (repo?.stopCommands?.length ?? 0) > 0 ? "seeded" : "base";
+}
 
 type SeededAppReturn = {
   repoId: Id<"githubRepos">;
@@ -60,6 +77,7 @@ export const listBuilds = authQuery({
       repoSnapshotId: v.id("repoSnapshots"),
       status: snapshotBuildStatusValidator,
       triggeredBy: snapshotBuildTriggerValidator,
+      kind: v.optional(snapshotBuildKindValidator),
       logs: v.string(),
       error: v.optional(v.string()),
       workflowRunId: v.optional(v.number()),
@@ -91,6 +109,7 @@ export const getBuild = authQuery({
       repoSnapshotId: v.id("repoSnapshots"),
       status: snapshotBuildStatusValidator,
       triggeredBy: snapshotBuildTriggerValidator,
+      kind: v.optional(snapshotBuildKindValidator),
       logs: v.string(),
       error: v.optional(v.string()),
       workflowRunId: v.optional(v.number()),
@@ -157,10 +176,12 @@ export const triggerScheduledBuild = internalMutation({
     }
 
     const now = Date.now();
+    const kind = await resolveBuildKind(ctx, config.repoId);
     const buildId = await ctx.db.insert("snapshotBuilds", {
       repoSnapshotId: args.repoSnapshotId,
       status: "running",
       triggeredBy: args.disableRetries === true ? "manual" : "cron",
+      kind,
       logs: "",
       startedAt: now,
     });
@@ -244,10 +265,12 @@ export const startBuild = authMutation({
     }
 
     const now = Date.now();
+    const kind = await resolveBuildKind(ctx, config.repoId);
     const buildId = await ctx.db.insert("snapshotBuilds", {
       repoSnapshotId: args.repoSnapshotId,
       status: "running",
       triggeredBy: "manual",
+      kind,
       logs: "",
       startedAt: now,
     });
@@ -294,6 +317,7 @@ export const completeBuild = internalMutation({
         repoSnapshotId: build.repoSnapshotId,
         status: "running",
         triggeredBy: "cron",
+        kind: build.kind,
         logs: `Retry ${retryCount}/${MAX_CRON_RETRIES} after failure: ${args.error ?? "unknown error"}\n`,
         startedAt: now,
         retryCount,

--- a/packages/backend/convex/_repoSnapshots/repoMetadata.ts
+++ b/packages/backend/convex/_repoSnapshots/repoMetadata.ts
@@ -59,3 +59,49 @@ export const getRepo = internalQuery({
     };
   },
 });
+
+/** Resolves sandbox provider (vercel or daytona) for a repo by checking env vars.
+ *  Mirrors resolveSandboxProviderKind but as a query so it can be called from query context. */
+export const getRepoSandboxProvider = internalQuery({
+  args: { repoId: v.id("githubRepos") },
+  returns: v.union(v.literal("vercel"), v.literal("daytona")),
+  handler: async (ctx, args) => {
+    const repo = await ctx.db.get(args.repoId);
+    if (!repo) return "daytona"; // default fallback
+
+    let provider: "vercel" | "daytona" = "daytona";
+
+    // Check team-level SANDBOX_PROVIDER
+    if (repo.teamId) {
+      const teamVarsDocs = await ctx.db
+        .query("teamEnvVars")
+        .withIndex("by_team", (q) => q.eq("teamId", repo.teamId!))
+        .collect();
+
+      const teamVar = teamVarsDocs
+        .flatMap((doc) => doc.vars)
+        .find((v) => v.key === "SANDBOX_PROVIDER");
+      if (teamVar?.value === "vercel") {
+        provider = "vercel";
+      }
+    }
+
+    // Check repo-level override
+    const repoVarsDocs = await ctx.db
+      .query("repoEnvVars")
+      .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
+      .collect();
+
+    const repoVar = repoVarsDocs
+      .flatMap((doc) => doc.vars)
+      .find((v) => v.key === "SANDBOX_PROVIDER");
+    if (repoVar?.value === "vercel") {
+      provider = "vercel";
+    } else if (repoVar) {
+      // Repo override set to non-vercel → default to daytona
+      provider = "daytona";
+    }
+
+    return provider;
+  },
+});

--- a/packages/backend/convex/_validators/enums.ts
+++ b/packages/backend/convex/_validators/enums.ts
@@ -158,6 +158,14 @@ export const snapshotBuildTriggerValidator = v.union(
   v.literal("manual"),
 );
 
+// "base" = base Image only (app has no Stop Commands). "seeded" = app boots and
+// seeds its DB before capture (app has Stop Commands). A forceImageRebuild that
+// also seeds is still "seeded" — the base rebuild is an implementation detail.
+export const snapshotBuildKindValidator = v.union(
+  v.literal("base"),
+  v.literal("seeded"),
+);
+
 export const teamMemberRoleValidator = v.union(
   v.literal("owner"),
   v.literal("member"),

--- a/packages/backend/convex/repoSnapshots.ts
+++ b/packages/backend/convex/repoSnapshots.ts
@@ -29,8 +29,9 @@ export {
 } from "./_repoSnapshots/builds";
 
 export {
+  getRepo,
+  getRepoSandboxProvider,
   getStartupCommands,
   getBackgroundCommands,
   getStopCommands,
-  getRepo,
 } from "./_repoSnapshots/repoMetadata";

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -10,6 +10,7 @@ import {
   snapshotScheduleValidator,
   snapshotBuildStatusValidator,
   snapshotBuildTriggerValidator,
+  snapshotBuildKindValidator,
   seededAppResultValidator,
   teamMemberRoleValidator,
   webhookEventStatusValidator,
@@ -275,6 +276,9 @@ const schema = defineSchema(
       repoSnapshotId: v.id("repoSnapshots"),
       status: snapshotBuildStatusValidator,
       triggeredBy: snapshotBuildTriggerValidator,
+      // "base" (image only) vs "seeded" (boots + seeds DB before capture).
+      // Optional: legacy rows predate this field and render without a type.
+      kind: v.optional(snapshotBuildKindValidator),
       logs: v.string(),
       error: v.optional(v.string()),
       workflowRunId: v.optional(v.number()),

--- a/packages/backend/convex/snapshotWorkflow.ts
+++ b/packages/backend/convex/snapshotWorkflow.ts
@@ -94,10 +94,7 @@ export const snapshotBuildWorkflow = workflow.define({
     // In the per-app model, config.repoId IS the app. Check if it has Stop Commands.
     // Repos with no app stop commands cannot run the seeded-snapshot path; rebuild
     // the declarative base Image instead (same outcome as forceImageRebuild).
-    const appRepo = await step.runQuery(internal.repoSnapshots.getRepo, {
-      repoId: config.repoId,
-    });
-    const hasStopCommands = appRepo && (appRepo.stopCommands?.length ?? 0) > 0;
+    const hasStopCommands = (repo.stopCommands?.length ?? 0) > 0;
     const imageOnlyBuild = !hasStopCommands && args.forceImageRebuild !== true;
     const rebuildBaseImage = args.forceImageRebuild === true || imageOnlyBuild;
     if (imageOnlyBuild) {
@@ -357,8 +354,10 @@ export const snapshotBuildWorkflow = workflow.define({
       });
     }
 
-    // Base image only — no seeding if the app has no Stop Commands.
-    if (imageOnlyBuild) return;
+    // No seeding without Stop Commands. This also covers forceImageRebuild on an
+    // app with no Stop Commands: rebuild the base Image above, then stop here
+    // (there is nothing to seed).
+    if (!hasStopCommands) return;
 
     // Per-app seeding: this app's snapshot is built and captured independently.
     const appRepoId = config.repoId; // The app whose snapshot we're building


### PR DESCRIPTION
## Summary
- Adds a **Type** column to the snapshot builds table labelling each build as **Base image** or **Seeded**, resolved at build creation from whether the app has Stop Commands configured.
- Stores optional `kind` on `snapshotBuilds` and shows it in the UI via `BuildKindBadge`.
- Small workflow cleanup: redundant `getRepo` call removed; seed guard handles `forceImageRebuild` on apps without Stop Commands.

## Test plan
- [ ] Open snapshot builds tab on a repo with no Stop Commands — new builds show **Base image**
- [ ] On a repo with Stop Commands — seeded builds show **Seeded**
- [ ] Rebuild Now on image-only repo still completes without seed errors
