### PR TITLE
feat: recall sent messages in composer and reorder the queue

### DIFF
--- a/apps/web/src/lib/components/QueuedMessagesPanel.tsx
+++ b/apps/web/src/lib/components/QueuedMessagesPanel.tsx
@@ -22,7 +22,29 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@conductor/ui";
-import { IconInfoCircle, IconPencil, IconTrash } from "@tabler/icons-react";
+import {
+  IconGripVertical,
+  IconInfoCircle,
+  IconPencil,
+  IconTrash,
+} from "@tabler/icons-react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { MarqueeOnHover } from "@/lib/components/ui/MarqueeOnHover";
 
 interface QueuedMessageItem {
@@ -37,6 +59,95 @@ interface QueuedMessagesPanelProps {
   renderContent?: (content: string) => React.ReactNode;
   onEdit?: (id: Id<"queuedMessages">, content: string) => Promise<void>;
   onDelete?: (id: Id<"queuedMessages">) => Promise<void>;
+  /** When provided, items become drag-reorderable; receives the new top-to-bottom id order. */
+  onReorder?: (orderedIds: Id<"queuedMessages">[]) => Promise<void>;
+}
+
+/** A single sortable queue row. Drag lives on the grip handle only so the
+ *  edit/delete buttons stay clickable. */
+function SortableQueuedItem({
+  item,
+  draggable,
+  renderContent,
+  onEditClick,
+  onDeleteClick,
+}: {
+  item: QueuedMessageItem;
+  draggable: boolean;
+  renderContent?: (content: string) => React.ReactNode;
+  onEditClick?: (item: QueuedMessageItem) => void;
+  onDeleteClick?: (item: QueuedMessageItem) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id, disabled: !draggable });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <QueueItem
+      ref={setNodeRef}
+      style={style}
+      className={isDragging ? "opacity-50" : undefined}
+    >
+      <div className="flex items-start gap-2">
+        {draggable ? (
+          <button
+            type="button"
+            aria-label="Reorder queued message"
+            className="mt-0.5 shrink-0 cursor-grab touch-none rounded p-0.5 text-muted-foreground/50 opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+            {...attributes}
+            {...listeners}
+          >
+            <IconGripVertical size={14} />
+          </button>
+        ) : (
+          <QueueItemIndicator />
+        )}
+        <MarqueeOnHover className="min-w-0 grow text-xs text-muted-foreground">
+          {renderContent ? renderContent(item.content) : item.content}
+        </MarqueeOnHover>
+        <QueueItemActions>
+          {item.info ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <QueueItemAction aria-label="Queued message details">
+                  <IconInfoCircle size={14} />
+                </QueueItemAction>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{item.info}</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+          {onEditClick ? (
+            <QueueItemAction
+              aria-label="Edit queued message"
+              onClick={() => onEditClick(item)}
+            >
+              <IconPencil size={14} />
+            </QueueItemAction>
+          ) : null}
+          {onDeleteClick ? (
+            <QueueItemAction
+              aria-label="Delete queued message"
+              onClick={() => onDeleteClick(item)}
+            >
+              <IconTrash size={14} />
+            </QueueItemAction>
+          ) : null}
+        </QueueItemActions>
+      </div>
+    </QueueItem>
+  );
 }
 
 /**
@@ -49,6 +160,7 @@ export function QueuedMessagesPanel({
   renderContent,
   onEdit,
   onDelete,
+  onReorder,
 }: QueuedMessagesPanelProps) {
   const [editingItem, setEditingItem] = useState<QueuedMessageItem | null>(
     null,
@@ -60,6 +172,13 @@ export function QueuedMessagesPanel({
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
   useEffect(() => {
     setDraftContent(editingItem?.content ?? "");
   }, [editingItem]);
@@ -67,6 +186,21 @@ export function QueuedMessagesPanel({
   if (items.length === 0) {
     return null;
   }
+
+  // Reorder only makes sense with 2+ items and a handler wired.
+  const draggable = Boolean(onReorder) && items.length > 1;
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!onReorder || !over || active.id === over.id) return;
+    const oldIndex = items.findIndex((item) => item.id === active.id);
+    const newIndex = items.findIndex((item) => item.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const orderedIds = arrayMove(items, oldIndex, newIndex).map(
+      (item) => item.id,
+    );
+    void onReorder(orderedIds);
+  };
 
   return (
     <>
@@ -77,48 +211,27 @@ export function QueuedMessagesPanel({
           </QueueSectionTrigger>
           <QueueSectionContent>
             <QueueList>
-              {items.map((item) => (
-                <QueueItem key={item.id}>
-                  <div className="flex items-start gap-2">
-                    <QueueItemIndicator />
-                    <MarqueeOnHover className="min-w-0 grow text-xs text-muted-foreground">
-                      {renderContent
-                        ? renderContent(item.content)
-                        : item.content}
-                    </MarqueeOnHover>
-                    <QueueItemActions>
-                      {item.info ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <QueueItemAction aria-label="Queued message details">
-                              <IconInfoCircle size={14} />
-                            </QueueItemAction>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>{item.info}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : null}
-                      {onEdit ? (
-                        <QueueItemAction
-                          aria-label="Edit queued message"
-                          onClick={() => setEditingItem(item)}
-                        >
-                          <IconPencil size={14} />
-                        </QueueItemAction>
-                      ) : null}
-                      {onDelete ? (
-                        <QueueItemAction
-                          aria-label="Delete queued message"
-                          onClick={() => setDeletingItem(item)}
-                        >
-                          <IconTrash size={14} />
-                        </QueueItemAction>
-                      ) : null}
-                    </QueueItemActions>
-                  </div>
-                </QueueItem>
-              ))}
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={items.map((item) => item.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {items.map((item) => (
+                    <SortableQueuedItem
+                      key={item.id}
+                      item={item}
+                      draggable={draggable}
+                      renderContent={renderContent}
+                      onEditClick={onEdit ? setEditingItem : undefined}
+                      onDeleteClick={onDelete ? setDeletingItem : undefined}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
             </QueueList>
           </QueueSectionContent>
         </QueueSection>

--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -46,6 +46,7 @@ import {
 import type { Doc, Id } from "@conductor/backend";
 import { ScreenshotPreview, VideoPreview } from "@/lib/components/MediaPreview";
 import { MessageMentionText } from "@/lib/components/chat/MessageMentionText";
+import { tokenizedToEditable } from "@/lib/components/mentions";
 import { ChatMessageActions } from "@/lib/components/chat/ChatMessageActions";
 import {
   MentionTextarea,
@@ -239,6 +240,23 @@ export function ChatBody({
       );
     }
   });
+  const reorderQueuedMessages = useMutation(
+    api.queuedMessages.reorder,
+  ).withOptimisticUpdate((localStore, args) => {
+    const current = localStore.getQuery(api.queuedMessages.listByParent, {
+      parentId: args.parentId,
+    });
+    if (current === undefined) return;
+    const byId = new Map(current.map((m) => [m._id, m]));
+    const reordered = args.orderedIds
+      .map((id) => byId.get(id))
+      .filter((m): m is (typeof current)[number] => m !== undefined);
+    localStore.setQuery(
+      api.queuedMessages.listByParent,
+      { parentId: args.parentId },
+      reordered,
+    );
+  });
 
   const evaIcon = <EvaIcon />;
 
@@ -290,6 +308,18 @@ export function ChatBody({
         info: formatQueuedInfo?.(message),
       })),
     [queuedMessages, formatQueuedInfo],
+  );
+
+  // Previously sent user messages as editable display text, newest-first, for
+  // ArrowUp/ArrowDown history recall in the composer. Tokenized mentions are
+  // de-tokenized to plain label text (the editor's chip map is mount-only).
+  const messageHistory = useMemo(
+    () =>
+      messages
+        .filter((m) => m.role === "user" && !m.isSystemAlert && m.content)
+        .map((m) => tokenizedToEditable(m.content ?? "").displayText)
+        .reverse(),
+    [messages],
   );
 
   // Index of the latest user message — everything from here to the end is the
@@ -498,6 +528,11 @@ export function ChatBody({
             onDelete={async (id) => {
               await deleteQueuedMessage({ id });
             }}
+            onReorder={async (orderedIds) => {
+              const parentId = queuedMessages[0]?.parentId;
+              if (!parentId) return;
+              await reorderQueuedMessages({ parentId, orderedIds });
+            }}
           />
           {preInputContent}
           {!hintDismissed ? (
@@ -556,6 +591,7 @@ export function ChatBody({
                     placeholder={placeholder}
                     initialMentionMap={draft?.mentionMap}
                     initialSkillMap={draft?.skillMap}
+                    history={messageHistory}
                   />
                   <PromptInputFooter>
                     <PromptInputTools>

--- a/apps/web/src/lib/components/chat/MentionTextarea.tsx
+++ b/apps/web/src/lib/components/chat/MentionTextarea.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useCallback } from "react";
+import { forwardRef, useCallback, useRef } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { usePromptInputController } from "@conductor/ui";
 import type { Doc, Id } from "@conductor/backend";
@@ -42,6 +42,12 @@ interface MentionTextareaProps {
   placeholder?: string;
   initialMentionMap?: Map<string, string>;
   initialSkillMap?: Map<string, string>;
+  /**
+   * Previously sent messages as editable display text, newest-first. When
+   * provided, ArrowUp on the first line recalls older messages and ArrowDown
+   * moves back toward the live draft (terminal-style history).
+   */
+  history?: string[];
 }
 
 export const MentionTextarea = forwardRef<
