### PR TITLE
Revert/sidebar sandbox chat entries

### DIFF
--- a/packages/backend/convex/_github/prFlow.ts
+++ b/packages/backend/convex/_github/prFlow.ts
@@ -69,11 +69,22 @@ export const createSessionPr = action({
   },
 });
 
+function isBranchNotAheadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("is not ahead of") ||
+    message.includes("No commits between") ||
+    /not ready for a pull request/i.test(message)
+  );
+}
+
 /**
  * Opens a draft PR for a session branch after the first successful push.
  * Idempotent: returns the existing prUrl when one is already stored.
- * Called from sessionExecuteWorkflow after pushSandboxBranch succeeds; also
- * retried on later turns if the first attempt failed.
+ * Returns null (no alert) when the branch has no commits ahead of base —
+ * plan-only turns push the branch tip but have nothing to review yet; later
+ * turns with commits retry and open the draft.
+ * Called from sessionExecuteWorkflow after pushSandboxBranch succeeds.
  */
 export const createDraftSessionPr = internalAction({
   args: { sessionId: v.id("sessions") },
@@ -107,23 +118,34 @@ export const createDraftSessionPr = internalAction({
       repo.rootDirectory,
     );
 
-    const result: string = await ctx.runAction(
-      internal.taskWorkflowActions.createPullRequest,
-      {
-        installationId: repo.installationId,
-        repoOwner: repo.owner,
-        repoName: repo.name,
-        branchName: session.branchName,
-        baseBranch: repo.defaultBaseBranch,
-        title: session.title,
-        body: buildPrBody(
-          [{ heading: "Summary", content: summaryContent }],
-          evaUrl,
-        ),
-        labels: ["eva", "session", "draft", ...(appLabel ? [appLabel] : [])],
-        draft: true,
-      },
-    );
+    let result: string;
+    try {
+      result = await ctx.runAction(
+        internal.taskWorkflowActions.createPullRequest,
+        {
+          installationId: repo.installationId,
+          repoOwner: repo.owner,
+          repoName: repo.name,
+          branchName: session.branchName,
+          baseBranch: repo.defaultBaseBranch,
+          title: session.title,
+          body: buildPrBody(
+            [{ heading: "Summary", content: summaryContent }],
+            evaUrl,
+          ),
+          labels: ["eva", "session", "draft", ...(appLabel ? [appLabel] : [])],
+          draft: true,
+        },
+      );
+    } catch (error) {
+      if (isBranchNotAheadError(error)) {
+        console.log(
+          `[github] Skipping draft PR for session ${args.sessionId}: branch has no commits ahead of base`,
+        );
+        return null;
+      }
+      throw error;
+    }
 
     await ctx.runMutation(internal.sessions.setPrUrl, {
       id: args.sessionId,

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -401,7 +401,8 @@ export const sessionExecuteWorkflow = workflow.define({
         },
       );
 
-      // Open a draft PR after the first successful push (no-op if one exists).
+      // Open a draft PR after the first successful push (no-op if one exists,
+      // or if the branch has no commits ahead of base — plan-only turns).
       // Retried on later turns so a transient GitHub failure self-heals.
       try {
         await step.runAction(internal.github.createDraftSessionPr, {

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -401,8 +401,8 @@ export const sessionExecuteWorkflow = workflow.define({
         },
       );
 
-      // Open a draft PR after the first successful push (no-op if one exists,
-      // or if the branch has no commits ahead of base — plan-only turns).
+      // Open a draft PR after the first successful push (no-op if one exists
+      // on the session or on GitHub for this branch, or if not ahead of base).
       // Retried on later turns so a transient GitHub failure self-heals.
       try {
         await step.runAction(internal.github.createDraftSessionPr, {

--- a/packages/backend/convex/taskWorkflowActions.ts
+++ b/packages/backend/convex/taskWorkflowActions.ts
@@ -230,8 +230,16 @@ async function waitForPullRequestHead(params: {
       if (comparison.data.ahead_by > 0) {
         return;
       }
-      lastError = `${params.branchName} is not ahead of ${params.baseBranch}`;
+      // Compare succeeded: GitHub sees both tips and head is not ahead.
+      // Retrying won't create commits — fail immediately (plan-only turns).
+      throw new Error(
+        `${params.branchName} is not ahead of ${params.baseBranch}`,
+      );
     } catch (error) {
+      if (error instanceof Error && error.message.includes("is not ahead of")) {
+        throw error;
+      }
+      // Branch may not be visible yet right after push — keep retrying.
       lastError =
         error instanceof Error ? error.message : "GitHub compare failed";
     }

--- a/packages/backend/convex/taskWorkflowActions.ts
+++ b/packages/backend/convex/taskWorkflowActions.ts
@@ -129,6 +129,14 @@ async function findOpenPullRequestForBranch(params: {
   return { url: pr.html_url, number: pr.number, body: pr.body };
 }
 
+function isPullRequestAlreadyExistsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /pull request already exists/i.test(message) ||
+    /A pull request already exists for/i.test(message)
+  );
+}
+
 async function createPullRequestWithGitHub(
   args: PullRequestCreateParams,
 ): Promise<string> {
@@ -155,32 +163,52 @@ async function createPullRequestWithGitHub(
     baseBranch,
   });
 
-  const pr = await octokit.rest.pulls.create({
-    owner: args.repoOwner,
-    repo: args.repoName,
-    title: `Eva: ${args.title}`,
-    body: args.body,
-    head: args.branchName,
-    base: baseBranch,
-    draft: args.draft ?? false,
-  });
+  let prNumber: number;
+  let prUrl: string;
+  try {
+    const pr = await octokit.rest.pulls.create({
+      owner: args.repoOwner,
+      repo: args.repoName,
+      title: `Eva: ${args.title}`,
+      body: args.body,
+      head: args.branchName,
+      base: baseBranch,
+      draft: args.draft ?? false,
+    });
+    prNumber = pr.data.number;
+    prUrl = pr.data.html_url;
+  } catch (error) {
+    // Concurrent create or list lag: adopt the existing PR instead of failing.
+    if (isPullRequestAlreadyExistsError(error)) {
+      for (const delayMs of [0, 1000, 2000]) {
+        if (delayMs > 0) {
+          await sleep(delayMs);
+        }
+        const raced = await findOpenPullRequestForBranch(args);
+        if (raced) {
+          return raced.url;
+        }
+      }
+    }
+    throw error;
+  }
 
   if (args.labels.length > 0) {
     try {
       await octokit.rest.issues.addLabels({
         owner: args.repoOwner,
         repo: args.repoName,
-        issue_number: pr.data.number,
+        issue_number: prNumber,
         labels: args.labels,
       });
     } catch (labelError) {
       console.error(
-        `Failed to add labels to PR ${pr.data.html_url}: ${labelError instanceof Error ? labelError.message : String(labelError)}`,
+        `Failed to add labels to PR ${prUrl}: ${labelError instanceof Error ? labelError.message : String(labelError)}`,
       );
     }
   }
 
-  return pr.data.html_url;
+  return prUrl;
 }
 
 async function refreshPullRequestBodyWithGitHub(


### PR DESCRIPTION
Plan-only turns were waiting on GitHub then posting a failure alert; only open a draft when the branch is actually ahead of base.