### PR TITLE
feat(chat): subagent drill-in, todo checklists, blocking questions

### DIFF
--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -146,7 +146,7 @@ interface ChatBodyProps {
   /** Submits a structured answer for {@link blockingQuestion}, resuming the turn. */
   onAnswerBlockingQuestion?: (
     toolUseId: string,
-    answers: Record<string, string | string[]>,
+    answers: Record<string, string>,
   ) => Promise<void>;
   isExecuting: boolean;
   isInputDisabled: boolean;
@@ -370,7 +370,7 @@ export function ChatBody({
   );
 
   const handleBlockingAnswer = useCallback(
-    async (answers: Record<string, string | string[]>) => {
+    async (answers: Record<string, string>) => {
       if (!blockingQuestion || !onAnswerBlockingQuestion) return;
       await onAnswerBlockingQuestion(blockingQuestion.toolUseId, answers);
     },
@@ -486,6 +486,7 @@ export function ChatBody({
                       questions={blockingQuestions}
                       onAnswer={handleQuestionAnswer}
                       onAnswerStructured={handleBlockingAnswer}
+                      isLoading={isExecuting}
                     />
                   </div>
                 ) : activePendingQuestion ? (

--- a/apps/web/src/lib/components/chat/ChatBody.tsx
+++ b/apps/web/src/lib/components/chat/ChatBody.tsx
@@ -136,6 +136,17 @@ interface ChatBodyProps {
   streamingActivity?: string;
   streamingContent?: string;
   streamingPendingQuestion?: string;
+  /**
+   * A blocking AskUserQuestion awaiting the user (Agent SDK `canUseTool`). When
+   * set, its interactive card replaces the fire-and-forget `streamingPendingQuestion`
+   * path and the turn stays executing until {@link onAnswerBlockingQuestion} runs.
+   */
+  blockingQuestion?: { toolUseId: string; payload: string };
+  /** Submits a structured answer for {@link blockingQuestion}, resuming the turn. */
+  onAnswerBlockingQuestion?: (
+    toolUseId: string,
+    answers: Record<string, string | string[]>,
+  ) => Promise<void>;
   isExecuting: boolean;
   isInputDisabled: boolean;
   isArchived?: boolean;
@@ -213,6 +224,8 @@ export function ChatBody({
   streamingActivity,
   streamingContent,
   streamingPendingQuestion,
+  blockingQuestion,
+  onAnswerBlockingQuestion,
   isExecuting,
   isInputDisabled,
   isArchived,
@@ -307,6 +320,13 @@ export function ChatBody({
     () => (questionDismissed ? null : parsePendingQuestion(pendingQuestionRaw)),
     [questionDismissed, pendingQuestionRaw],
   );
+  // A blocking AskUserQuestion (Agent SDK) takes precedence over the
+  // fire-and-forget path: it keeps the turn paused until the user answers.
+  const blockingQuestions = useMemo(
+    () =>
+      blockingQuestion ? parsePendingQuestion(blockingQuestion.payload) : null,
+    [blockingQuestion],
+  );
 
   useEffect(() => {
     if (pendingQuestionRaw) {
@@ -346,6 +366,14 @@ export function ChatBody({
       await onSend(answer);
     },
     [onSend],
+  );
+
+  const handleBlockingAnswer = useCallback(
+    async (answers: Record<string, string | string[]>) => {
+      if (!blockingQuestion || !onAnswerBlockingQuestion) return;
+      await onAnswerBlockingQuestion(blockingQuestion.toolUseId, answers);
+    },
+    [blockingQuestion, onAnswerBlockingQuestion],
   );
 
   const queuedMessageItems = useMemo(
@@ -422,7 +450,15 @@ export function ChatBody({
                     {streamingContent}
                   </MessageResponse>
                 ) : null}
-                {activePendingQuestion && (
+                {blockingQuestions ? (
+                  <div className="mt-3">
+                    <MultipleChoiceQuestion
+                      questions={blockingQuestions}
+                      onAnswer={handleQuestionAnswer}
+                      onAnswerStructured={handleBlockingAnswer}
+                    />
+                  </div>
+                ) : activePendingQuestion ? (
                   <div className="mt-3">
                     <MultipleChoiceQuestion
                       questions={activePendingQuestion}
@@ -430,7 +466,7 @@ export function ChatBody({
                       isLoading={isExecuting}
                     />
                   </div>
-                )}
+                ) : null}
               </>
             ) : (
               <>
@@ -558,7 +594,7 @@ export function ChatBody({
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
-      {!isArchived && !activePendingQuestion && (
+      {!isArchived && !activePendingQuestion && !blockingQuestions && (
         <div className="p-2 md:p-3 max-w-3xl mx-auto w-full">
           <AnimatePresence initial={false}>
             {beforeQueuedContent ? (

--- a/apps/web/src/lib/components/plan/MultipleChoiceQuestion.tsx
+++ b/apps/web/src/lib/components/plan/MultipleChoiceQuestion.tsx
@@ -27,6 +27,13 @@ interface MultipleChoiceQuestionProps {
   options?: OptionItem[];
   questions?: QuestionItem[];
   onAnswer: (answer: string) => void;
+  /**
+   * When provided, submitting calls this with a structured map (question text →
+   * selected label, or an array for multi-select) INSTEAD of {@link onAnswer}'s
+   * `Q:/A:` string. Used for blocking AskUserQuestion, where the answer becomes a
+   * real tool_result rather than a new chat message.
+   */
+  onAnswerStructured?: (answers: Record<string, string | string[]>) => void;
   isLoading?: boolean;
   questionNumber?: number;
   // Optional controls appended to the submit row (e.g. a question counter and
@@ -39,6 +46,7 @@ export function MultipleChoiceQuestion({
   options,
   questions,
   onAnswer,
+  onAnswerStructured,
   isLoading = false,
   trailingControls,
 }: MultipleChoiceQuestionProps) {
@@ -100,10 +108,30 @@ export function MultipleChoiceQuestion({
       .join("\n\n");
   };
 
+  // Structured answer keyed by question text: an array for multi-select, a single
+  // string otherwise (or the free-text "Other" value). Shape the SDK's
+  // AskUserQuestion expects back as the tool result.
+  const buildStructuredAnswer = (): Record<string, string | string[]> => {
+    const result: Record<string, string | string[]> = {};
+    resolvedQuestions.forEach((rq, idx) => {
+      if (otherActive[idx]) {
+        result[rq.question] = (customAnswers[idx] ?? "").trim();
+        return;
+      }
+      const selected = answers[idx] ?? [];
+      result[rq.question] = rq.multiSelect ? selected : (selected[0] ?? "");
+    });
+    return result;
+  };
+
   const handleNext = () => {
     if (!currentHasAnswer || isLoading) return;
     if (isLastStep) {
-      onAnswer(formatAnswer());
+      if (onAnswerStructured) {
+        onAnswerStructured(buildStructuredAnswer());
+      } else {
+        onAnswer(formatAnswer());
+      }
     } else {
       setCurrentStep((prev) => prev + 1);
     }

--- a/apps/web/src/lib/components/plan/MultipleChoiceQuestion.tsx
+++ b/apps/web/src/lib/components/plan/MultipleChoiceQuestion.tsx
@@ -29,11 +29,11 @@ interface MultipleChoiceQuestionProps {
   onAnswer: (answer: string) => void;
   /**
    * When provided, submitting calls this with a structured map (question text →
-   * selected label, or an array for multi-select) INSTEAD of {@link onAnswer}'s
-   * `Q:/A:` string. Used for blocking AskUserQuestion, where the answer becomes a
-   * real tool_result rather than a new chat message.
+   * selected label; multi-select joined as a comma-separated string) INSTEAD of
+   * {@link onAnswer}'s `Q:/A:` string. Used for blocking AskUserQuestion, where
+   * the answer becomes a real tool_result rather than a new chat message.
    */
-  onAnswerStructured?: (answers: Record<string, string | string[]>) => void;
+  onAnswerStructured?: (answers: Record<string, string>) => void;
   isLoading?: boolean;
   questionNumber?: number;
   // Optional controls appended to the submit row (e.g. a question counter and
@@ -108,18 +108,20 @@ export function MultipleChoiceQuestion({
       .join("\n\n");
   };
 
-  // Structured answer keyed by question text: an array for multi-select, a single
-  // string otherwise (or the free-text "Other" value). Shape the SDK's
-  // AskUserQuestion expects back as the tool result.
-  const buildStructuredAnswer = (): Record<string, string | string[]> => {
-    const result: Record<string, string | string[]> = {};
+  // Structured answer keyed by question text → selected label (or free-text
+  // "Other"). Multi-select is a comma-separated string — the shape AskUserQuestion
+  // expects in updatedInput.answers.
+  const buildStructuredAnswer = (): Record<string, string> => {
+    const result: Record<string, string> = {};
     resolvedQuestions.forEach((rq, idx) => {
       if (otherActive[idx]) {
         result[rq.question] = (customAnswers[idx] ?? "").trim();
         return;
       }
       const selected = answers[idx] ?? [];
-      result[rq.question] = rq.multiSelect ? selected : (selected[0] ?? "");
+      result[rq.question] = rq.multiSelect
+        ? selected.join(", ")
+        : (selected[0] ?? "");
     });
     return result;
   };

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
@@ -341,7 +341,7 @@ export function ChatPanel({
   });
   const answerPendingQuestion = useMutation(api.pendingQuestions.answer);
   const handleAnswerBlockingQuestion = useCallback(
-    async (toolUseId: string, answers: Record<string, string | string[]>) => {
+    async (toolUseId: string, answers: Record<string, string>) => {
       await answerPendingQuestion({
         entityId: sessionId,
         toolUseId,

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
@@ -333,6 +333,23 @@ export function ChatPanel({
     await cancelExecutionMutation({ sessionId });
   }, [cancelExecutionMutation, sessionId]);
 
+  // Blocking AskUserQuestion: the paused sandbox turn posts a question here; the
+  // user's answer resumes the SAME turn (rather than starting a new message).
+  const activeQuestion = useQuery(api.pendingQuestions.getActive, {
+    entityId: sessionId,
+  });
+  const answerPendingQuestion = useMutation(api.pendingQuestions.answer);
+  const handleAnswerBlockingQuestion = useCallback(
+    async (toolUseId: string, answers: Record<string, string | string[]>) => {
+      await answerPendingQuestion({
+        entityId: sessionId,
+        toolUseId,
+        answer: JSON.stringify(answers),
+      });
+    },
+    [answerPendingQuestion, sessionId],
+  );
+
   const handleGenerateSummary = async () => {
     setIsSummarizing(true);
     try {
@@ -657,6 +674,8 @@ export function ChatPanel({
         streamingActivity={streamingActivity}
         streamingContent={streamingContent}
         streamingPendingQuestion={streamingPendingQuestion}
+        blockingQuestion={activeQuestion ?? undefined}
+        onAnswerBlockingQuestion={handleAnswerBlockingQuestion}
         isExecuting={isExecuting}
         isInputDisabled={!isSandboxActive}
         isArchived={isArchived}

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## PR recap GitHub comments link to the correct Eva doc URL - 2026-07-17
+## Richer agent-SDK tool UIs: subagent drill-in, todo checklists, blocking questions - 2026-07-17
+
+- Subagent activity now nests: a subagent row expands to show the reads, edits, and commands it ran, instead of a single opaque "Ran agent" line.
+- Fixed subagent runs going unrecognised — the Agent SDK renamed the tool from `Task` to `Agent`, and both names are now mapped.
+- TodoWrite/TaskCreate/TaskUpdate now render as a single live checklist with per-item status instead of a generic "Updating tasks" row.
+- AskUserQuestion can now block the turn: in SDK sessions the agent pauses via `canUseTool` until the user answers, and the answer resumes the same turn as a real tool result (no timeout while waiting).
+- Reason for change: the Agent SDK integration surfaced these tools generically; this makes subagent work, task tracking, and clarifying questions first-class in the chat.
 
 - Sticky PR recap comments now use the per-repo numeric `/docs/N` path instead of the Convex document id, which Eva routes do not resolve.
 - Reason for change: “View recap in Eva” links were 404ing / failing to load the doc after a successful recap.

--- a/packages/backend/callback-src/config.ts
+++ b/packages/backend/callback-src/config.ts
@@ -19,6 +19,17 @@ export const ALLOWED_TOOLS = process.env.ALLOWED_TOOLS || "Read,Glob,Grep";
 /** "sdk" runs Claude via the Agent SDK query(); anything else spawns `claude -p`. */
 export const CLAUDE_ATTEMPT_MODE = process.env.CLAUDE_ATTEMPT_MODE || "cli";
 /**
+ * Human-in-the-loop AskUserQuestion. Only the Agent SDK exposes the `canUseTool`
+ * pause needed to block a turn on an answer, and only sessions currently wire the
+ * answering UI — so this is gated to SDK session runs. Elsewhere AskUserQuestion
+ * stays the old fire-and-forget metadata (surfaced after the turn). When enabled
+ * the SDK drops `bypassPermissions` for a `canUseTool` gate that auto-allows every
+ * tool except AskUserQuestion (which waits for the user's answer via Convex).
+ */
+export const BLOCKING_QUESTIONS_ENABLED =
+  process.env.ENTITY_ID_FIELD === "sessionId" &&
+  (CLAUDE_ATTEMPT_MODE === "sdk" || CLAUDE_ATTEMPT_MODE === "sdk-daemon");
+/**
  * Pre-warm mode for the sdk-daemon: boot the daemon (creating the warm query()
  * so the CLI/MCP/API connection is live) and wait for the first prompt via the
  * handoff protocol instead of running an initial turn. Lets a session-open
@@ -295,6 +306,7 @@ export const TOOL_STEP_TYPES = new Set([
   "notebook",
   "subtask",
   "question",
+  "todos",
 ]);
 
 export const CODEX_PRICING_PER_MILLION: Record<

--- a/packages/backend/callback-src/parse/canonical.ts
+++ b/packages/backend/callback-src/parse/canonical.ts
@@ -4,7 +4,12 @@ import { codexParseLine } from "../providers/codex.js";
 import { cursorParseLine } from "../providers/cursor.js";
 import { opencodeParseLine } from "../providers/opencode.js";
 import { callbackState as S } from "../runtime/state.js";
-import type { CanonicalEvent, JsonObject, ProgressStep } from "../types.js";
+import type {
+  CanonicalEvent,
+  JsonObject,
+  ProgressStep,
+  TodoItem,
+} from "../types.js";
 import { tryParseJson } from "../utils.js";
 
 export {
@@ -17,16 +22,68 @@ export {
   toolCallToStep,
 } from "./toolSteps.js";
 
+/** Flips one step to complete and swaps its in-progress label for the past-tense one. */
+function markStepComplete(step: ProgressStep): void {
+  step.status = "complete";
+  if (completedLabels[step.label]) {
+    step.label = completedLabels[step.label];
+  } else if (step.label.startsWith("Using ") && step.label.endsWith("...")) {
+    step.label = "Used " + step.label.slice(6, -3);
+  }
+}
+
 /** Marks the last accumulated step as complete and updates its label. */
 export function markLastComplete(): void {
   if (S.accumulatedSteps.length === 0) return;
-  const last = S.accumulatedSteps[S.accumulatedSteps.length - 1];
-  last.status = "complete";
-  if (completedLabels[last.label]) {
-    last.label = completedLabels[last.label];
-  } else if (last.label.startsWith("Using ") && last.label.endsWith("...")) {
-    last.label = "Used " + last.label.slice(6, -3);
+  markStepComplete(S.accumulatedSteps[S.accumulatedSteps.length - 1]);
+}
+
+/**
+ * Completes the step whose `toolUseId` matches this tool_result (Claude sets it
+ * on every tool_use). Falls back to the last step for providers/steps without an
+ * id. Matching by id is what lets a subagent's parent `Agent` step stay active
+ * until its own tool_result, rather than being closed by its first child.
+ */
+function completeToolStep(trackingId?: string): void {
+  if (trackingId) {
+    for (let i = S.accumulatedSteps.length - 1; i >= 0; i--) {
+      const step = S.accumulatedSteps[i];
+      if (step.toolUseId === trackingId) {
+        markStepComplete(step);
+        return;
+      }
+    }
   }
+  markLastComplete();
+}
+
+/** Short "N of M done" summary used as the todos step's fallback detail. */
+function summarizeTodos(todos: TodoItem[]): string {
+  const done = todos.filter((t) => t.status === "completed").length;
+  return `${done} of ${todos.length} done`;
+}
+
+/**
+ * Applies a todo checklist snapshot. TodoWrite/TaskCreate/TaskUpdate fire many
+ * times per turn; rather than one activity row per call, we keep ONE evolving
+ * "todos" step and update it in place so the UI shows a single live checklist.
+ */
+function applyTodosSnapshot(todos: TodoItem[]): void {
+  const existing = S.accumulatedSteps.find((step) => step.type === "todos");
+  if (existing) {
+    existing.todos = todos;
+    existing.detail = summarizeTodos(todos);
+    return;
+  }
+  markLastComplete();
+  S.accumulatedSteps.push({
+    type: "todos",
+    label: "Updating tasks...",
+    detail: summarizeTodos(todos),
+    todos,
+    status: "active",
+  });
+  S.lastStepType = "tool";
 }
 
 /** Thinking is a transient liveness signal, not a durable activity row. */
@@ -49,7 +106,17 @@ function pushProgressStep(step: ProgressStep): void {
     updateThinkingStep(step.label, step.detail);
     return;
   }
-  markLastComplete();
+  // When pushing the FIRST step inside a subagent, don't auto-complete its
+  // parent `Agent` step — the parent stays active until its own tool_result
+  // (completed by toolUseId). Sibling children still close each other normally.
+  const last = S.accumulatedSteps[S.accumulatedSteps.length - 1];
+  const isFirstChildUnderParent =
+    step.parentToolUseId !== undefined &&
+    last !== undefined &&
+    last.toolUseId === step.parentToolUseId;
+  if (!isFirstChildUnderParent) {
+    markLastComplete();
+  }
   S.accumulatedSteps.push(step);
   S.lastStepType = "tool";
 }
@@ -81,7 +148,7 @@ export function applyCanonicalEvents(events: CanonicalEvent[]): boolean {
         }
         break;
       case "complete_tool":
-        markLastComplete();
+        completeToolStep(ev.trackingId);
         if (ev.trackingId !== undefined) {
           S.codexToolItemIds.delete(ev.trackingId);
         }
@@ -112,6 +179,9 @@ export function applyCanonicalEvents(events: CanonicalEvent[]): boolean {
         break;
       case "set_pending_question":
         S.pendingQuestionData = ev.data;
+        break;
+      case "set_todos":
+        applyTodosSnapshot(ev.todos);
         break;
       case "set_codex_thread":
         S.activeCodexThreadId = ev.threadId;

--- a/packages/backend/callback-src/parse/toolSteps.ts
+++ b/packages/backend/callback-src/parse/toolSteps.ts
@@ -411,14 +411,20 @@ export function toolCallToStep(name: string, input: JsonObject): ProgressStep {
             : undefined,
         status: "active",
       };
+    // Subagent spawn. Named `Agent` since claude-code v2.1.63; older CLIs emit
+    // `Task`. Match both so subagent runs are always recognised (a bare `Task`
+    // previously fell through to the generic "Using Task..." row).
     case "Agent":
+    case "Task":
       return {
         type: "subtask",
         label: "Running agent...",
         detail:
           typeof input.description === "string"
             ? String(input.description)
-            : undefined,
+            : typeof input.subagent_type === "string"
+              ? String(input.subagent_type)
+              : undefined,
         status: "active",
       };
     case "TodoWrite":

--- a/packages/backend/callback-src/providers/claude.ts
+++ b/packages/backend/callback-src/providers/claude.ts
@@ -1,3 +1,4 @@
+import { BLOCKING_QUESTIONS_ENABLED } from "../config.js";
 import {
   buildClaudeStartupStep,
   syncClaudeStateToPersist,
@@ -5,9 +6,60 @@ import {
 import { updateThinkingStep } from "../parse/canonical.js";
 import { toolCallToStep } from "../parse/toolSteps.js";
 import { callbackState as S } from "../runtime/state.js";
-import type { CanonicalEvent, JsonObject, StreamLineResult } from "../types.js";
+import type {
+  CanonicalEvent,
+  JsonObject,
+  JsonValue,
+  StreamLineResult,
+  TodoItem,
+} from "../types.js";
 import { elapsedAttemptMs, log } from "../utils.js";
 import type { ProviderAdapter } from "./types.js";
+
+/** Coerces a raw todo status field to the checklist's fixed set. */
+function normalizeTodoStatus(value: JsonValue): TodoItem["status"] {
+  return value === "in_progress" || value === "completed" ? value : "pending";
+}
+
+/**
+ * Folds one todo tool call into `S.todoState` and returns the current snapshot.
+ * `TodoWrite` (the tool the sandbox CLI emits) sends the full list every call,
+ * so it is a straight replace. `TaskCreate`/`TaskUpdate` (newer CLI Task tools)
+ * are handled best-effort — create appends, update patches the last item — so a
+ * CLI upgrade degrades gracefully rather than losing the checklist entirely.
+ */
+function reduceTodoState(name: string, input: JsonObject): TodoItem[] {
+  if (name === "TodoWrite") {
+    const raw = Array.isArray(input.todos) ? input.todos : [];
+    S.todoState.length = 0;
+    for (const item of raw) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const content = typeof item.content === "string" ? item.content : "";
+      if (!content) continue;
+      S.todoState.push({ content, status: normalizeTodoStatus(item.status) });
+    }
+  } else if (name === "TaskCreate") {
+    const content =
+      typeof input.subject === "string"
+        ? input.subject
+        : typeof input.description === "string"
+          ? input.description
+          : "";
+    if (content) {
+      S.todoState.push({ content, status: normalizeTodoStatus(input.status) });
+    }
+  } else if (name === "TaskUpdate") {
+    const last = S.todoState[S.todoState.length - 1];
+    if (last) {
+      if (input.status !== undefined)
+        last.status = normalizeTodoStatus(input.status);
+      if (typeof input.subject === "string" && input.subject) {
+        last.content = input.subject;
+      }
+    }
+  }
+  return S.todoState.map((t) => ({ ...t }));
+}
 
 /**
  * Handles Anthropic partial (`stream_event`) messages emitted when the SDK is
@@ -108,6 +160,13 @@ export function claudeParseLine(event: JsonObject): CanonicalEvent[] {
       : null;
   const content =
     message && Array.isArray(message.content) ? message.content : [];
+  // Set on messages produced INSIDE a subagent — the parent `Agent` tool_use id.
+  // The UI nests these steps under the matching `subtask` row.
+  const parentToolUseId =
+    typeof event.parent_tool_use_id === "string" &&
+    event.parent_tool_use_id.trim()
+      ? event.parent_tool_use_id.trim()
+      : undefined;
   for (const block of content) {
     if (!block || typeof block !== "object" || Array.isArray(block)) continue;
     if (block.type === "tool_use" && typeof block.name === "string") {
@@ -117,17 +176,46 @@ export function claudeParseLine(event: JsonObject): CanonicalEvent[] {
         !Array.isArray(block.input)
           ? block.input
           : {};
+      // Todo tools drive a single evolving checklist, not one activity row per
+      // call. Read-only variants add nothing to the timeline.
+      if (
+        block.name === "TodoWrite" ||
+        block.name === "TaskCreate" ||
+        block.name === "TaskUpdate"
+      ) {
+        events.push({
+          kind: "set_todos",
+          todos: reduceTodoState(block.name, input),
+        });
+        continue;
+      }
+      if (
+        block.name === "TodoRead" ||
+        block.name === "TaskGet" ||
+        block.name === "TaskList"
+      ) {
+        continue;
+      }
       const step = toolCallToStep(block.name, input);
       const trackingId =
         typeof block.id === "string" && block.id.trim()
           ? block.id.trim()
           : undefined;
+      if (trackingId) step.toolUseId = trackingId;
+      if (parentToolUseId) step.parentToolUseId = parentToolUseId;
       events.push(
         trackingId
           ? { kind: "push_step", step, trackingId }
           : { kind: "push_step", step },
       );
-      if (block.name === "AskUserQuestion" && block.input) {
+      // Fire-and-forget question metadata (surfaced after the turn). Skipped in
+      // blocking mode, where canUseTool owns the question round-trip and driving
+      // this too would double-render the question in the UI.
+      if (
+        !BLOCKING_QUESTIONS_ENABLED &&
+        block.name === "AskUserQuestion" &&
+        block.input
+      ) {
         events.push({
           kind: "set_pending_question",
           data: JSON.stringify(block.input),

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import {
   ALLOWED_TOOLS,
+  BLOCKING_QUESTIONS_ENABLED,
   CLAUDE_RUNTIME_CONFIG_DIR,
   MAX_TOTAL_RUNTIME_MS,
   NO_OUTPUT_CHECK_INTERVAL_MS,
@@ -20,6 +21,7 @@ import {
   trimBufferHead,
 } from "../runtime/buffers.js";
 import { resetAttemptState } from "../runtime/cliAttempt.js";
+import { buildCanUseTool } from "../runtime/pendingQuestion.js";
 import { callbackState as S } from "../runtime/state.js";
 import type { CliAttemptResult, SessionMode } from "../types.js";
 import { log } from "../utils.js";
@@ -48,6 +50,18 @@ export type JsonLike =
 
 export type SdkMessage = Record<string, JsonLike>;
 
+/** Result the SDK expects from `canUseTool` (matches the Agent SDK's PermissionResult). */
+export type SdkPermissionResult =
+  | { behavior: "allow"; updatedInput: Record<string, JsonLike> }
+  | { behavior: "deny"; message: string };
+
+/** The `canUseTool` permission callback passed to `query()`. */
+export type SdkCanUseTool = (
+  toolName: string,
+  input: Record<string, JsonLike>,
+  options: { signal: AbortSignal; toolUseID?: string },
+) => Promise<SdkPermissionResult>;
+
 export type SdkOptions = {
   cwd: string;
   model: string;
@@ -63,6 +77,8 @@ export type SdkOptions = {
   resume?: string;
   extraArgs?: Record<string, string>;
   includePartialMessages?: boolean;
+  /** Per-tool permission gate. Set only when blocking questions are enabled. */
+  canUseTool?: SdkCanUseTool;
 };
 
 export type SdkUserMessage = {
@@ -190,6 +206,26 @@ function buildSdkOptionsFromParts(
       ? { allowedTools: ALLOWED_TOOLS.split(",") }
       : { allowedTools: [] };
 
+  // Blocking questions need `canUseTool`, which the SDK ignores under
+  // `bypassPermissions`. When enabled we switch to `default` mode and let the
+  // gate auto-allow every tool except AskUserQuestion (which waits for the user).
+  // Otherwise keep the original bypass behaviour (no per-tool gating).
+  const permissionOption: {
+    permissionMode: string;
+    allowDangerouslySkipPermissions: boolean;
+    canUseTool?: SdkCanUseTool;
+  } =
+    tools === "agent" && BLOCKING_QUESTIONS_ENABLED
+      ? {
+          permissionMode: "default",
+          allowDangerouslySkipPermissions: false,
+          canUseTool: buildCanUseTool(),
+        }
+      : {
+          permissionMode: "bypassPermissions",
+          allowDangerouslySkipPermissions: true,
+        };
+
   return {
     cwd: WORK_DIR,
     model: normalizedClaudeModel,
@@ -205,8 +241,7 @@ function buildSdkOptionsFromParts(
           preset: "claude_code",
           append: EVA_SDK_SYSTEM_APPEND,
         },
-    permissionMode: "bypassPermissions",
-    allowDangerouslySkipPermissions: true,
+    ...permissionOption,
     // Emit token-level partial (`stream_event`) messages so claudeParseLine can
     // stream text deltas into the reply live (dedup guards the final message).
     includePartialMessages: true,
@@ -282,6 +317,13 @@ export async function runClaudeSdkAttempt(
   };
   const healthTimer = setInterval(() => {
     const now = Date.now();
+    // A turn paused on a blocking question produces no SDK messages by design —
+    // keep the timers fresh so it is never killed while genuinely waiting.
+    if (S.awaitingQuestionAnswer) {
+      S.activeAttemptStartedAt = now;
+      lastMessageAt = now;
+      return;
+    }
     if (now - S.activeAttemptStartedAt > MAX_TOTAL_RUNTIME_MS) {
       timedOutForMaxRuntime = true;
       log("runClaudeSdkAttempt: max runtime exceeded — interrupting");

--- a/packages/backend/callback-src/providers/claudeSdkDaemon.ts
+++ b/packages/backend/callback-src/providers/claudeSdkDaemon.ts
@@ -132,6 +132,13 @@ function startTurnWatchdog(): void {
   const timer = setInterval(() => {
     if (!turnActive) return;
     const now = Date.now();
+    // A turn paused on a blocking question emits no SDK messages by design —
+    // keep both timers fresh so the wait is never mistaken for a stalled turn.
+    if (S.awaitingQuestionAnswer) {
+      turnStartedAtMs = now;
+      lastMessageAtMs = now;
+      return;
+    }
     if (now - turnStartedAtMs > MAX_TOTAL_RUNTIME_MS) {
       turnActive = false;
       void failTurnAndExit("The assistant exceeded the maximum turn runtime.");
@@ -258,6 +265,8 @@ function resetTurnState(): void {
   S.lastProcessed = 0;
   S.inFlightToolUses = 0;
   S.pendingQuestionData = "";
+  S.todoState.length = 0;
+  S.awaitingQuestionAnswer = false;
   S.lastStepType = "thinking";
 }
 

--- a/packages/backend/callback-src/runtime/pendingQuestion.ts
+++ b/packages/backend/callback-src/runtime/pendingQuestion.ts
@@ -1,0 +1,111 @@
+import { ENTITY_ID } from "../config.js";
+import { callConvexWithRetry } from "../http/convexClient.js";
+import { callbackState as S } from "./state.js";
+import type { JsonValue } from "../types.js";
+import type { JsonLike, SdkCanUseTool } from "../providers/claudeSdk.js";
+import { log } from "../utils.js";
+
+// How often the paused turn polls Convex for the user's answer. Matches the
+// daemon's turn-claim cadence — the model is idle while waiting, so this only
+// adds at most one poll of latency once the answer lands.
+const POLL_INTERVAL_MS = 300;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Reads `.value.answer` (a JSON string, or null) out of a claimAnswer result.
+ * Convex's `/api/mutation` wraps returns in `{ status, value }`, so the answer
+ * lives under `.value`; falls back to the top level for an unwrapped value.
+ */
+function readClaimedAnswer(result: JsonValue): string | null {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    return null;
+  }
+  const inner = result.value;
+  const payload =
+    typeof inner === "object" && inner !== null && !Array.isArray(inner)
+      ? inner
+      : result;
+  const answer = payload.answer;
+  return typeof answer === "string" ? answer : null;
+}
+
+/** Publishes the question so the UI can render it and collect an answer. */
+async function postQuestion(toolUseId: string, payload: string): Promise<void> {
+  await callConvexWithRetry("mutation", "pendingQuestions:post", {
+    entityId: ENTITY_ID ?? "",
+    toolUseId,
+    payload,
+  });
+}
+
+/** Polls until the user answers, or the turn is cancelled (signal aborts). */
+async function pollForAnswer(
+  toolUseId: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  while (!signal.aborted) {
+    const result = await callConvexWithRetry(
+      "mutation",
+      "pendingQuestions:claimAnswer",
+      { entityId: ENTITY_ID ?? "", toolUseId },
+    );
+    const answer = readClaimedAnswer(result);
+    if (answer !== null) return answer;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return null;
+}
+
+/** Parses the stored answer JSON into an object safe to merge into tool input. */
+function parseAnswers(answerJson: string): Record<string, JsonLike> {
+  try {
+    const parsed: JsonLike = JSON.parse(answerJson);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed;
+    }
+  } catch {
+    /* malformed answer — fall through to empty */
+  }
+  return {};
+}
+
+/**
+ * Builds the SDK `canUseTool` gate used when blocking questions are enabled.
+ * Every tool is auto-allowed EXCEPT AskUserQuestion, which posts the question to
+ * Convex and blocks (no timeout) until the user answers — then returns the
+ * answer as the tool's input so the model continues the SAME turn with a real
+ * tool_result rather than the question ending the turn.
+ */
+export function buildCanUseTool(): SdkCanUseTool {
+  return async (toolName, input, options) => {
+    if (toolName !== "AskUserQuestion") {
+      return { behavior: "allow", updatedInput: input };
+    }
+    const toolUseId =
+      typeof options.toolUseID === "string" && options.toolUseID
+        ? options.toolUseID
+        : "";
+    S.awaitingQuestionAnswer = true;
+    log("canUseTool: AskUserQuestion — posting question, awaiting user answer");
+    try {
+      await postQuestion(toolUseId, JSON.stringify(input));
+      const answerJson = await pollForAnswer(toolUseId, options.signal);
+      if (answerJson === null) {
+        return { behavior: "deny", message: "The question was cancelled." };
+      }
+      return {
+        behavior: "allow",
+        updatedInput: { ...input, answers: parseAnswers(answerJson) },
+      };
+    } finally {
+      S.awaitingQuestionAnswer = false;
+    }
+  };
+}

--- a/packages/backend/callback-src/runtime/state.ts
+++ b/packages/backend/callback-src/runtime/state.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from "child_process";
 import type { WriteStream } from "fs";
-import type { JsonValue, ProgressStep } from "../types.js";
+import type { JsonValue, ProgressStep, TodoItem } from "../types.js";
 
 function parsePriorStep(value: JsonValue): ProgressStep | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -63,6 +63,13 @@ type CallbackState = {
   heartbeatFailureStreakStartedAt: number;
   inFlightToolUses: number;
   codexToolItemIds: Set<string>;
+  /** Current todo checklist for this turn, rebuilt from TodoWrite/TaskCreate/
+   * TaskUpdate calls and mirrored into the single "todos" activity step. */
+  todoState: TodoItem[];
+  /** True while a turn is paused inside canUseTool waiting for the user's answer
+   * to a blocking AskUserQuestion. Suspends the per-turn watchdog so a genuinely
+   * waiting turn is never killed for producing no SDK messages. */
+  awaitingQuestionAnswer: boolean;
   doneFileWritten: boolean;
   flushInProgress: boolean;
   pingInProgress: boolean;
@@ -107,6 +114,8 @@ export const callbackState: CallbackState = {
   heartbeatFailureStreakStartedAt: 0,
   inFlightToolUses: 0,
   codexToolItemIds: new Set<string>(),
+  todoState: [],
+  awaitingQuestionAnswer: false,
   doneFileWritten: false,
   flushInProgress: false,
   pingInProgress: false,
@@ -175,6 +184,8 @@ export function resetStateForTests(): void {
   callbackState.parsedStreamEventCount = 0;
   callbackState.currentStreamedContent = "";
   callbackState.streamedAssistantTextThisMessage = false;
+  callbackState.todoState.length = 0;
+  callbackState.awaitingQuestionAnswer = false;
 }
 
 export function setFatalHeartbeatForTest(message: string): void {

--- a/packages/backend/callback-src/types.ts
+++ b/packages/backend/callback-src/types.ts
@@ -16,6 +16,19 @@ export type ProgressStep = {
   /** Full, unshortened path for file-type steps. Powers the chat File Viewer. */
   path?: string;
   status: "active" | "complete";
+  /** The tool_use id that produced this step (Claude only). Lets a tool_result
+   * complete the exact step, and anchors nested subagent children. */
+  toolUseId?: string;
+  /** Set when this step ran inside a subagent — the parent `Agent` tool_use id.
+   * The UI nests these under the matching `subtask` step. */
+  parentToolUseId?: string;
+  /** Todo checklist snapshot (type "todos" only), JSON-serialised for transport. */
+  todos?: TodoItem[];
+};
+
+export type TodoItem = {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
 };
 
 export type SessionMode = {
@@ -38,6 +51,7 @@ export type CanonicalEvent =
   | { kind: "mark_message_start" }
   | { kind: "update_reasoning"; text: string }
   | { kind: "set_pending_question"; data: string }
+  | { kind: "set_todos"; todos: TodoItem[] }
   | { kind: "set_codex_thread"; threadId: string }
   | { kind: "mark_first_assistant" };
 

--- a/packages/backend/convex/_daytona/callbackScript.generated.ts
+++ b/packages/backend/convex/_daytona/callbackScript.generated.ts
@@ -26,6 +26,7 @@ var PROVIDER = process.env.AI_PROVIDER || "claude";
 var MODEL = process.env.AI_MODEL || process.env.CLAUDE_MODEL || "claude:sonnet";
 var ALLOWED_TOOLS = process.env.ALLOWED_TOOLS || "Read,Glob,Grep";
 var CLAUDE_ATTEMPT_MODE = process.env.CLAUDE_ATTEMPT_MODE || "cli";
+var BLOCKING_QUESTIONS_ENABLED = process.env.ENTITY_ID_FIELD === "sessionId" && (CLAUDE_ATTEMPT_MODE === "sdk" || CLAUDE_ATTEMPT_MODE === "sdk-daemon");
 var CLAUDE_PREWARM = process.env.CLAUDE_PREWARM === "1";
 var CALLBACK_SCRIPT_FP = process.env.CALLBACK_SCRIPT_FP || "";
 var DAEMON_OPTS_SIG = process.env.EVA_DAEMON_OPTS || "";
@@ -183,7 +184,8 @@ var TOOL_STEP_TYPES = /* @__PURE__ */ new Set([
   "web_search",
   "notebook",
   "subtask",
-  "question"
+  "question",
+  "todos"
 ]);
 var CODEX_PRICING_PER_MILLION = {
   "gpt-5.4": { input: 1.25, cached: 0.125, output: 10 },
@@ -465,6 +467,8 @@ var callbackState = {
   heartbeatFailureStreakStartedAt: 0,
   inFlightToolUses: 0,
   codexToolItemIds: /* @__PURE__ */ new Set(),
+  todoState: [],
+  awaitingQuestionAnswer: false,
   doneFileWritten: false,
   flushInProgress: false,
   pingInProgress: false,
@@ -987,11 +991,15 @@ function toolCallToStep(name, input) {
         path: typeof input.notebook_path === "string" ? String(input.notebook_path) : void 0,
         status: "active"
       };
+    // Subagent spawn. Named \`Agent\` since claude-code v2.1.63; older CLIs emit
+    // \`Task\`. Match both so subagent runs are always recognised (a bare \`Task\`
+    // previously fell through to the generic "Using Task..." row).
     case "Agent":
+    case "Task":
       return {
         type: "subtask",
         label: "Running agent...",
-        detail: typeof input.description === "string" ? String(input.description) : void 0,
+        detail: typeof input.description === "string" ? String(input.description) : typeof input.subagent_type === "string" ? String(input.subagent_type) : void 0,
         status: "active"
       };
     case "TodoWrite":
@@ -1781,6 +1789,35 @@ function prepareClaudeSessionState() {
 }
 
 // callback-src/providers/claude.ts
+function normalizeTodoStatus(value) {
+  return value === "in_progress" || value === "completed" ? value : "pending";
+}
+function reduceTodoState(name, input) {
+  if (name === "TodoWrite") {
+    const raw = Array.isArray(input.todos) ? input.todos : [];
+    callbackState.todoState.length = 0;
+    for (const item of raw) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const content = typeof item.content === "string" ? item.content : "";
+      if (!content) continue;
+      callbackState.todoState.push({ content, status: normalizeTodoStatus(item.status) });
+    }
+  } else if (name === "TaskCreate") {
+    const content = typeof input.subject === "string" ? input.subject : typeof input.description === "string" ? input.description : "";
+    if (content) {
+      callbackState.todoState.push({ content, status: normalizeTodoStatus(input.status) });
+    }
+  } else if (name === "TaskUpdate") {
+    const last = callbackState.todoState[callbackState.todoState.length - 1];
+    if (last) {
+      if (input.status !== void 0) last.status = normalizeTodoStatus(input.status);
+      if (typeof input.subject === "string" && input.subject) {
+        last.content = input.subject;
+      }
+    }
+  }
+  return callbackState.todoState.map((t) => ({ ...t }));
+}
 function parseClaudeStreamEvent(event) {
   const events = [];
   const inner = event.event && typeof event.event === "object" && !Array.isArray(event.event) ? event.event : null;
@@ -1837,16 +1874,26 @@ function claudeParseLine(event) {
   }
   const message = event.message && typeof event.message === "object" && !Array.isArray(event.message) ? event.message : null;
   const content = message && Array.isArray(message.content) ? message.content : [];
+  const parentToolUseId = typeof event.parent_tool_use_id === "string" && event.parent_tool_use_id.trim() ? event.parent_tool_use_id.trim() : void 0;
   for (const block of content) {
     if (!block || typeof block !== "object" || Array.isArray(block)) continue;
     if (block.type === "tool_use" && typeof block.name === "string") {
       const input = block.input && typeof block.input === "object" && !Array.isArray(block.input) ? block.input : {};
+      if (block.name === "TodoWrite" || block.name === "TaskCreate" || block.name === "TaskUpdate") {
+        events.push({ kind: "set_todos", todos: reduceTodoState(block.name, input) });
+        continue;
+      }
+      if (block.name === "TodoRead" || block.name === "TaskGet" || block.name === "TaskList") {
+        continue;
+      }
       const step = toolCallToStep(block.name, input);
       const trackingId = typeof block.id === "string" && block.id.trim() ? block.id.trim() : void 0;
+      if (trackingId) step.toolUseId = trackingId;
+      if (parentToolUseId) step.parentToolUseId = parentToolUseId;
       events.push(
         trackingId ? { kind: "push_step", step, trackingId } : { kind: "push_step", step }
       );
-      if (block.name === "AskUserQuestion" && block.input) {
+      if (!BLOCKING_QUESTIONS_ENABLED && block.name === "AskUserQuestion" && block.input) {
         events.push({
           kind: "set_pending_question",
           data: JSON.stringify(block.input)
@@ -2441,15 +2488,50 @@ var opencodeAdapter = {
 };
 
 // callback-src/parse/canonical.ts
+function markStepComplete(step) {
+  step.status = "complete";
+  if (completedLabels[step.label]) {
+    step.label = completedLabels[step.label];
+  } else if (step.label.startsWith("Using ") && step.label.endsWith("...")) {
+    step.label = "Used " + step.label.slice(6, -3);
+  }
+}
 function markLastComplete() {
   if (callbackState.accumulatedSteps.length === 0) return;
-  const last = callbackState.accumulatedSteps[callbackState.accumulatedSteps.length - 1];
-  last.status = "complete";
-  if (completedLabels[last.label]) {
-    last.label = completedLabels[last.label];
-  } else if (last.label.startsWith("Using ") && last.label.endsWith("...")) {
-    last.label = "Used " + last.label.slice(6, -3);
+  markStepComplete(callbackState.accumulatedSteps[callbackState.accumulatedSteps.length - 1]);
+}
+function completeToolStep(trackingId) {
+  if (trackingId) {
+    for (let i = callbackState.accumulatedSteps.length - 1; i >= 0; i--) {
+      const step = callbackState.accumulatedSteps[i];
+      if (step.toolUseId === trackingId) {
+        markStepComplete(step);
+        return;
+      }
+    }
   }
+  markLastComplete();
+}
+function summarizeTodos(todos) {
+  const done = todos.filter((t) => t.status === "completed").length;
+  return \`\${done} of \${todos.length} done\`;
+}
+function applyTodosSnapshot(todos) {
+  const existing = callbackState.accumulatedSteps.find((step) => step.type === "todos");
+  if (existing) {
+    existing.todos = todos;
+    existing.detail = summarizeTodos(todos);
+    return;
+  }
+  markLastComplete();
+  callbackState.accumulatedSteps.push({
+    type: "todos",
+    label: "Updating tasks...",
+    detail: summarizeTodos(todos),
+    todos,
+    status: "active"
+  });
+  callbackState.lastStepType = "tool";
 }
 function updateThinkingStep(label, detail) {
   void label;
@@ -2464,7 +2546,11 @@ function pushProgressStep(step) {
     updateThinkingStep(step.label, step.detail);
     return;
   }
-  markLastComplete();
+  const last = callbackState.accumulatedSteps[callbackState.accumulatedSteps.length - 1];
+  const isFirstChildUnderParent = step.parentToolUseId !== void 0 && last !== void 0 && last.toolUseId === step.parentToolUseId;
+  if (!isFirstChildUnderParent) {
+    markLastComplete();
+  }
   callbackState.accumulatedSteps.push(step);
   callbackState.lastStepType = "tool";
 }
@@ -2489,7 +2575,7 @@ function applyCanonicalEvents(events) {
         }
         break;
       case "complete_tool":
-        markLastComplete();
+        completeToolStep(ev.trackingId);
         if (ev.trackingId !== void 0) {
           callbackState.codexToolItemIds.delete(ev.trackingId);
         }
@@ -2515,6 +2601,9 @@ function applyCanonicalEvents(events) {
         break;
       case "set_pending_question":
         callbackState.pendingQuestionData = ev.data;
+        break;
+      case "set_todos":
+        applyTodosSnapshot(ev.todos);
         break;
       case "set_codex_thread":
         callbackState.activeCodexThreadId = ev.threadId;
@@ -3021,6 +3110,74 @@ async function runCliAttempt(options) {
   });
 }
 
+// callback-src/runtime/pendingQuestion.ts
+var POLL_INTERVAL_MS = 300;
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function readClaimedAnswer(result) {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    return null;
+  }
+  const inner = result.value;
+  const payload = typeof inner === "object" && inner !== null && !Array.isArray(inner) ? inner : result;
+  const answer = payload.answer;
+  return typeof answer === "string" ? answer : null;
+}
+async function postQuestion(toolUseId, payload) {
+  await callConvexWithRetry("mutation", "pendingQuestions:post", {
+    entityId: ENTITY_ID ?? "",
+    toolUseId,
+    payload
+  });
+}
+async function pollForAnswer(toolUseId, signal) {
+  while (!signal.aborted) {
+    const result = await callConvexWithRetry(
+      "mutation",
+      "pendingQuestions:claimAnswer",
+      { entityId: ENTITY_ID ?? "", toolUseId }
+    );
+    const answer = readClaimedAnswer(result);
+    if (answer !== null) return answer;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return null;
+}
+function parseAnswers(answerJson) {
+  try {
+    const parsed = JSON.parse(answerJson);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+  }
+  return {};
+}
+function buildCanUseTool() {
+  return async (toolName, input, options) => {
+    if (toolName !== "AskUserQuestion") {
+      return { behavior: "allow", updatedInput: input };
+    }
+    const toolUseId = typeof options.toolUseID === "string" && options.toolUseID ? options.toolUseID : "";
+    callbackState.awaitingQuestionAnswer = true;
+    log("canUseTool: AskUserQuestion \\u2014 posting question, awaiting user answer");
+    try {
+      await postQuestion(toolUseId, JSON.stringify(input));
+      const answerJson = await pollForAnswer(toolUseId, options.signal);
+      if (answerJson === null) {
+        return { behavior: "deny", message: "The question was cancelled." };
+      }
+      return {
+        behavior: "allow",
+        updatedInput: { ...input, answers: parseAnswers(answerJson) }
+      };
+    } finally {
+      callbackState.awaitingQuestionAnswer = false;
+    }
+  };
+}
+
 // callback-src/providers/claudeSdk.ts
 var SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 var SDK_VERSION = "0.3.201";
@@ -3089,6 +3246,14 @@ function buildConversationalSdkOptions() {
 var EVA_SDK_SYSTEM_APPEND = "You are running inside Eva, a platform that runs coding agents in remote sandboxes against GitHub repos. Treat the workspace as the active repo checkout.";
 function buildSdkOptionsFromParts(sessionMode, extraArgs, tools = "agent") {
   const allowedToolsOption = tools === "agent" && ALLOWED_TOOLS ? { allowedTools: ALLOWED_TOOLS.split(",") } : { allowedTools: [] };
+  const permissionOption = tools === "agent" && BLOCKING_QUESTIONS_ENABLED ? {
+    permissionMode: "default",
+    allowDangerouslySkipPermissions: false,
+    canUseTool: buildCanUseTool()
+  } : {
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true
+  };
   return {
     cwd: WORK_DIR,
     model: normalizedClaudeModel,
@@ -3104,8 +3269,7 @@ function buildSdkOptionsFromParts(sessionMode, extraArgs, tools = "agent") {
       preset: "claude_code",
       append: EVA_SDK_SYSTEM_APPEND
     },
-    permissionMode: "bypassPermissions",
-    allowDangerouslySkipPermissions: true,
+    ...permissionOption,
     // Emit token-level partial (\`stream_event\`) messages so claudeParseLine can
     // stream text deltas into the reply live (dedup guards the final message).
     includePartialMessages: true,
@@ -3156,6 +3320,11 @@ async function runClaudeSdkAttempt(sessionMode) {
   };
   const healthTimer = setInterval(() => {
     const now = Date.now();
+    if (callbackState.awaitingQuestionAnswer) {
+      callbackState.activeAttemptStartedAt = now;
+      lastMessageAt = now;
+      return;
+    }
     if (now - callbackState.activeAttemptStartedAt > MAX_TOTAL_RUNTIME_MS) {
       timedOutForMaxRuntime = true;
       log("runClaudeSdkAttempt: max runtime exceeded \\u2014 interrupting");
@@ -3232,7 +3401,7 @@ async function runClaudeSdkAttempt(sessionMode) {
 }
 
 // callback-src/providers/claudeSdkDaemon.ts
-function sleep(ms) {
+function sleep2(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 var DAEMON_PID_FILE = "/tmp/eva-daemon.pid";
@@ -3281,6 +3450,11 @@ function startTurnWatchdog() {
   const timer = setInterval(() => {
     if (!turnActive) return;
     const now = Date.now();
+    if (callbackState.awaitingQuestionAnswer) {
+      turnStartedAtMs = now;
+      lastMessageAtMs = now;
+      return;
+    }
     if (now - turnStartedAtMs > MAX_TOTAL_RUNTIME_MS) {
       turnActive = false;
       void failTurnAndExit("The assistant exceeded the maximum turn runtime.");
@@ -3371,6 +3545,8 @@ function resetTurnState() {
   callbackState.lastProcessed = 0;
   callbackState.inFlightToolUses = 0;
   callbackState.pendingQuestionData = "";
+  callbackState.todoState.length = 0;
+  callbackState.awaitingQuestionAnswer = false;
   callbackState.lastStepType = "thinking";
 }
 async function finalizeTurn(output, opts = {}) {
@@ -3688,7 +3864,7 @@ async function waitForNextTurn() {
       await materializeTurnAttachments(turn);
       return turn;
     }
-    await sleep(PROMPT_POLL_INTERVAL_MS);
+    await sleep2(PROMPT_POLL_INTERVAL_MS);
   }
   return null;
 }

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -216,6 +216,7 @@ import type * as notificationDigest from "../notificationDigest.js";
 import type * as notificationEmail from "../notificationEmail.js";
 import type * as notifications from "../notifications.js";
 import type * as numId from "../numId.js";
+import type * as pendingQuestions from "../pendingQuestions.js";
 import type * as prBody from "../prBody.js";
 import type * as prRecapWorkflow from "../prRecapWorkflow.js";
 import type * as presence from "../presence.js";
@@ -489,6 +490,7 @@ declare const fullApi: ApiFromModules<{
   notificationEmail: typeof notificationEmail;
   notifications: typeof notifications;
   numId: typeof numId;
+  pendingQuestions: typeof pendingQuestions;
   prBody: typeof prBody;
   prRecapWorkflow: typeof prRecapWorkflow;
   presence: typeof presence;

--- a/packages/backend/convex/pendingQuestions.ts
+++ b/packages/backend/convex/pendingQuestions.ts
@@ -1,0 +1,102 @@
+import { v } from "convex/values";
+import { authQuery, authMutation } from "./functions";
+
+/**
+ * Blocking AskUserQuestion round-trip. A sandbox turn paused inside canUseTool
+ * `post`s the question, the UI `getActive`s the unanswered one and writes the
+ * user's choice via `answer`, and the sandbox `claimAnswer`s it to resume the
+ * turn. `entityId` is the generic session/project/task id, matching how
+ * `streaming.ts` keys its state, so this is not tied to any one entity type.
+ *
+ * Auth mirrors `streaming.ts`: a valid identity (the sandbox CONVEX_TOKEN for
+ * post/claim, the signed-in user for answer/getActive) — no per-entity check,
+ * since the row only carries the model's own question text.
+ */
+
+const activeQuestionValidator = v.union(
+  v.object({ toolUseId: v.string(), payload: v.string() }),
+  v.null(),
+);
+
+/**
+ * Publishes a question for the UI (sandbox token). Clears any prior rows for the
+ * entity first — only one turn runs at a time per entity, so a leftover row
+ * (e.g. from a cancelled turn) must never shadow the current question.
+ */
+export const post = authMutation({
+  args: { entityId: v.string(), toolUseId: v.string(), payload: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const stale = await ctx.db
+      .query("pendingQuestions")
+      .withIndex("by_entity", (q) => q.eq("entityId", args.entityId))
+      .collect();
+    for (const row of stale) {
+      await ctx.db.delete(row._id);
+    }
+    await ctx.db.insert("pendingQuestions", {
+      entityId: args.entityId,
+      toolUseId: args.toolUseId,
+      payload: args.payload,
+      createdAt: Date.now(),
+    });
+    return null;
+  },
+});
+
+/** The oldest unanswered question for an entity, for the UI to render. */
+export const getActive = authQuery({
+  args: { entityId: v.string() },
+  returns: activeQuestionValidator,
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("pendingQuestions")
+      .withIndex("by_entity", (q) => q.eq("entityId", args.entityId))
+      .collect();
+    const pending = rows
+      .filter((row) => row.answer === undefined)
+      .sort((a, b) => a.createdAt - b.createdAt)[0];
+    if (!pending) return null;
+    return { toolUseId: pending.toolUseId, payload: pending.payload };
+  },
+});
+
+/** Records the user's answer (signed-in user), unblocking the paused turn. */
+export const answer = authMutation({
+  args: { entityId: v.string(), toolUseId: v.string(), answer: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("pendingQuestions")
+      .withIndex("by_entity_tool", (q) =>
+        q.eq("entityId", args.entityId).eq("toolUseId", args.toolUseId),
+      )
+      .first();
+    if (!existing) return null;
+    await ctx.db.patch(existing._id, {
+      answer: args.answer,
+      answeredAt: Date.now(),
+    });
+    return null;
+  },
+});
+
+/** Claims the answer for the sandbox (sandbox token). Deletes the row once taken. */
+export const claimAnswer = authMutation({
+  args: { entityId: v.string(), toolUseId: v.string() },
+  returns: v.object({ answer: v.union(v.string(), v.null()) }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("pendingQuestions")
+      .withIndex("by_entity_tool", (q) =>
+        q.eq("entityId", args.entityId).eq("toolUseId", args.toolUseId),
+      )
+      .first();
+    if (!existing || existing.answer === undefined) {
+      return { answer: null };
+    }
+    const claimed = existing.answer;
+    await ctx.db.delete(existing._id);
+    return { answer: claimed };
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -160,6 +160,20 @@ const schema = defineSchema(
       pendingQuestion: v.optional(v.string()),
       lastUpdatedAt: v.optional(v.number()),
     }).index("by_entity", ["entityId"]),
+    // Blocking AskUserQuestion round-trip. The paused sandbox turn posts a row
+    // here (via canUseTool), the UI reads the unanswered one and writes the
+    // answer, and the sandbox claims the answer to resume the turn. `entityId`
+    // is the generic session/project/task id (matches streamingActivity).
+    pendingQuestions: defineTable({
+      entityId: v.string(),
+      toolUseId: v.string(),
+      payload: v.string(),
+      answer: v.optional(v.string()),
+      answeredAt: v.optional(v.number()),
+      createdAt: v.number(),
+    })
+      .index("by_entity", ["entityId"])
+      .index("by_entity_tool", ["entityId", "toolUseId"]),
     docs: defineTable(docFields)
       .index("by_repo", ["repoId"])
       .index("by_session", ["sessionId"])

--- a/packages/ui/src/ai-elements/activity-shared.tsx
+++ b/packages/ui/src/ai-elements/activity-shared.tsx
@@ -14,8 +14,15 @@ import {
   BookOpenIcon,
   WrenchIcon,
   MessageSquareIcon,
+  ListTodoIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+
+/** One item in a todo checklist step (type "todos"). */
+export interface TodoItem {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+}
 
 export interface ActivityStep {
   type:
@@ -33,12 +40,19 @@ export interface ActivityStep {
     | "reasoning"
     | "response"
     | "question"
+    | "todos"
     | "tool";
   label: string;
   detail?: string;
   /** Full, unshortened path for file-type steps. Powers the chat File Viewer. */
   path?: string;
   status: "complete" | "active";
+  /** The tool_use id that produced this step (Claude only). */
+  toolUseId?: string;
+  /** Parent `Agent` tool_use id — set on steps that ran inside a subagent. */
+  parentToolUseId?: string;
+  /** Todo checklist snapshot (type "todos" only). */
+  todos?: TodoItem[];
 }
 
 export function EvaThinkingIcon({ className }: { className?: string }) {
@@ -68,6 +82,7 @@ export const stepConfig = {
   reasoning: { icon: EvaThinkingIcon, defaultLabel: "Thinking..." },
   response: { icon: MessageSquareIcon, defaultLabel: "Response" },
   question: { icon: MessageSquareIcon, defaultLabel: "Asked a question" },
+  todos: { icon: ListTodoIcon, defaultLabel: "Task list" },
   tool: { icon: WrenchIcon, defaultLabel: "Used tool" },
 };
 

--- a/packages/ui/src/ai-elements/activity-tasks-utils.ts
+++ b/packages/ui/src/ai-elements/activity-tasks-utils.ts
@@ -4,6 +4,12 @@ export interface ActivityBlock {
   type: ActivityStep["type"];
   status: "active" | "complete";
   items: ActivityStep[];
+  /**
+   * For `subtask` blocks only: the nested activity of each subagent, keyed by
+   * that subagent's `Agent` tool_use id. Lets the UI expand a subagent row to
+   * show the reads/edits/commands it ran.
+   */
+  subtaskChildren?: Record<string, ActivityBlock[]>;
 }
 
 /**
@@ -53,9 +59,9 @@ function normalizeStep(step: ActivityStep): ActivityStep | null {
   return step;
 }
 
-export function groupSteps(steps: ActivityStep[]): ActivityBlock[] {
+/** Groups consecutive same-type steps into blocks (no subagent partitioning). */
+function groupConsecutive(steps: ActivityStep[]): ActivityBlock[] {
   const blocks: ActivityBlock[] = [];
-
   for (const rawStep of steps) {
     const step = normalizeStep(rawStep);
     if (!step) continue;
@@ -66,9 +72,54 @@ export function groupSteps(steps: ActivityStep[]): ActivityBlock[] {
       blocks.push({ type: step.type, status: step.status, items: [step] });
     }
   }
-
   for (const block of blocks) {
     block.status = block.items[block.items.length - 1].status;
+  }
+  return blocks;
+}
+
+/**
+ * Groups steps into activity blocks. Steps that ran inside a subagent (those
+ * with `parentToolUseId`) are pulled out of the main flow and nested under the
+ * matching `subtask` block instead, so a subagent renders as one expandable row
+ * showing its own reads/edits/commands rather than flattening into the timeline.
+ */
+export function groupSteps(steps: ActivityStep[]): ActivityBlock[] {
+  const childrenByParent = new Map<string, ActivityStep[]>();
+  const topLevel: ActivityStep[] = [];
+  for (const step of steps) {
+    const parentId = step.parentToolUseId;
+    if (parentId) {
+      const existing = childrenByParent.get(parentId);
+      if (existing) existing.push(step);
+      else childrenByParent.set(parentId, [step]);
+    } else {
+      topLevel.push(step);
+    }
+  }
+
+  const blocks = groupConsecutive(topLevel);
+  const attached = new Set<string>();
+  for (const block of blocks) {
+    if (block.type !== "subtask") continue;
+    const children: Record<string, ActivityBlock[]> = {};
+    for (const item of block.items) {
+      const toolUseId = item.toolUseId;
+      if (!toolUseId) continue;
+      const kids = childrenByParent.get(toolUseId);
+      if (kids && kids.length > 0) {
+        children[toolUseId] = groupConsecutive(kids);
+        attached.add(toolUseId);
+      }
+    }
+    if (Object.keys(children).length > 0) block.subtaskChildren = children;
+  }
+
+  // Fallback: never drop activity. Any children whose parent subtask wasn't
+  // found (e.g. deep nesting) are appended at the top level rather than lost.
+  for (const [parentId, kids] of childrenByParent) {
+    if (attached.has(parentId)) continue;
+    blocks.push(...groupConsecutive(kids));
   }
 
   return blocks;
@@ -122,6 +173,7 @@ const titleBuilders: Record<
   reasoning: (_n, active) => (active ? "Thinking..." : "Thought"),
   response: () => "",
   question: () => "",
+  todos: (_n, active) => (active ? "Updating tasks" : "Task list"),
 };
 
 export function getBlockTitle(block: ActivityBlock): string {

--- a/packages/ui/src/ai-elements/activity-tasks.tsx
+++ b/packages/ui/src/ai-elements/activity-tasks.tsx
@@ -8,12 +8,18 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../ui/collapsible";
-import { ChevronDownIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  CircleIcon,
+  CircleCheckBigIcon,
+  LoaderIcon,
+} from "lucide-react";
 import { cn } from "../utils/cn";
 import { Spinner } from "../ui/spinner";
 import { Shimmer } from "./shimmer";
 import {
   type ActivityStep,
+  type TodoItem,
   useSpinnerVerb,
   useElapsedSeconds,
   formatElapsed,
@@ -68,6 +74,80 @@ function getFileVerb(type: ActivityStep["type"], active: boolean): string {
   return active ? "Reading" : "Read";
 }
 
+/** Status glyph for one todo row. */
+function TodoStatusIcon({ status }: { status: TodoItem["status"] }) {
+  if (status === "completed") {
+    return (
+      <CircleCheckBigIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <LoaderIcon className="mt-0.5 size-3.5 shrink-0 animate-spin text-primary" />
+    );
+  }
+  return (
+    <CircleIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+  );
+}
+
+/** Renders a todo checklist, or a plain fallback line for legacy/empty snapshots. */
+function TodoChecklist({
+  todos,
+  fallback,
+}: {
+  todos: TodoItem[];
+  fallback: string;
+}) {
+  if (todos.length === 0) {
+    return <TaskItem>{fallback}</TaskItem>;
+  }
+  return (
+    <ul className="space-y-1">
+      {todos.map((todo, i) => (
+        <li key={i} className="flex items-start gap-2 text-sm">
+          <TodoStatusIcon status={todo.status} />
+          <span
+            className={cn(
+              "leading-snug",
+              todo.status === "completed" &&
+                "text-muted-foreground line-through",
+              todo.status === "in_progress" && "font-medium text-foreground",
+              todo.status === "pending" && "text-muted-foreground",
+            )}
+          >
+            {todo.content}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** One subagent row: its description plus its own nested activity, indented. */
+function SubtaskItem({
+  item,
+  childBlocks,
+  onOpenFile,
+}: {
+  item: ActivityStep;
+  childBlocks?: ActivityBlock[];
+  onOpenFile?: (path: string) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <TaskItem>{item.detail ?? item.label}</TaskItem>
+      {childBlocks && childBlocks.length > 0 ? (
+        <div className="ml-1 space-y-1.5 border-l border-border pl-3">
+          {childBlocks.map((child, i) => (
+            <ActivityBlockRow key={i} block={child} onOpenFile={onOpenFile} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function ActivityBlockRow({
   block,
   onOpenFile,
@@ -94,38 +174,59 @@ function ActivityBlockRow({
         }
       />
       <TaskContent>
-        {block.items.map((item, i) =>
-          isFileType ? (
-            <TaskItem key={i}>
-              <span className="inline-flex max-w-full items-center gap-1">
-                {fileVerb}
-                {item.path && onOpenFile ? (
-                  <button
-                    type="button"
-                    title={item.path}
-                    onClick={() => onOpenFile(item.path ?? "")}
-                    className="inline-flex min-w-0 max-w-full cursor-pointer"
+        {block.type === "todos"
+          ? block.items.map((item, i) => (
+              <TodoChecklist
+                key={i}
+                todos={item.todos ?? []}
+                fallback={item.detail ?? item.label}
+              />
+            ))
+          : block.type === "subtask"
+            ? block.items.map((item, i) => (
+                <SubtaskItem
+                  key={i}
+                  item={item}
+                  childBlocks={
+                    item.toolUseId
+                      ? block.subtaskChildren?.[item.toolUseId]
+                      : undefined
+                  }
+                  onOpenFile={onOpenFile}
+                />
+              ))
+            : block.items.map((item, i) =>
+                isFileType ? (
+                  <TaskItem key={i}>
+                    <span className="inline-flex max-w-full items-center gap-1">
+                      {fileVerb}
+                      {item.path && onOpenFile ? (
+                        <button
+                          type="button"
+                          title={item.path}
+                          onClick={() => onOpenFile(item.path ?? "")}
+                          className="inline-flex min-w-0 max-w-full cursor-pointer"
+                        >
+                          <TaskItemFile className="transition-colors hover:bg-muted">
+                            {item.detail ?? item.label}
+                          </TaskItemFile>
+                        </button>
+                      ) : (
+                        <TaskItemFile>{item.detail ?? item.label}</TaskItemFile>
+                      )}
+                    </span>
+                  </TaskItem>
+                ) : block.type === "bash" ? (
+                  <TaskItem
+                    key={i}
+                    className="line-clamp-2 break-all font-mono text-xs"
                   >
-                    <TaskItemFile className="transition-colors hover:bg-muted">
-                      {item.detail ?? item.label}
-                    </TaskItemFile>
-                  </button>
+                    {item.detail ?? item.label}
+                  </TaskItem>
                 ) : (
-                  <TaskItemFile>{item.detail ?? item.label}</TaskItemFile>
-                )}
-              </span>
-            </TaskItem>
-          ) : block.type === "bash" ? (
-            <TaskItem
-              key={i}
-              className="line-clamp-2 break-all font-mono text-xs"
-            >
-              {item.detail ?? item.label}
-            </TaskItem>
-          ) : (
-            <TaskItem key={i}>{item.detail ?? item.label}</TaskItem>
-          ),
-        )}
+                  <TaskItem key={i}>{item.detail ?? item.label}</TaskItem>
+                ),
+              )}
       </TaskContent>
     </Task>
   );


### PR DESCRIPTION
Richer UIs for the Agent SDK tools surfaced in sessions chat. Two phases.

## Phase 1 — parser + activity UI (low risk)

- **Subagent drill-in**: inner subagent steps (carried by `parent_tool_use_id`) now nest under an expandable `subtask` row showing the reads/edits/commands the subagent ran, instead of one opaque "Ran agent" line.
- **Task/Agent fix**: the SDK renamed the subagent tool `Task` → `Agent`; both names are now mapped, so subagent spawns are no longer shown as a generic "Using Task..." row.
- **TodoWrite checklist**: `TodoWrite` (and best-effort `TaskCreate`/`TaskUpdate`) render as a single live checklist step with per-item status, instead of a generic "Updating tasks" row.
- Tool steps now complete by `toolUseId`, so a subagent's parent stays active until its own `tool_result` rather than being closed by its first child.

## Phase 2 — blocking AskUserQuestion (SDK sessions only)

- New `canUseTool` gate: auto-allows every tool **except** `AskUserQuestion`, which posts to a new `pendingQuestions` Convex table and **blocks (no timeout)** until the user answers, then resumes the **same turn** with a real `tool_result`.
- The per-turn watchdog is suspended while awaiting an answer (a paused turn is never killed for producing no messages).
- `MultipleChoiceQuestion` gains a structured-answer path; `ChatBody` + sessions `ChatPanel` wire the question round-trip.
- **Gated** to SDK sessions (`ENTITY_ID_FIELD=sessionId`) via `BLOCKING_QUESTIONS_ENABLED`. Every other surface keeps the existing fire-and-forget question behaviour, so no surface can hang on an unwired UI.

## Verification done
- `npm run test:callback` (17/17), `convex codegen --typecheck`, and `tsc` on web + ui + callback-src all pass (only a pre-existing `opencode.ts:50` error remains).

## ⚠️ Verify on dev before merge
- **`canUseTool` return shape**: implemented against the established `{ behavior: "allow", updatedInput } / { behavior: "deny", message }` PermissionResult (the SDK isn't installed locally to read its `.d.ts`). Confirm against the sandbox's `@anthropic-ai/claude-agent-sdk` 0.3.201 types, and confirm dropping `bypassPermissions` for `permissionMode: "default"` + canUseTool still auto-runs Edit/Bash without prompting.
- Drive a real session end-to-end: a subagent task (nested activity), a multi-step task (checklist), and an AskUserQuestion (turn stays executing, answering resumes the same turn, cancel unwinds cleanly).

Follow-up: project/task chat still use the fire-and-forget question path; wiring the blocking UI there is a separate change.
