### PR TITLE
fix(mcp): make OAuth client TTL check deterministic in `getClient`

### DIFF
--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -546,6 +546,7 @@ http.route({
 
     const client = await ctx.runQuery(internal.mcp.oauth.getClient, {
       clientId,
+      now: Date.now(),
     });
 
     if (!client) {

--- a/packages/backend/convex/mcp/native.ts
+++ b/packages/backend/convex/mcp/native.ts
@@ -106,6 +106,7 @@ export const authorizeGet = httpAction(async (ctx, request) => {
 
     const client = await ctx.runQuery(internal.mcp.oauth.getClient, {
       clientId: params.client_id,
+      now: Date.now(),
     });
 
     if (!client) {

--- a/packages/backend/convex/mcp/oauth.ts
+++ b/packages/backend/convex/mcp/oauth.ts
@@ -137,8 +137,11 @@ export const registerClient = internalMutation({
  * Returns null if not found or expired (24h TTL).
  */
 export const getClient = internalQuery({
-  args: { clientId: v.string() },
-  handler: async (ctx, { clientId }) => {
+  // `now` is passed in by the caller: computing Date.now() inside a query makes
+  // the TTL check nondeterministic — Convex caches query results by data
+  // dependencies, so an expired registration could keep being served.
+  args: { clientId: v.string(), now: v.number() },
+  handler: async (ctx, { clientId, now }) => {
     const client = await ctx.db
       .query("mcpClientRegistrations")
       .withIndex("by_clientId", (q) => q.eq("clientId", clientId))
@@ -147,7 +150,7 @@ export const getClient = internalQuery({
     if (!client) return null;
 
     // 24h TTL for client registrations
-    if (Date.now() - client.registeredAt > CLIENT_TTL_MS) {
+    if (now - client.registeredAt > CLIENT_TTL_MS) {
       return null;
     }
 


### PR DESCRIPTION
## What I found

I ran [convex-doctor](https://github.com/fagnersales/convex-doctor) (a static analyzer for Convex backends) against `packages/backend/convex`. It reported no errors — the codebase is in good shape — but one warning stood out as a real correctness issue rather than a style/perf lint:

`convex/mcp/oauth.ts` — `getClient` (an `internalQuery`) enforces the 24h TTL on dynamic OAuth client registrations like this:

```ts
if (Date.now() - client.registeredAt > CLIENT_TTL_MS) {
  return null;
}
```

Convex queries are meant to be deterministic: their results are cached and only invalidated when the *data* they read changes — not when wall-clock time passes. `Date.now()` inside a query is frozen at execution time, so a cached "this client is still valid" result can keep being served after the registration has actually expired. The TTL becomes best-effort instead of enforced at read time (until `cleanupExpired` happens to delete the row and invalidate the cache).

Since this gates the MCP OAuth flow (`/authorize` and the client-lookup HTTP route both call it), an expired `client_id` being accepted past its TTL is a small but genuine auth-adjacent correctness gap.

## What I changed

The standard fix for this pattern: compute the timestamp where nondeterminism is allowed (the calling HTTP actions) and pass it in as an argument.

- `convex/mcp/oauth.ts` — `getClient` now takes `now: v.number()` and compares against that instead of calling `Date.now()` in the query.
- `convex/http.ts` and `convex/mcp/native.ts` — the only two callers (both `httpAction`s, where reading the clock is fine) pass `now: Date.now()`.

`getClient` is an `internalQuery`, so this is not a public API change. Behavior is identical except the TTL check now always uses the caller's current time.

## What I deliberately did **not** change

convex-doctor also flagged a number of warn/info-level lints I looked at and chose to leave alone:

- **`SCHEDULE_PUBLIC_FN` (5 sites)** — server actions calling `api.sessions.get` / `api.githubRepos.get` / `api.githubRepos.getByIdString` via `ctx.runQuery`. These are *intentional*: all five are public, client-invoked actions that use the `authQuery`-based public functions **as their authorization check** (the code comments say exactly that). Mechanically switching them to `internal.*` would remove access control. If you ever want to silence the lint, the clean refactor is extracting the auth check into a shared helper — but the current code is correct.
- **`REDUNDANT_INDEX` (21)** — real observation (single-field indexes that are prefixes of compound ones), but removing them requires rewriting every `.withIndex("by_repo", …)` call site. Too much churn for me to do confidently from outside the project.
- **`FILTER_IN_QUERY` / `UNBOUNDED_COLLECT` / `AWAIT_IN_LOOP`** — mostly cron/cleanup/admin paths or small tables where the pattern is fine in practice, or fixes that need index/product decisions best made by you.

## How I verified

- Re-ran convex-doctor: the `NONDETERMINISTIC_QUERY` finding is gone; no new findings introduced (everything else unchanged).
- Grepped for all `getClient` references — exactly the two call sites, both updated.
- (I couldn't run `convex codegen --typecheck` locally because dependency install was blocked in my environment, but the change is a mechanical argument addition on an internal function with both callers updated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
