### PR TITLE
feat(chat): session-wide reasoning lever for sandbox chats

### DIFF
--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -14,6 +14,7 @@ import {
   PromptInputSpeech,
   PromptInputSubmit,
   ModelSelect,
+  ReasoningLever,
   usePromptInputController,
   type PromptInputMessage,
   type ModelOption,
@@ -33,7 +34,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useMutation } from "convex/react";
-import { api, type AIModel } from "@conductor/backend";
+import {
+  api,
+  getAIModelProvider,
+  providerSupportsReasoning,
+  REASONING_LEVELS,
+  type AIModel,
+  type ReasoningLevel,
+} from "@conductor/backend";
 import type { Doc, Id } from "@conductor/backend";
 import { ScreenshotPreview, VideoPreview } from "@/lib/components/MediaPreview";
 import { MessageMentionText } from "@/lib/components/chat/MessageMentionText";
@@ -60,6 +68,18 @@ export type ChatBodyMessage = Doc<"messages"> & {
 };
 
 export type ChatBodyQueuedMessage = Doc<"queuedMessages">;
+
+const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
+  off: "Off",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  max: "Max",
+};
+const REASONING_LEVEL_OPTIONS = REASONING_LEVELS.map((value) => ({
+  value,
+  label: REASONING_LEVEL_LABELS[value],
+}));
 
 interface ParsedQuestion {
   question: string;
@@ -126,6 +146,13 @@ interface ChatBodyProps {
   model: AIModel;
   setModel: (model: AIModel) => void;
   modelOptions: ReadonlyArray<ModelOption<AIModel>>;
+  /**
+   * Session-wide reasoning effort. When both the level and setter are provided
+   * and the selected model's provider supports a runtime lever (Claude/Codex),
+   * a reasoning lever is shown next to the model selector.
+   */
+  reasoningLevel?: ReasoningLevel;
+  onReasoningLevelChange?: (level: ReasoningLevel) => void;
   /** Called with the tokenized content. Caller decides whether to send or enqueue. */
   onSend: (content: string) => Promise<void>;
   onCancel: () => Promise<void>;
@@ -176,6 +203,8 @@ export function ChatBody({
   model,
   setModel,
   modelOptions,
+  reasoningLevel,
+  onReasoningLevelChange,
   onSend,
   onCancel,
   preConversationContent,
@@ -540,6 +569,15 @@ export function ChatBody({
                   <PromptInputFooter>
                     <PromptInputTools>{toolsBefore}</PromptInputTools>
                     <div className="flex min-w-0 items-center gap-1">
+                      {onReasoningLevelChange &&
+                      reasoningLevel &&
+                      providerSupportsReasoning(getAIModelProvider(model)) ? (
+                        <ReasoningLever
+                          value={reasoningLevel}
+                          options={REASONING_LEVEL_OPTIONS}
+                          onValueChange={onReasoningLevelChange}
+                        />
+                      ) : null}
                       <ModelSelect
                         value={model}
                         options={modelOptions}

--- a/apps/web/src/lib/components/projects/ProjectSandboxChatPanel.tsx
+++ b/apps/web/src/lib/components/projects/ProjectSandboxChatPanel.tsx
@@ -7,10 +7,12 @@ import { useLocalStorage } from "usehooks-ts";
 import {
   api,
   DEFAULT_AI_MODEL,
+  DEFAULT_REASONING_LEVEL,
   findAIModelOption,
   normalizeAIModel,
   type AIModel,
   type Id,
+  type ReasoningLevel,
 } from "@conductor/backend";
 import {
   ChatBody,
@@ -21,6 +23,7 @@ import { useAvailableAiModels } from "@/lib/hooks/useAvailableAiModels";
 
 interface StoredSettings {
   model: AIModel;
+  reasoningLevel: ReasoningLevel;
 }
 
 function chatSettingsKey(parentId: string) {
@@ -54,14 +57,21 @@ export function ProjectSandboxChatPanel({
   const defaultModel = normalizeAIModel(repo.defaultModel ?? DEFAULT_AI_MODEL);
   const [settings, setSettings] = useLocalStorage<StoredSettings>(
     chatSettingsKey(projectId),
-    { model: defaultModel },
+    { model: defaultModel, reasoningLevel: DEFAULT_REASONING_LEVEL },
   );
   const model = normalizeAIModel(settings.model);
+  const reasoningLevel = settings.reasoningLevel ?? DEFAULT_REASONING_LEVEL;
   const { options: modelOptions } = useAvailableAiModels(repo._id, model);
 
   const setModel = useCallback(
     (next: AIModel) =>
       setSettings((prev) => ({ ...prev, model: normalizeAIModel(next) })),
+    [setSettings],
+  );
+
+  const setReasoningLevel = useCallback(
+    (next: ReasoningLevel) =>
+      setSettings((prev) => ({ ...prev, reasoningLevel: next })),
     [setSettings],
   );
 
@@ -78,6 +88,7 @@ export function ProjectSandboxChatPanel({
           projectId,
           message: content,
           model,
+          reasoningLevel,
         });
         return;
       }
@@ -86,9 +97,18 @@ export function ProjectSandboxChatPanel({
         projectId,
         message: content,
         model,
+        reasoningLevel,
       });
     },
-    [isExecuting, enqueueMessage, addMessage, startExecute, projectId, model],
+    [
+      isExecuting,
+      enqueueMessage,
+      addMessage,
+      startExecute,
+      projectId,
+      model,
+      reasoningLevel,
+    ],
   );
 
   const handleCancel = useCallback(async () => {
@@ -128,6 +148,8 @@ export function ProjectSandboxChatPanel({
         model={model}
         setModel={setModel}
         modelOptions={modelOptions}
+        reasoningLevel={reasoningLevel}
+        onReasoningLevelChange={setReasoningLevel}
         onSend={handleSend}
         onCancel={handleCancel}
         formatQueuedInfo={formatQueuedInfo}

--- a/apps/web/src/lib/components/tasks/TaskSandboxChatPanel.tsx
+++ b/apps/web/src/lib/components/tasks/TaskSandboxChatPanel.tsx
@@ -7,10 +7,12 @@ import { useLocalStorage } from "usehooks-ts";
 import {
   api,
   DEFAULT_AI_MODEL,
+  DEFAULT_REASONING_LEVEL,
   findAIModelOption,
   normalizeAIModel,
   type AIModel,
   type Id,
+  type ReasoningLevel,
 } from "@conductor/backend";
 import {
   ChatBody,
@@ -21,6 +23,7 @@ import { useAvailableAiModels } from "@/lib/hooks/useAvailableAiModels";
 
 interface StoredSettings {
   model: AIModel;
+  reasoningLevel: ReasoningLevel;
 }
 
 function chatSettingsKey(parentId: string) {
@@ -56,14 +59,21 @@ export function TaskSandboxChatPanel({
   const defaultModel = normalizeAIModel(repo.defaultModel ?? DEFAULT_AI_MODEL);
   const [settings, setSettings] = useLocalStorage<StoredSettings>(
     chatSettingsKey(taskId),
-    { model: defaultModel },
+    { model: defaultModel, reasoningLevel: DEFAULT_REASONING_LEVEL },
   );
   const model = normalizeAIModel(settings.model);
+  const reasoningLevel = settings.reasoningLevel ?? DEFAULT_REASONING_LEVEL;
   const { options: modelOptions } = useAvailableAiModels(repo._id, model);
 
   const setModel = useCallback(
     (next: AIModel) =>
       setSettings((prev) => ({ ...prev, model: normalizeAIModel(next) })),
+    [setSettings],
+  );
+
+  const setReasoningLevel = useCallback(
+    (next: ReasoningLevel) =>
+      setSettings((prev) => ({ ...prev, reasoningLevel: next })),
     [setSettings],
   );
 
@@ -80,6 +90,7 @@ export function TaskSandboxChatPanel({
           taskId,
           message: content,
           model,
+          reasoningLevel,
         });
         return;
       }
@@ -88,9 +99,18 @@ export function TaskSandboxChatPanel({
         taskId,
         message: content,
         model,
+        reasoningLevel,
       });
     },
-    [isExecuting, enqueueMessage, addMessage, startExecute, taskId, model],
+    [
+      isExecuting,
+      enqueueMessage,
+      addMessage,
+      startExecute,
+      taskId,
+      model,
+      reasoningLevel,
+    ],
   );
 
   const handleCancel = useCallback(async () => {
@@ -130,6 +150,8 @@ export function TaskSandboxChatPanel({
         model={model}
         setModel={setModel}
         modelOptions={modelOptions}
+        reasoningLevel={reasoningLevel}
+        onReasoningLevelChange={setReasoningLevel}
         onSend={handleSend}
         onCancel={handleCancel}
         formatQueuedInfo={formatQueuedInfo}

--- a/apps/web/src/lib/hooks/useSessionSettings.ts
+++ b/apps/web/src/lib/hooks/useSessionSettings.ts
@@ -4,8 +4,10 @@ import { useCallback } from "react";
 import { useLocalStorage } from "usehooks-ts";
 import {
   DEFAULT_AI_MODEL,
+  DEFAULT_REASONING_LEVEL,
   normalizeAIModel,
   type AIModel,
+  type ReasoningLevel,
 } from "@conductor/backend";
 
 const SESSION_MODES = ["edit", "plan"] as const;
@@ -21,11 +23,13 @@ function normalizeMode(mode: string): SessionMode {
 interface StoredSettings {
   model: AIModel;
   mode: SessionMode;
+  reasoningLevel: ReasoningLevel;
 }
 
 const DEFAULT_SETTINGS: StoredSettings = {
   model: DEFAULT_AI_MODEL,
   mode: "edit",
+  reasoningLevel: DEFAULT_REASONING_LEVEL,
 };
 
 function storageKey(sessionId: string) {
@@ -59,10 +63,19 @@ export function useSessionSettings(
     [setSettings],
   );
 
+  const setReasoningLevel = useCallback(
+    (reasoningLevel: ReasoningLevel) => {
+      setSettings((prev) => ({ ...prev, reasoningLevel }));
+    },
+    [setSettings],
+  );
+
   return {
     model: normalizeAIModel(settings.model),
     mode: normalizeMode(settings.mode),
+    reasoningLevel: settings.reasoningLevel ?? DEFAULT_REASONING_LEVEL,
     setModel,
     setMode,
+    setReasoningLevel,
   };
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
@@ -151,9 +151,10 @@ export function ChatPanel({
   const [completedAudits, setCompletedAudits] = useState(0);
 
   const defaultModel = normalizeAIModel(repo.defaultModel);
-  const { mode, setMode, model, setModel } = useSessionSettings(sessionId, {
-    defaultModel,
-  });
+  const { mode, setMode, model, setModel, reasoningLevel, setReasoningLevel } =
+    useSessionSettings(sessionId, {
+      defaultModel,
+    });
   const { options: modelOptions } = useAvailableAiModels(repo._id, model);
 
   const draftSeed = useChatDraftSeed({
@@ -251,6 +252,7 @@ export function ChatPanel({
           message: content,
           mode,
           model,
+          reasoningLevel,
         });
         return;
       }
@@ -263,7 +265,13 @@ export function ChatPanel({
       // rows arrive (on success OR error).
       void Promise.all([
         addMessage({ id: sessionId, role: "user", content, mode }),
-        startExecution({ sessionId, message: content, mode, model }),
+        startExecution({
+          sessionId,
+          message: content,
+          mode,
+          model,
+          reasoningLevel,
+        }),
       ]).catch(async (error) => {
         const errorMessage =
           error instanceof Error ? error.message : "Failed to send message";
@@ -283,6 +291,7 @@ export function ChatPanel({
       sessionId,
       mode,
       model,
+      reasoningLevel,
     ],
   );
 
@@ -624,6 +633,8 @@ export function ChatPanel({
         model={model}
         setModel={setModel}
         modelOptions={modelOptions}
+        reasoningLevel={reasoningLevel}
+        onReasoningLevelChange={setReasoningLevel}
         onSend={handleSend}
         onCancel={handleCancel}
         formatQueuedInfo={formatQueuedInfo}

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Session-wide reasoning/thinking lever for sandbox chats - 2026-07-10
+
+- Added a reasoning-effort lever (Off/Low/Med/High/Max slider in a toolbar popover) to session, task, and project sandbox chats so users can tune how hard the agent thinks; the level persists per-chat and applies to every message.
+- The lever only shows for Claude and Codex, which expose a runtime control; it is hidden for Cursor (reasoning baked into the model id) and Opencode (no runtime lever).
+- One abstract level is threaded to the sandbox and mapped per provider — Claude via `MAX_THINKING_TOKENS`, Codex via `model_reasoning_effort` — and folded into the session daemon signature so changing it mid-session respawns the daemon.
+
 ## Vercel session preview for non-3000 ports (Vite 5173) - 2026-07-10
 
 - Vercel app/dev preview now always fronts the real listen port through the reserved auth proxy on 54321, so Vite (and any non-3000) sessions no longer call `sandbox.domain(5173)` and hit "No route for port".

--- a/packages/backend/callback-src/config.ts
+++ b/packages/backend/callback-src/config.ts
@@ -169,6 +169,41 @@ process.env.GH_NO_UPDATE_NOTIFIER = "1";
 
 export const REPO_ID = process.env.REPO_ID;
 
+// --- Reasoning / thinking effort ---
+// `AI_REASONING_EFFORT` is the abstract, provider-neutral level set on the chat
+// input lever (off|low|medium|high|max). Each provider is configured from it:
+//   - Claude: MAX_THINKING_TOKENS env (read by the CLI and the Agent SDK alike).
+//   - Codex: `model_reasoning_effort` in config.toml (see codexSession.ts).
+// Providers without a runtime lever (Cursor, Opencode) ignore it entirely.
+export const REASONING_EFFORT = process.env.AI_REASONING_EFFORT || "";
+
+const CLAUDE_THINKING_BUDGET: Record<string, string> = {
+  off: "0",
+  low: "4000",
+  medium: "10000",
+  high: "24000",
+  max: "31999",
+};
+
+const CODEX_REASONING_EFFORT: Record<string, string> = {
+  off: "minimal",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  max: "high",
+};
+
+// Set the Claude thinking budget at module load so the spawned CLI child (which
+// inherits process.env) and the Agent SDK (which spreads process.env into its
+// options) both pick it up. Unset level => leave the model's own default alone.
+if (PROVIDER === "claude" && CLAUDE_THINKING_BUDGET[REASONING_EFFORT]) {
+  process.env.MAX_THINKING_TOKENS = CLAUDE_THINKING_BUDGET[REASONING_EFFORT];
+}
+
+// Resolved Codex reasoning effort (empty when unset or not Codex).
+export const codexReasoningEffort =
+  PROVIDER === "codex" ? (CODEX_REASONING_EFFORT[REASONING_EFFORT] ?? "") : "";
+
 export const toolsArg = ALLOWED_TOOLS
   ? '--allowedTools "' + ALLOWED_TOOLS + '"'
   : "";

--- a/packages/backend/callback-src/session/codexSession.ts
+++ b/packages/backend/callback-src/session/codexSession.ts
@@ -10,6 +10,7 @@ import {
   CODEX_PERSIST_STATE_FILE,
   CODEX_PERSIST_DIR,
   CODEX_RUNTIME_HOME_DIR,
+  codexReasoningEffort,
 } from "../config.js";
 import { updateThinkingStep } from "../parse/canonical.js";
 import { callbackState as S } from "../runtime/state.js";
@@ -64,7 +65,11 @@ function buildCodexRuntimeConfig(
         const trimmed = line.trim().toLowerCase();
         return (
           !trimmed.startsWith("sandbox_mode") &&
-          !trimmed.startsWith("approval_policy")
+          !trimmed.startsWith("approval_policy") &&
+          // Drop any configured reasoning effort; the session lever wins when set.
+          !(
+            codexReasoningEffort && trimmed.startsWith("model_reasoning_effort")
+          )
         );
       })
     : [];
@@ -73,6 +78,9 @@ function buildCodexRuntimeConfig(
     'approval_policy = "never"',
     'sandbox_mode = "danger-full-access"',
   ];
+  if (codexReasoningEffort) {
+    runtimeLines.push(`model_reasoning_effort = "${codexReasoningEffort}"`);
+  }
   if (normalizedPreservedLines.length > 0) {
     runtimeLines.push(...normalizedPreservedLines);
   }

--- a/packages/backend/convex/_daytona/callbackScript.generated.ts
+++ b/packages/backend/convex/_daytona/callbackScript.generated.ts
@@ -132,6 +132,25 @@ if (GH_TOKEN) {
 process.env.GH_PROMPT_DISABLED = "1";
 process.env.GH_NO_UPDATE_NOTIFIER = "1";
 var REPO_ID = process.env.REPO_ID;
+var REASONING_EFFORT = process.env.AI_REASONING_EFFORT || "";
+var CLAUDE_THINKING_BUDGET = {
+  off: "0",
+  low: "4000",
+  medium: "10000",
+  high: "24000",
+  max: "31999"
+};
+var CODEX_REASONING_EFFORT = {
+  off: "minimal",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  max: "high"
+};
+if (PROVIDER === "claude" && CLAUDE_THINKING_BUDGET[REASONING_EFFORT]) {
+  process.env.MAX_THINKING_TOKENS = CLAUDE_THINKING_BUDGET[REASONING_EFFORT];
+}
+var codexReasoningEffort = PROVIDER === "codex" ? CODEX_REASONING_EFFORT[REASONING_EFFORT] ?? "" : "";
 var toolsArg = ALLOWED_TOOLS ? '--allowedTools "' + ALLOWED_TOOLS + '"' : "";
 var systemArg = SYSTEM_PROMPT ? "--append-system-prompt " + JSON.stringify(SYSTEM_PROMPT) : "";
 var settingsJson = '{"attribution":{"commit":"","pr":""}}';
@@ -1977,13 +1996,17 @@ function buildCodexRuntimeConfig(rawValue, encodedValue) {
   const configuredValue = rawValue || (encodedValue ? decodeBase64(encodedValue) : "");
   const preservedLines = configuredValue ? configuredValue.split(/\\r?\\n/).filter((line) => {
     const trimmed = line.trim().toLowerCase();
-    return !trimmed.startsWith("sandbox_mode") && !trimmed.startsWith("approval_policy");
+    return !trimmed.startsWith("sandbox_mode") && !trimmed.startsWith("approval_policy") && // Drop any configured reasoning effort; the session lever wins when set.
+    !(codexReasoningEffort && trimmed.startsWith("model_reasoning_effort"));
   }) : [];
   const normalizedPreservedLines = preservedLines.filter((line) => line.trim());
   const runtimeLines = [
     'approval_policy = "never"',
     'sandbox_mode = "danger-full-access"'
   ];
+  if (codexReasoningEffort) {
+    runtimeLines.push(\`model_reasoning_effort = "\${codexReasoningEffort}"\`);
+  }
   if (normalizedPreservedLines.length > 0) {
     runtimeLines.push(...normalizedPreservedLines);
   }
@@ -3238,7 +3261,9 @@ function startTurnWatchdog() {
       void failTurnAndExit("The assistant exceeded the maximum turn runtime.");
     } else if (now - lastMessageAtMs > NO_MESSAGE_TIMEOUT_MS) {
       turnActive = false;
-      void failTurnAndExit("The assistant stopped responding. Please try again.");
+      void failTurnAndExit(
+        "The assistant stopped responding. Please try again."
+      );
     }
   }, WATCHDOG_TICK_MS);
   timer.unref?.();

--- a/packages/backend/convex/_queues/helpers.ts
+++ b/packages/backend/convex/_queues/helpers.ts
@@ -75,6 +75,7 @@ export async function startNextQueuedSessionMessage(
         message: nextMessage.content,
         mode: nextMessage.mode,
         model: nextMessage.model,
+        reasoningLevel: nextMessage.reasoningLevel,
         userId: nextMessage.userId,
         installationId: repo.installationId,
       },
@@ -218,6 +219,7 @@ export async function startNextQueuedProjectChatMessage(
         projectId,
         message: nextMessage.content,
         model: nextMessage.model ?? DEFAULT_AI_MODEL,
+        reasoningLevel: nextMessage.reasoningLevel,
         userId: nextMessage.userId,
       },
     );
@@ -284,6 +286,7 @@ export async function startNextQueuedTaskChatMessage(
         taskId,
         message: nextMessage.content,
         model: nextMessage.model ?? DEFAULT_AI_MODEL,
+        reasoningLevel: nextMessage.reasoningLevel,
         userId: nextMessage.userId,
       },
     );

--- a/packages/backend/convex/_sessions/execution.ts
+++ b/packages/backend/convex/_sessions/execution.ts
@@ -2,7 +2,11 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { workflow, cancelTrackedWorkflow } from "../workflowManager";
 import { authMutation, hasRepoAccess } from "../functions";
-import { aiModelValidator, sessionModeValidator } from "../validators";
+import {
+  aiModelValidator,
+  reasoningLevelValidator,
+  sessionModeValidator,
+} from "../validators";
 import { trackSessionWorkflow } from "../workflowWatchdog";
 import { clearStreamingActivity } from "../_taskWorkflow/helpers";
 import { startNextQueuedSessionMessage } from "../_queues/helpers";
@@ -16,6 +20,7 @@ export const startExecute = authMutation({
     message: v.string(),
     mode: sessionModeValidator,
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -79,6 +84,7 @@ export const startExecute = authMutation({
         repoId: session.repoId,
         userId: ctx.userId,
         model: normalizedModel,
+        reasoningLevel: args.reasoningLevel,
         allowedTools: MODE_TOOLS[effectiveMode],
         sessionPersistenceId: args.sessionId,
       });
@@ -92,6 +98,7 @@ export const startExecute = authMutation({
         message: args.message,
         mode: args.mode,
         model: args.model,
+        reasoningLevel: args.reasoningLevel,
         userId: ctx.userId,
         installationId: repo.installationId,
       },
@@ -135,6 +142,7 @@ export const enqueueMessage = authMutation({
     message: v.string(),
     mode: sessionModeValidator,
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -153,6 +161,7 @@ export const enqueueMessage = authMutation({
       userId: ctx.userId,
       mode: args.mode,
       model: args.model,
+      reasoningLevel: args.reasoningLevel,
     });
     await ctx.db.patch(args.sessionId, { updatedAt: Date.now() });
     return null;

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -7,6 +7,7 @@ import { ensureSandboxStartedSteps } from "../_daytona/resumeSandboxSteps";
 import { authMutation, hasRepoAccess } from "../functions";
 import {
   aiModelValidator,
+  reasoningLevelValidator,
   workflowCompleteValidator,
   normalizeAIModel,
 } from "../validators";
@@ -186,6 +187,7 @@ export const sessionExecuteWorkflow = workflow.define({
     message: v.string(),
     mode: sessionModeArgValidator,
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
     userId: v.id("users"),
     installationId: v.number(),
   },
@@ -300,6 +302,7 @@ export const sessionExecuteWorkflow = workflow.define({
       repoId: data.repoId,
       userId: args.userId,
       model: data.model,
+      reasoningLevel: args.reasoningLevel,
       allowedTools: data.allowedTools,
       sessionPersistenceId: args.sessionId,
     });

--- a/packages/backend/convex/_validators/aiModels.ts
+++ b/packages/backend/convex/_validators/aiModels.ts
@@ -39,6 +39,33 @@ export const aiModelValidator = v.union(
   v.literal("cursor:composer-2.5"),
 );
 
+/**
+ * Abstract, provider-neutral reasoning effort levels shown on the chat input
+ * lever. A single level is threaded to the sandbox as the `AI_REASONING_EFFORT`
+ * env var and mapped to each provider's native control in the callback runner
+ * (`callback-src/config.ts`): Claude -> `MAX_THINKING_TOKENS`, Codex ->
+ * `model_reasoning_effort`. Only Claude and Codex expose a runtime lever, so the
+ * UI hides it for other providers (see `providerSupportsReasoning`).
+ */
+export const REASONING_LEVELS = [
+  "off",
+  "low",
+  "medium",
+  "high",
+  "max",
+] as const;
+export type ReasoningLevel = (typeof REASONING_LEVELS)[number];
+
+export const reasoningLevelValidator = v.union(
+  v.literal("off"),
+  v.literal("low"),
+  v.literal("medium"),
+  v.literal("high"),
+  v.literal("max"),
+);
+
+export const DEFAULT_REASONING_LEVEL: ReasoningLevel = "medium";
+
 export type AIProvider = "claude" | "codex" | "opencode" | "cursor";
 export type LegacyClaudeModel = "opus" | "sonnet" | "haiku";
 export type AIModel =
@@ -365,6 +392,15 @@ export function getAIModelProvider(
   if (normalized.startsWith("opencode:")) return "opencode";
   if (normalized.startsWith("cursor:")) return "cursor";
   return "claude";
+}
+
+/**
+ * Whether a provider exposes a runtime reasoning-effort lever. Cursor bakes
+ * reasoning into the model id (e.g. `cursor:...-high-thinking`) and Opencode has
+ * no runtime control, so the chat input hides the lever for them.
+ */
+export function providerSupportsReasoning(provider: AIProvider): boolean {
+  return provider === "claude" || provider === "codex";
 }
 
 /** Finds the full AIModelOption metadata for a given model string, falling back to the default. */

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { aiModelValidator } from "./aiModels";
+import { aiModelValidator, reasoningLevelValidator } from "./aiModels";
 import {
   deploymentStatusValidator,
   docKindValidator,
@@ -417,6 +417,7 @@ export const queuedMessageFields = {
   userId: v.id("users"),
   mode: v.optional(sessionModeValidator),
   model: v.optional(aiModelValidator),
+  reasoningLevel: v.optional(reasoningLevelValidator),
   responseLength: v.optional(v.string()),
   personaId: v.optional(v.id("designPersonas")),
   numDesigns: v.optional(v.number()),

--- a/packages/backend/convex/agentTaskChatWorkflow.ts
+++ b/packages/backend/convex/agentTaskChatWorkflow.ts
@@ -7,6 +7,7 @@ import { ensureSandboxStartedSteps } from "./_daytona/resumeSandboxSteps";
 import { authMutation, hasRepoAccess } from "./functions";
 import {
   aiModelValidator,
+  reasoningLevelValidator,
   workflowCompleteValidator,
   normalizeAIModel,
 } from "./validators";
@@ -70,6 +71,7 @@ export const startExecute = authMutation({
     taskId: v.id("agentTasks"),
     message: v.string(),
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -89,6 +91,7 @@ export const startExecute = authMutation({
         taskId: args.taskId,
         message: args.message,
         model: args.model,
+        reasoningLevel: args.reasoningLevel,
         userId: ctx.userId,
       },
     );
@@ -104,6 +107,7 @@ export const enqueueMessage = authMutation({
     taskId: v.id("agentTasks"),
     message: v.string(),
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -125,6 +129,7 @@ export const enqueueMessage = authMutation({
       createdAt: Date.now(),
       userId: ctx.userId,
       model: args.model,
+      reasoningLevel: args.reasoningLevel,
     });
     await ctx.db.patch(args.taskId, { updatedAt: Date.now() });
     return null;
@@ -199,6 +204,7 @@ export const agentTaskChatExecuteWorkflow = workflow.define({
     taskId: v.id("agentTasks"),
     message: v.string(),
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
     userId: v.id("users"),
   },
   handler: async (step, args): Promise<void> => {
@@ -295,6 +301,7 @@ export const agentTaskChatExecuteWorkflow = workflow.define({
       completionMutation: "agentTaskChatWorkflow:handleCompletion",
       entityIdField: "taskId",
       model: data.model,
+      reasoningLevel: args.reasoningLevel,
       allowedTools: CHAT_ALLOWED_TOOLS,
       repoId: data.repoId,
       sessionPersistenceId: args.taskId,

--- a/packages/backend/convex/projectChatWorkflow.ts
+++ b/packages/backend/convex/projectChatWorkflow.ts
@@ -7,6 +7,7 @@ import { ensureSandboxStartedSteps } from "./_daytona/resumeSandboxSteps";
 import { authMutation, hasRepoAccess } from "./functions";
 import {
   aiModelValidator,
+  reasoningLevelValidator,
   workflowCompleteValidator,
   normalizeAIModel,
 } from "./validators";
@@ -71,6 +72,7 @@ export const startExecute = authMutation({
     projectId: v.id("projects"),
     message: v.string(),
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -87,6 +89,7 @@ export const startExecute = authMutation({
         projectId: args.projectId,
         message: args.message,
         model: args.model,
+        reasoningLevel: args.reasoningLevel,
         userId: ctx.userId,
       },
     );
@@ -103,6 +106,7 @@ export const enqueueMessage = authMutation({
     projectId: v.id("projects"),
     message: v.string(),
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -121,6 +125,7 @@ export const enqueueMessage = authMutation({
       createdAt: Date.now(),
       userId: ctx.userId,
       model: args.model,
+      reasoningLevel: args.reasoningLevel,
     });
     await ctx.db.patch(args.projectId, { updatedAt: Date.now() });
     return null;
@@ -192,6 +197,7 @@ export const projectChatExecuteWorkflow = workflow.define({
     projectId: v.id("projects"),
     message: v.string(),
     model: aiModelValidator,
+    reasoningLevel: v.optional(reasoningLevelValidator),
     userId: v.id("users"),
   },
   handler: async (step, args): Promise<void> => {
@@ -287,6 +293,7 @@ export const projectChatExecuteWorkflow = workflow.define({
       completionMutation: "projectChatWorkflow:handleCompletion",
       entityIdField: "projectId",
       model: data.model,
+      reasoningLevel: args.reasoningLevel,
       allowedTools: CHAT_ALLOWED_TOOLS,
       repoId: data.repoId,
       sessionPersistenceId: args.projectId,

--- a/packages/backend/index.ts
+++ b/packages/backend/index.ts
@@ -18,9 +18,13 @@ export {
   getVisibleAIModelOptions,
   hasCodexAuthEnvVar,
   normalizeAIModel,
+  providerSupportsReasoning,
+  REASONING_LEVELS,
+  DEFAULT_REASONING_LEVEL,
   type AIModel,
   type AIModelOption,
   type AIProvider,
   type AIProviderAvailability,
+  type ReasoningLevel,
   PERSONALISATION_PRESETS,
 } from "./convex/validators";

--- a/packages/ui/src/ai-elements/index.ts
+++ b/packages/ui/src/ai-elements/index.ts
@@ -8,6 +8,7 @@ export * from "./prompt-input";
 export * from "./provider-icon";
 export * from "./prompt-input-settings";
 export * from "./prompt-input-speech";
+export * from "./prompt-input-reasoning";
 export * from "./reasoning";
 export * from "./shimmer";
 export * from "./web-preview";

--- a/packages/ui/src/ai-elements/prompt-input-reasoning.tsx
+++ b/packages/ui/src/ai-elements/prompt-input-reasoning.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { IconBrain } from "@tabler/icons-react";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { cn } from "../utils/cn";
+
+export interface ReasoningLevelOption<TLevel extends string = string> {
+  value: TLevel;
+  label: string;
+}
+
+export interface ReasoningLeverProps<TLevel extends string = string> {
+  value: TLevel;
+  /** Ordered lowest → highest; the slider position maps to this array's index. */
+  options: ReadonlyArray<ReasoningLevelOption<TLevel>>;
+  onValueChange: (value: TLevel) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Toolbar lever for the session-wide reasoning effort. The trigger button shows
+ * the current level; the popover holds a discrete slider (a native range input,
+ * so it is keyboard-accessible with no extra dependency) whose stops map 1:1 to
+ * `options`. Only rendered for providers that support a runtime lever — the
+ * caller decides visibility (see `providerSupportsReasoning`).
+ */
+export function ReasoningLever<TLevel extends string>({
+  value,
+  options,
+  onValueChange,
+  disabled,
+  className,
+}: ReasoningLeverProps<TLevel>) {
+  const currentIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  );
+  const current = options[currentIndex] ?? options[0];
+  const maxIndex = options.length - 1;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          title="Reasoning effort"
+          className={cn(
+            "flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50",
+            className,
+          )}
+        >
+          <IconBrain size={14} />
+          {current?.label ?? "Reasoning"}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-foreground">
+              Reasoning effort
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {current?.label}
+            </span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={maxIndex}
+            step={1}
+            value={currentIndex}
+            disabled={disabled}
+            aria-label="Reasoning effort"
+            onChange={(event) => {
+              const next = options[Number(event.target.value)];
+              if (next) onValueChange(next.value);
+            }}
+            className="w-full accent-primary"
+          />
+          <div className="flex justify-between">
+            {options.map((option, index) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => onValueChange(option.value)}
+                className={cn(
+                  "text-[10px] transition-colors hover:text-foreground",
+                  index === currentIndex
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground",
+                )}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Applies to every message in this chat. Higher levels let Eva think
+            longer before responding.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## What

Adds a **reasoning/thinking lever** to session, task, and project sandbox chats — a brain-icon button in the input toolbar that opens a popover with an **Off / Low / Med / High / Max** slider. The chosen level persists per-chat (localStorage, mirroring how `model` already works) and applies to every message in that chat.

The lever is shown only for **Claude** and **Codex** (which expose a runtime control) and hidden for **Cursor** (reasoning baked into the model id) and **Opencode** (no runtime lever).

## How

One abstract level rides the existing `extraEnvVars` passthrough as `AI_REASONING_EFFORT`; the callback runner maps it per provider:
- **Claude** → `MAX_THINKING_TOKENS` (off=0 … max=31999) — works for both the CLI and SDK-daemon paths.
- **Codex** → `model_reasoning_effort` in `config.toml` (off→minimal … max→high).

For **sessions** (daemon pull-dispatch), the level is folded into the daemon `optsSig`, so changing it mid-session respawns the daemon — reusing the existing model/tools-change mechanism.

## Notes

- Slider is a styled native `<input type="range">` — no new dependency.
- `queuedMessages` carries an optional `reasoningLevel` so queued messages relaunch at the right level (optional field, no migration).

## Verification

- `convex codegen --typecheck`, `apps/web` tsc, `packages/ui` tsc all pass; no `any`/`unknown`/`as`/`!` in new code.
- Callback bundle rebuilt with the mapping present.
- Live visual check of the lever was blocked by pre-existing, unrelated `sessions:list` validator drift (`startupRequestedAt`) on the shared dev backend, which breaks the repo sidebar in the preview env. Not caused by this change.