### PR TITLE
fix(chat): stop flashing "Resuming sandbox" on active-sandbox messages

### DIFF
--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -427,7 +427,13 @@ export function ChatBody({
           ) : null}
           {message.role === "user" && (
             <div className="flex items-center justify-end gap-2 mt-0.5 ml-auto">
-              <div className="flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="flex items-center gap-3 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100">
+                {message.content ? (
+                  <ChatMessageActions
+                    copyText={message.content}
+                    revealOnHover={false}
+                  />
+                ) : null}
                 {message.mode && (
                   <div className="flex items-center gap-1 text-[11px] text-muted-foreground/60">
                     {message.mode === "plan" ? (

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Suppress spurious "Resuming sandbox" step for active chats - 2026-07-10
+
+- Session, project, and agent-task chats no longer flash a "Resuming sandbox..." step on every message when the sandbox is already active; on Vercel the step now only shows for a genuine resume.
+- Each chat's data query now surfaces its sandbox status so the resume workflow can skip the cosmetic activity when the status is "active", with no extra query or latency.
+
 ## Session-wide reasoning/thinking lever for sandbox chats - 2026-07-10
 
 - Added a reasoning-effort lever (Off/Low/Med/High/Max slider in a toolbar popover) to session, task, and project sandbox chats so users can tune how hard the agent thinks; the level persists per-chat and applies to every message.

--- a/packages/backend/convex/_daytona/resumeSandboxSteps.ts
+++ b/packages/backend/convex/_daytona/resumeSandboxSteps.ts
@@ -20,6 +20,14 @@ type EnsureSandboxStartedArgs = {
   repoId: Id<"githubRepos">;
   /** When set, a "restoring…" activity is surfaced to this streaming entity. */
   streamingEntityId?: string;
+  /**
+   * True when the caller already knows the sandbox is running (e.g. the
+   * session/project/task status is "active"). Suppresses the cosmetic Vercel
+   * "Resuming sandbox…" activity so it does not flash on every message for an
+   * already-running sandbox. Ignored on Daytona, which gates on the real
+   * `kickoff.state` instead.
+   */
+  sandboxRunning?: boolean;
 };
 
 /**
@@ -80,7 +88,7 @@ export async function ensureSandboxStartedSteps(
   // start action; extra workflow steps were measured at ~6–8s of pure latency.
   // Also skip cold-storage copy — that is Daytona archived restore only.
   if (provider === "vercel") {
-    if (args.streamingEntityId) {
+    if (args.streamingEntityId && !args.sandboxRunning) {
       await step.runMutation(internal.streaming.internalSet, {
         entityId: args.streamingEntityId,
         currentActivity: JSON.stringify([

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -10,6 +10,7 @@ import {
   reasoningLevelValidator,
   workflowCompleteValidator,
   normalizeAIModel,
+  sessionStatusValidator,
 } from "../validators";
 import { FALLBACK_GIT_BASE_BRANCH } from "@conductor/shared";
 import {
@@ -229,6 +230,7 @@ export const sessionExecuteWorkflow = workflow.define({
           vercelSandboxId: data.vercelSandboxId,
           repoId: data.repoId,
           streamingEntityId: args.sessionId,
+          sandboxRunning: data.status === "active",
         });
       } catch (error) {
         await step.runMutation(internal.sessionWorkflow.saveResult, {
@@ -499,6 +501,7 @@ export const getSessionData = internalQuery({
   returns: v.object({
     sandboxId: v.optional(v.string()),
     vercelSandboxId: v.optional(v.string()),
+    status: sessionStatusValidator,
     repoOwner: v.string(),
     repoName: v.string(),
     repoId: v.id("githubRepos"),
@@ -532,6 +535,7 @@ export const getSessionData = internalQuery({
     return {
       sandboxId: session.sandboxId,
       vercelSandboxId: session.vercelSandboxId,
+      status: session.status,
       repoOwner: repo.owner,
       repoName: repo.name,
       repoId: session.repoId,

--- a/packages/backend/convex/agentTaskChatWorkflow.ts
+++ b/packages/backend/convex/agentTaskChatWorkflow.ts
@@ -10,6 +10,7 @@ import {
   reasoningLevelValidator,
   workflowCompleteValidator,
   normalizeAIModel,
+  taskSandboxStatusValidator,
 } from "./validators";
 import {
   recordCompletionLog,
@@ -247,6 +248,7 @@ export const agentTaskChatExecuteWorkflow = workflow.define({
         vercelSandboxId: data.vercelSandboxId,
         repoId: data.repoId,
         streamingEntityId,
+        sandboxRunning: data.sandboxStatus === "active",
       });
     } catch (error) {
       await step.runMutation(internal.agentTaskChatWorkflow.saveResult, {
@@ -376,6 +378,7 @@ export const getChatData = internalQuery({
   returns: v.object({
     sandboxId: v.optional(v.string()),
     vercelSandboxId: v.optional(v.string()),
+    sandboxStatus: v.optional(taskSandboxStatusValidator),
     repoOwner: v.string(),
     repoName: v.string(),
     repoId: v.id("githubRepos"),
@@ -427,6 +430,7 @@ export const getChatData = internalQuery({
     return {
       sandboxId: task.sandboxId,
       vercelSandboxId: task.vercelSandboxId,
+      sandboxStatus: task.reviewTaskSandboxStatus,
       repoOwner: repo.owner,
       repoName: repo.name,
       repoId: task.repoId,

--- a/packages/backend/convex/projectChatWorkflow.ts
+++ b/packages/backend/convex/projectChatWorkflow.ts
@@ -10,6 +10,7 @@ import {
   reasoningLevelValidator,
   workflowCompleteValidator,
   normalizeAIModel,
+  taskSandboxStatusValidator,
 } from "./validators";
 import {
   recordCompletionLog,
@@ -239,6 +240,7 @@ export const projectChatExecuteWorkflow = workflow.define({
         vercelSandboxId: data.vercelSandboxId,
         repoId: data.repoId,
         streamingEntityId,
+        sandboxRunning: data.sandboxStatus === "active",
       });
     } catch (error) {
       await step.runMutation(internal.projectChatWorkflow.saveResult, {
@@ -368,6 +370,7 @@ export const getChatData = internalQuery({
   returns: v.object({
     sandboxId: v.optional(v.string()),
     vercelSandboxId: v.optional(v.string()),
+    sandboxStatus: v.optional(taskSandboxStatusValidator),
     repoOwner: v.string(),
     repoName: v.string(),
     repoId: v.id("githubRepos"),
@@ -419,6 +422,7 @@ export const getChatData = internalQuery({
     return {
       sandboxId: project.sandboxId,
       vercelSandboxId: project.vercelSandboxId,
+      sandboxStatus: project.reviewProjectSandboxStatus,
       repoOwner: repo.owner,
       repoName: repo.name,
       repoId: project.repoId,


### PR DESCRIPTION
## Problem

Sending a message in a session (or project / agent-task) chat always showed **"Resuming sandbox..."** as the first step — even when the sandbox was already active. It is a cosmetic step, not a real operation.

## Root cause

`ensureSandboxStartedSteps` emits the "Resuming sandbox..." streaming activity **unconditionally** on the Vercel branch whenever a persisted sandbox id exists. Unlike the Daytona branch (which early-returns when `kickoff.state === "running"`), Vercel deliberately skips the state-checking kickoff/poll to avoid ~6–8s of latency — but in doing so it lost any "am I actually resuming?" gate. The per-message chat workflows run this first, guarded only by "a sandbox id exists".

## Fix

Gate the cosmetic Vercel emit on the chat's own sandbox status — the same signal the frontend uses for `isSandboxActive` (`status === "active"`). It is already loaded by each chat workflow's data query, so there's no extra query or latency.

- `resumeSandboxSteps.ts`: add optional `sandboxRunning` arg; skip the Vercel emit when true. Daytona untouched.
- Session / project / agent-task data queries now surface their sandbox status.
- The three per-message callers pass `sandboxRunning: <status> === "active"`. Startup workflows are unchanged, so a genuine start still shows the message.

## Verification

- `npx convex codegen --typecheck enable` passes.
- Runtime: on the Vercel provider, sending a message in an **active** chat no longer flashes the resume step; a **stopped** one still shows it. Daytona behaviour unchanged.