@@ -56,6 +62,7 @@ export const MentionTextarea = forwardRef<
     placeholder,
     initialMentionMap,
     initialSkillMap,
+    history,
   },
   ref,
 ) {
@@ -63,6 +70,50 @@ export const MentionTextarea = forwardRef<
   const controller = usePromptInputController();
   const value = controller.textInput.value;
   const navigateToDocById = useDocMentionNavigate(repoBasePath);
+
+  // Cursor into `history` (null = editing the live draft) and the draft stashed
+  // when history navigation began, so ArrowDown past the newest entry restores it.
+  const historyIndexRef = useRef<number | null>(null);
+  const stashedDraftRef = useRef("");
+  const setInput = controller.textInput.setInput;
+
+  // Any manual keystroke exits history navigation back to a fresh draft.
+  const handleValueChange = useCallback(
+    (next: string) => {
+      historyIndexRef.current = null;
+      setInput(next);
+    },
+    [setInput],
+  );
+
+  const handleHistoryNavigate = useCallback(
+    (direction: "up" | "down") => {
+      if (!history || history.length === 0) return false;
+      if (direction === "up") {
+        if (historyIndexRef.current === null) {
+          stashedDraftRef.current = value;
+          historyIndexRef.current = 0;
+        } else {
+          historyIndexRef.current = Math.min(
+            historyIndexRef.current + 1,
+            history.length - 1,
+          );
+        }
+        setInput(history[historyIndexRef.current] ?? "");
+        return true;
+      }
+      if (historyIndexRef.current === null) return false;
+      if (historyIndexRef.current === 0) {
+        historyIndexRef.current = null;
+        setInput(stashedDraftRef.current);
+        return true;
+      }
+      historyIndexRef.current -= 1;
+      setInput(history[historyIndexRef.current] ?? "");
+      return true;
+    },
+    [history, value, setInput],
+  );
 
   const handleMentionChipClick = useCallback(
     (id: string) => {
@@ -98,7 +149,10 @@ export const MentionTextarea = forwardRef<
     <MentionEditor
       ref={ref}
       value={value}
-      onValueChange={controller.textInput.setInput}
+      onValueChange={handleValueChange}
+      onHistoryNavigate={
+        history && history.length > 0 ? handleHistoryNavigate : undefined
+      }
       items={items}
       slashItems={slashItems}
       onMentionChipClick={handleMentionChipClick}

--- a/apps/web/src/lib/components/mentions/MentionEditor.tsx
+++ b/apps/web/src/lib/components/mentions/MentionEditor.tsx
@@ -16,6 +16,8 @@ import {
   buildMentionPattern,
   buildSkillPattern,
   extractEditableText,
+  isCaretOnFirstLine,
+  isCaretOnLastLine,
   normalizeMentionText,
   placeCursorAtEnd,
   renderEditorChipHtml,
@@ -58,6 +60,12 @@ export interface MentionEditorProps<TItem extends MentionItem = MentionItem> {
   chipClassName?: string;
   skillChipClassName?: string;
   onEnterSubmit?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  /**
+   * Called when ArrowUp is pressed on the first line, or ArrowDown on the last
+   * line, while the mention popup is closed. Return true if the navigation was
+   * handled (e.g. a history entry was applied) to suppress caret movement.
+   */
+  onHistoryNavigate?: (direction: "up" | "down") => boolean;
   renderItem?: (item: TItem, isSelected: boolean) => ReactNode;
   renderSlashItem?: (item: SlashItem, isSelected: boolean) => ReactNode;
   filterSlashItem?: (item: SlashItem, query: string) => boolean;
@@ -220,6 +228,7 @@ export function MentionEditor<TItem extends MentionItem = MentionItem>({
   chipClassName = MENTION_CHIP_CLASS,
   skillChipClassName = SKILL_CHIP_CLASS,
   onEnterSubmit,
+  onHistoryNavigate,
   renderItem = defaultRenderItem,
   renderSlashItem = defaultRenderSlashItem,
   filterItem = defaultFilter,
@@ -584,6 +593,31 @@ export function MentionEditor<TItem extends MentionItem = MentionItem>({
         }
       }
 
+      // Message-history recall: only when the popup is closed and no modifier
+      // is held, so it never competes with the mention picker or shortcuts.
+      if (
+        onHistoryNavigate &&
+        !trigger.isOpen &&
+        !e.shiftKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey
+      ) {
+        const el = editorRef.current;
+        if (e.key === "ArrowUp" && el && isCaretOnFirstLine(el)) {
+          if (onHistoryNavigate("up")) {
+            e.preventDefault();
+            return;
+          }
+        }
+        if (e.key === "ArrowDown" && el && isCaretOnLastLine(el)) {
+          if (onHistoryNavigate("down")) {
+            e.preventDefault();
+            return;
+          }
+        }
+      }
+
       if (e.key === "Enter" && onEnterSubmit) {
         if (isComposing || e.nativeEvent.isComposing) return;
         if (e.shiftKey) return;
@@ -600,6 +634,7 @@ export function MentionEditor<TItem extends MentionItem = MentionItem>({
       closeTrigger,
       isComposing,
       onEnterSubmit,
+      onHistoryNavigate,
     ],
   );
 

--- a/apps/web/src/lib/components/mentions/mentionEditorUtils.ts
+++ b/apps/web/src/lib/components/mentions/mentionEditorUtils.ts
@@ -211,6 +211,51 @@ export function extractEditableText(el: Element): string {
   return out;
 }
 
+/** Last client rect of a collapsed caret range, or null when unavailable. */
+function caretRectFromRange(range: Range): DOMRect | null {
+  const rects = range.getClientRects();
+  const last = rects.item(rects.length - 1);
+  if (last) return last;
+  const rect = range.getBoundingClientRect();
+  if (rect.height > 0 || rect.width > 0 || rect.top !== 0) return rect;
+  return null;
+}
+
+/**
+ * True when the collapsed caret sits on the first visual line of `el`. Lets a
+ * chat composer recall history on ArrowUp without trapping multi-line editing.
+ * A non-collapsed selection returns false (leave arrows to the browser); an
+ * empty editor (no caret rect) returns true so history stays reachable.
+ */
+export function isCaretOnFirstLine(el: HTMLElement): boolean {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+    return false;
+  }
+  const range = selection.getRangeAt(0);
+  if (!el.contains(range.startContainer)) return false;
+  const caret = caretRectFromRange(range);
+  if (!caret) return true;
+  const editorRect = el.getBoundingClientRect();
+  const lineHeight = caret.height > 0 ? caret.height : 18;
+  return caret.top - editorRect.top < lineHeight;
+}
+
+/** True when the collapsed caret sits on the last visual line of `el`. */
+export function isCaretOnLastLine(el: HTMLElement): boolean {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+    return false;
+  }
+  const range = selection.getRangeAt(0);
+  if (!el.contains(range.startContainer)) return false;
+  const caret = caretRectFromRange(range);
+  if (!caret) return true;
+  const editorRect = el.getBoundingClientRect();
+  const lineHeight = caret.height > 0 ? caret.height : 18;
+  return editorRect.bottom - caret.bottom < lineHeight;
+}
+
 export function placeCursorAtEnd(el: Element): void {
   const sel = window.getSelection();
   if (!sel) return;

--- a/apps/web/src/routes/_repo/$owner/$repo/designs/_components/DesignChatPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/designs/_components/DesignChatPanel.tsx
@@ -45,6 +45,7 @@ import { useSessionSettings } from "@/lib/hooks/useSessionSettings";
 import { useAvailableAiModels } from "@/lib/hooks/useAvailableAiModels";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { MessageMentionText } from "@/lib/components/chat/MessageMentionText";
+import { tokenizedToEditable } from "@/lib/components/mentions";
 import {
   MentionTextarea,
   type MentionTextareaHandle,
@@ -125,6 +126,23 @@ export function DesignChatPanel({
       );
     }
   });
+  const reorderQueuedMessages = useMutation(
+    api.queuedMessages.reorder,
+  ).withOptimisticUpdate((localStore, args) => {
+    const current = localStore.getQuery(api.queuedMessages.listByParent, {
+      parentId: designSessionId,
+    });
+    if (current === undefined) return;
+    const byId = new Map(current.map((m) => [m._id, m]));
+    const reordered = args.orderedIds
+      .map((id) => byId.get(id))
+      .filter((m): m is (typeof current)[number] => m !== undefined);
+    localStore.setQuery(
+      api.queuedMessages.listByParent,
+      { parentId: designSessionId },
+      reordered,
+    );
+  });
   const { repo, basePath } = useRepo();
 
   const mentionRef = useRef<MentionTextareaHandle>(null);
@@ -143,6 +161,17 @@ export function DesignChatPanel({
 
   const messagesList = messages ?? [];
   const lastMessage = messagesList[messagesList.length - 1];
+
+  // Previously sent messages as editable display text, newest-first, for
+  // ArrowUp/ArrowDown history recall in the composer.
+  const messageHistory = useMemo(
+    () =>
+      (messages ?? [])
+        .filter((m) => m.role === "user" && !m.isSystemAlert && m.content)
+        .map((m) => tokenizedToEditable(m.content ?? "").displayText)
+        .reverse(),
+    [messages],
+  );
 
   useEffect(() => {
     if (isSending && lastMessage?.role === "assistant" && lastMessage.content) {
@@ -369,6 +398,12 @@ export function DesignChatPanel({
               onDelete={async (id) => {
                 await deleteQueuedMessage({ id });
               }}
+              onReorder={async (orderedIds) => {
+                await reorderQueuedMessages({
+                  parentId: designSessionId,
+                  orderedIds,
+                });
+              }}
             />
             {!draftSeed.isReady ? (
               // Placeholder that matches the input group's visual footprint.
@@ -398,6 +433,7 @@ export function DesignChatPanel({
                     }
                     initialMentionMap={draftSeed.mentionMap}
                     initialSkillMap={draftSeed.skillMap}
+                    history={messageHistory}
                   />
                   <PromptInputFooter>
                     <PromptInputTools>

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Composer message-history recall and reorderable queue - 2026-07-16
+
+- The chat composer now recalls previously sent messages: ArrowUp on the first line steps back through your sent messages and ArrowDown moves forward to your live draft, terminal-style. Works across session, quick-task, project, and design chats.
+- Queued messages can be dragged to reorder how they run; the new order persists and dequeue follows it. Recalled messages that contained @/‍ mentions come back as plain text (a known limit of the editor's mount-time chip map).
+- Added an `order` field + index to `queuedMessages` with a `reorder` mutation and a backfill migration for legacy rows; run order no longer depends on creation time.
+- Reason for change: retyping past prompts and being stuck with fixed FIFO queue order were both friction points in day-to-day chat use.
+
 ## Autosave automation settings and add a Sonner toast - 2026-07-16
 
 - The automation Settings tab no longer has a Save button: text fields (title, prompt, cron) autosave on blur and toggles/model select save immediately, so changes persist without an extra click.

--- a/packages/backend/convex/_designSessions/execution.ts
+++ b/packages/backend/convex/_designSessions/execution.ts
@@ -81,6 +81,7 @@ export const enqueueMessage = authMutation({
       parentId: args.id,
       content,
       createdAt: Date.now(),
+      order: Date.now(),
       userId: ctx.userId,
       model: normalizeAIModel(args.model),
       personaId: args.personaId,

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -78,6 +78,7 @@ import type * as _mentions_resolveMessageTokens from "../_mentions/resolveMessag
 import type * as _mentions_resolveSkillMentions from "../_mentions/resolveSkillMentions.js";
 import type * as _mentions_skillToken from "../_mentions/skillToken.js";
 import type * as _migrations_backfillNumIds from "../_migrations/backfillNumIds.js";
+import type * as _migrations_backfillQueuedMessageOrder from "../_migrations/backfillQueuedMessageOrder.js";
 import type * as _migrations_backfillTaskSubscribers from "../_migrations/backfillTaskSubscribers.js";
 import type * as _migrations_cleanup from "../_migrations/cleanup.js";
 import type * as _migrations_deleteRepos from "../_migrations/deleteRepos.js";
@@ -342,6 +343,7 @@ declare const fullApi: ApiFromModules<{
   "_mentions/resolveSkillMentions": typeof _mentions_resolveSkillMentions;
   "_mentions/skillToken": typeof _mentions_skillToken;
   "_migrations/backfillNumIds": typeof _migrations_backfillNumIds;
+  "_migrations/backfillQueuedMessageOrder": typeof _migrations_backfillQueuedMessageOrder;
   "_migrations/backfillTaskSubscribers": typeof _migrations_backfillTaskSubscribers;
   "_migrations/cleanup": typeof _migrations_cleanup;
   "_migrations/deleteRepos": typeof _migrations_deleteRepos;

--- a/packages/backend/convex/_migrations/backfillQueuedMessageOrder.ts
+++ b/packages/backend/convex/_migrations/backfillQueuedMessageOrder.ts
@@ -1,0 +1,31 @@
+import { v } from "convex/values";
+import { internalMutation } from "../_generated/server";
+
+/**
+ * Backfills `order` on queued messages that predate the field, setting it to
+ * `createdAt` so existing rows keep their FIFO run order under the new
+ * `by_parent_and_order` index. queuedMessages are transient (consumed within
+ * minutes), so this mainly guards rows in flight at deploy time.
+ *
+ * Run once: `npx convex run migrations:backfillQueuedMessageOrder`
+ * Delete this function after it has run everywhere it was needed.
+ */
+export const backfillQueuedMessageOrder = internalMutation({
+  args: {},
+  returns: v.object({ patched: v.number() }),
+  handler: async (ctx) => {
+    let patched = 0;
+    const messages = await ctx.db.query("queuedMessages").collect();
+    for (const message of messages) {
+      if (message.order !== undefined) {
+        continue;
+      }
+      await ctx.db.patch(message._id, { order: message.createdAt });
+      patched++;
+    }
+    console.log(
+      `[migration] backfillQueuedMessageOrder: patched ${patched} queued messages`,
+    );
+    return { patched };
+  },
+});

--- a/packages/backend/convex/_queues/helpers.ts
+++ b/packages/backend/convex/_queues/helpers.ts
@@ -24,7 +24,7 @@ export async function startNextQueuedSessionMessage(
 
   const nextMessage = await ctx.db
     .query("queuedMessages")
-    .withIndex("by_parent_and_created", (q) => q.eq("parentId", sessionId))
+    .withIndex("by_parent_and_order", (q) => q.eq("parentId", sessionId))
     .order("asc")
     .first();
   if (!nextMessage) {
@@ -118,9 +118,7 @@ export async function startNextQueuedDesignMessage(
 
   const nextMessage = await ctx.db
     .query("queuedMessages")
-    .withIndex("by_parent_and_created", (q) =>
-      q.eq("parentId", designSessionId),
-    )
+    .withIndex("by_parent_and_order", (q) => q.eq("parentId", designSessionId))
     .order("asc")
     .first();
   if (!nextMessage) {
@@ -193,7 +191,7 @@ export async function startNextQueuedProjectChatMessage(
 
   const nextMessage = await ctx.db
     .query("queuedMessages")
-    .withIndex("by_parent_and_created", (q) => q.eq("parentId", projectId))
+    .withIndex("by_parent_and_order", (q) => q.eq("parentId", projectId))
     .order("asc")
     .first();
   if (!nextMessage) {
@@ -260,7 +258,7 @@ export async function startNextQueuedTaskChatMessage(
 
   const nextMessage = await ctx.db
     .query("queuedMessages")
-    .withIndex("by_parent_and_created", (q) => q.eq("parentId", taskId))
+    .withIndex("by_parent_and_order", (q) => q.eq("parentId", taskId))
     .order("asc")
     .first();
   if (!nextMessage) {

--- a/packages/backend/convex/_sessions/execution.ts
+++ b/packages/backend/convex/_sessions/execution.ts
@@ -171,6 +171,7 @@ export const enqueueMessage = authMutation({
       parentId: args.sessionId,
       content,
       createdAt: Date.now(),
+      order: Date.now(),
       userId: ctx.userId,
       mode: args.mode,
       model: args.model,

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -284,6 +284,10 @@ export const githubRepoFields = {
   systemPrompt: v.optional(v.string()),
   prRecapsEnabled: v.optional(v.boolean()),
   prRecapModel: v.optional(aiModelValidator),
+  // Convex storage id of an uploaded logo image shown next to the repo in repo
+  // lists. Per-app (not shared across monorepo siblings). Resolved to a URL by
+  // list/listByTeam via ctx.storage.getUrl.
+  logoStorageId: v.optional(v.id("_storage")),
 };
 
 export const projectFields = {
@@ -415,6 +419,10 @@ export const queuedMessageFields = {
   ),
   content: v.string(),
   createdAt: v.number(),
+  // Sort key for queue run order. Enqueue sets Date.now() (appends to the end);
+  // the reorder mutation rewrites this to 0-based positions. Optional so the
+  // field deploys without a migration; legacy rows without it sort first.
+  order: v.optional(v.number()),
   userId: v.id("users"),
   mode: v.optional(sessionModeValidator),
   model: v.optional(aiModelValidator),

--- a/packages/backend/convex/agentTaskChatWorkflow.ts
+++ b/packages/backend/convex/agentTaskChatWorkflow.ts
@@ -128,6 +128,7 @@ export const enqueueMessage = authMutation({
       parentId: args.taskId,
       content,
       createdAt: Date.now(),
+      order: Date.now(),
       userId: ctx.userId,
       model: args.model,
       reasoningLevel: args.reasoningLevel,

--- a/packages/backend/convex/migrations.ts
+++ b/packages/backend/convex/migrations.ts
@@ -19,3 +19,4 @@ export {
   backfillNumIds,
   backfillNumIdsForEntityType,
 } from "./_migrations/backfillNumIds";
+export { backfillQueuedMessageOrder } from "./_migrations/backfillQueuedMessageOrder";

--- a/packages/backend/convex/projectChatWorkflow.ts
+++ b/packages/backend/convex/projectChatWorkflow.ts
@@ -130,6 +130,7 @@ export const enqueueMessage = authMutation({
       parentId: args.projectId,
       content,
       createdAt: Date.now(),
+      order: Date.now(),
       userId: ctx.userId,
       model: args.model,
       reasoningLevel: args.reasoningLevel,

--- a/packages/backend/convex/queuedMessages.ts
+++ b/packages/backend/convex/queuedMessages.ts
@@ -10,7 +10,7 @@ const queuedMessageValidator = v.object({
   ...queuedMessageFields,
 });
 
-/** Lists queued messages for a parent entity, ordered by creation time. */
+/** Lists queued messages for a parent entity, ordered by run order. */
 export const listByParent = authQuery({
   args: { parentId: parentIdValidator },
   returns: v.array(queuedMessageValidator),
@@ -24,9 +24,7 @@ export const listByParent = authQuery({
     }
     return await ctx.db
       .query("queuedMessages")
-      .withIndex("by_parent_and_created", (q) =>
-        q.eq("parentId", args.parentId),
-      )
+      .withIndex("by_parent_and_order", (q) => q.eq("parentId", args.parentId))
       .order("asc")
       .collect();
   },
@@ -84,6 +82,41 @@ export const remove = authMutation({
 
     await ctx.db.delete(args.id);
     await ctx.db.patch(queuedMessage.parentId, { updatedAt: Date.now() });
+    return null;
+  },
+});
+
+/**
+ * Rewrites the run order of a parent's queued messages. `orderedIds` is the
+ * desired top-to-bottom order; each message's `order` is set to its 0-based
+ * position. A later enqueue uses Date.now() (far larger), so newly queued
+ * messages always land after a reordered set.
+ */
+export const reorder = authMutation({
+  args: {
+    parentId: parentIdValidator,
+    orderedIds: v.array(v.id("queuedMessages")),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const parent = await ctx.db.get(args.parentId);
+    if (!parent || !parent.repoId) {
+      throw new Error("Queued message parent not found");
+    }
+    if (!(await hasRepoAccess(ctx.db, parent.repoId, ctx.userId))) {
+      throw new Error("Not authorized");
+    }
+
+    let index = 0;
+    for (const id of args.orderedIds) {
+      const queuedMessage = await ctx.db.get(id);
+      if (!queuedMessage || queuedMessage.parentId !== args.parentId) {
+        throw new Error("Queued message does not belong to this parent");
+      }
+      await ctx.db.patch(id, { order: index });
+      index += 1;
+    }
+    await ctx.db.patch(args.parentId, { updatedAt: Date.now() });
     return null;
   },
 });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -133,10 +133,9 @@ const schema = defineSchema(
     ]),
     taskActivity: defineTable(taskActivityFields).index("by_task", ["taskId"]),
     messages: defineTable(messageFields).index("by_parent", ["parentId"]),
-    queuedMessages: defineTable(queuedMessageFields).index(
-      "by_parent_and_created",
-      ["parentId", "createdAt"],
-    ),
+    queuedMessages: defineTable(queuedMessageFields)
+      .index("by_parent_and_created", ["parentId", "createdAt"])
+      .index("by_parent_and_order", ["parentId", "order"]),
     sessions: defineTable(sessionFields)
       .index("by_repo", ["repoId"])
       .index("by_user", ["userId"])

--- a/packages/ui/src/ai-elements/queue.tsx
+++ b/packages/ui/src/ai-elements/queue.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ComponentProps, ReactNode } from "react";
+import { forwardRef, type ComponentProps, type ReactNode } from "react";
 import { ChevronDownIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import {
@@ -104,15 +104,19 @@ export const QueueList = ({
 
 export type QueueItemProps = ComponentProps<"li">;
 
-export const QueueItem = ({ className, ...props }: QueueItemProps) => (
-  <li
-    className={cn(
-      "group flex flex-col gap-1 rounded-md px-3 py-1 text-sm transition-colors hover:bg-muted",
-      className,
-    )}
-    {...props}
-  />
+export const QueueItem = forwardRef<HTMLLIElement, QueueItemProps>(
+  ({ className, ...props }, ref) => (
+    <li
+      ref={ref}
+      className={cn(
+        "group flex flex-col gap-1 rounded-md px-3 py-1 text-sm transition-colors hover:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  ),
 );
+QueueItem.displayName = "QueueItem";
 
 export type QueueItemIndicatorProps = ComponentProps<"span"> & {
   completed?: boolean;


### PR DESCRIPTION
Composer message-history recall (ArrowUp/ArrowDown, caret-at-edge) across all chat surfaces, and drag-to-reorder for the queued-messages panel backed by a dedicated `order` field + reorder mutation + backfill migration.