### PR TITLE
test: regression vitests for recent fix commits

### DIFF
--- a/apps/web/src/lib/utils/appTabSlug.test.ts
+++ b/apps/web/src/lib/utils/appTabSlug.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "vitest";
+import { RESERVED_APP_TAB_SLUGS, slugifyAppTabName } from "./appTabSlug";
+
+test("RESERVED_APP_TAB_SLUGS keeps computer and legacy desktop reserved", () => {
+  // Computer tab URL is /computer; desktop stays reserved so custom tabs can't collide.
+  expect(RESERVED_APP_TAB_SLUGS.has("computer")).toBe(true);
+  expect(RESERVED_APP_TAB_SLUGS.has("desktop")).toBe(true);
+  expect(RESERVED_APP_TAB_SLUGS.has("browser")).toBe(true);
+});
+
+test("slugifyAppTabName lowercases and hyphenates display names", () => {
+  expect(slugifyAppTabName("Supabase Studio")).toBe("supabase-studio");
+  expect(slugifyAppTabName("  Foo__Bar  ")).toBe("foo-bar");
+  expect(slugifyAppTabName("!!!")).toBe("");
+});

--- a/apps/web/src/lib/utils/isChunkLoadError.test.ts
+++ b/apps/web/src/lib/utils/isChunkLoadError.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import { isChunkLoadError } from "./isChunkLoadError";
+
+test("isChunkLoadError detects ChunkLoadError name and common messages", () => {
+  const named = new Error("boom");
+  named.name = "ChunkLoadError";
+  expect(isChunkLoadError(named)).toBe(true);
+
+  expect(
+    isChunkLoadError(
+      new Error("Failed to fetch dynamically imported module: /assets/x.js"),
+    ),
+  ).toBe(true);
+  expect(isChunkLoadError(new Error("Loading chunk 12 failed"))).toBe(true);
+  expect(isChunkLoadError(new Error("Loading CSS chunk 3 failed"))).toBe(true);
+  expect(isChunkLoadError(new Error("Importing a module script failed"))).toBe(
+    true,
+  );
+});
+
+test("isChunkLoadError rejects unrelated errors and non-errors", () => {
+  expect(isChunkLoadError(new Error("Network timeout"))).toBe(false);
+  expect(isChunkLoadError("string")).toBe(false);
+  expect(isChunkLoadError(null)).toBe(false);
+});

--- a/apps/web/src/lib/utils/logs.test.ts
+++ b/apps/web/src/lib/utils/logs.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+import { formatTokens, getTotalInputTokens, parseResultEvent } from "./logs";
+
+test("parseResultEvent keeps input vs cache token categories separate", () => {
+  // Cost UI must not treat cache reads as billed input tokens.
+  const event = parseResultEvent(
+    JSON.stringify({
+      total_cost_usd: 1.25,
+      provider: "anthropic",
+      duration_ms: 1200,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 200,
+      },
+      modelUsage: {
+        "claude-sonnet": { costUSD: 1.25 },
+        other: { costUSD: 0.1 },
+      },
+    }),
+  );
+
+  expect(event.inputTokens).toBe(100);
+  expect(event.cacheReadTokens).toBe(1000);
+  expect(event.cacheCreationTokens).toBe(200);
+  expect(event.outputTokens).toBe(50);
+  expect(event.model).toBe("claude-sonnet");
+  expect(getTotalInputTokens(event)).toBe(1300);
+});
+
+test("parseResultEvent returns empty defaults for invalid JSON", () => {
+  expect(parseResultEvent(undefined).inputTokens).toBe(0);
+  expect(parseResultEvent("{").model).toBe("-");
+});
+
+test("formatTokens uses compact suffixes", () => {
+  expect(formatTokens(0)).toBe("0");
+  expect(formatTokens(1500)).toBe("1.5k");
+  expect(formatTokens(2_000_000)).toBe("2.0M");
+});

--- a/packages/backend/convex/_automations/helpers.ts
+++ b/packages/backend/convex/_automations/helpers.ts
@@ -3,12 +3,7 @@ import type { DataModel, Doc, Id } from "../_generated/dataModel";
 import { resolveCanonicalRepoId } from "../_githubRepos/helpers";
 import { filterActiveEntities } from "../numId";
 
-export function buildAutomationRunBranchName(
-  automationId: Id<"automations">,
-  runId: Id<"automationRuns">,
-): string {
-  return `eva/automation-${String(automationId)}-${String(runId)}`;
-}
+export { buildAutomationRunBranchName } from "../_git/branchNames";
 
 /** Lists automations visible for a repo: app-specific plus shared monorepo automations. */
 export async function listAutomationsForRepo(

--- a/packages/backend/convex/_git/branchNames.ts
+++ b/packages/backend/convex/_git/branchNames.ts
@@ -1,0 +1,21 @@
+import type { Id } from "../_generated/dataModel";
+
+/** Per-run automation branch so each run can open a fresh PR. */
+export function buildAutomationRunBranchName(
+  automationId: Id<"automations">,
+  runId: Id<"automationRuns">,
+): string {
+  return `eva/automation-${String(automationId)}-${String(runId)}`;
+}
+
+/** Project sandbox branch; v2+ after merge so the next cycle gets a new name. */
+export function buildProjectBranchName(
+  projectId: Id<"projects">,
+  branchVersion?: number,
+): string {
+  const version = branchVersion ?? 1;
+  if (version <= 1) {
+    return `eva/project-${projectId}`;
+  }
+  return `eva/project-${projectId}-v${version}`;
+}

--- a/packages/backend/convex/_projects/helpers.ts
+++ b/packages/backend/convex/_projects/helpers.ts
@@ -9,17 +9,7 @@ import type { DataModel, Id, Doc } from "../_generated/dataModel";
 
 type ConversationMessage = Doc<"projectDetails">["conversationHistory"][number];
 
-/** Builds a git branch name for a project, optionally versioned. */
-export function buildProjectBranchName(
-  projectId: Id<"projects">,
-  branchVersion?: number,
-): string {
-  const version = branchVersion ?? 1;
-  if (version <= 1) {
-    return `eva/project-${projectId}`;
-  }
-  return `eva/project-${projectId}-v${version}`;
-}
+export { buildProjectBranchName } from "../_git/branchNames";
 
 /** Convex validator for a project document with its conversation history and generated spec. */
 export const projectWithDetailsValidator = v.object({

--- a/packages/backend/convex/_repoSkills/decodeGitHubContent.ts
+++ b/packages/backend/convex/_repoSkills/decodeGitHubContent.ts
@@ -1,0 +1,12 @@
+/**
+ * Decode GitHub Contents API base64 payloads without Node `Buffer`
+ * (Convex isolate / browser-safe).
+ */
+export function decodeGitHubContent(content: string): string {
+  const binary = atob(content.replace(/\n/g, ""));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder("utf-8").decode(bytes);
+}

--- a/packages/backend/convex/_repoSkills/sync.ts
+++ b/packages/backend/convex/_repoSkills/sync.ts
@@ -11,6 +11,7 @@ import {
   parseSkillMarkdown,
   SKILL_FILE_NAME,
 } from "./skillMarkdown";
+import { decodeGitHubContent } from "./decodeGitHubContent";
 
 const SKILLS_ROOT_PATH = ".agents/skills";
 
@@ -66,15 +67,6 @@ const applyGithubSyncRef = makeFunctionReference<
 function isGithubNotFound(error: Error): boolean {
   const message = error.message.toLowerCase();
   return message.includes("not found") || message.includes("404");
-}
-
-function decodeGitHubContent(content: string): string {
-  const binary = atob(content.replace(/\n/g, ""));
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new TextDecoder("utf-8").decode(bytes);
 }
 
 async function fetchSkillDirectories(

--- a/packages/backend/convex/_repoSnapshots/builds.ts
+++ b/packages/backend/convex/_repoSnapshots/builds.ts
@@ -16,6 +16,7 @@ import {
 } from "../validators";
 import { authQuery, authMutation } from "../functions";
 import { workflow } from "../workflowManager";
+import { sanitizeSeededApps } from "./sanitizeSeededApps";
 
 const STALE_BUILD_MS = 30 * 60 * 1000;
 const MAX_CRON_RETRIES = 2;
@@ -55,35 +56,6 @@ async function expireStaleBuild(
     return false;
   }
   return true;
-}
-
-type SeededAppReturn = {
-  repoId: Id<"githubRepos">;
-  seededSnapshotName: string | null;
-  app?: string;
-  status?: "running" | "seeded" | "fallback";
-};
-
-/** Drops legacy warmup fields still present on older prod rows. */
-function sanitizeSeededApps(
-  seededApps: Doc<"snapshotBuilds">["seededApps"],
-): SeededAppReturn[] | undefined {
-  if (seededApps === undefined) {
-    return undefined;
-  }
-  return seededApps.map((app) => {
-    const cleaned: SeededAppReturn = {
-      repoId: app.repoId,
-      seededSnapshotName: app.seededSnapshotName,
-    };
-    if (app.app !== undefined) {
-      cleaned.app = app.app;
-    }
-    if (app.status !== undefined) {
-      cleaned.status = app.status;
-    }
-    return cleaned;
-  });
 }
 
 function sanitizeBuildForReturn(build: Doc<"snapshotBuilds">) {

--- a/packages/backend/convex/_repoSnapshots/sanitizeSeededApps.ts
+++ b/packages/backend/convex/_repoSnapshots/sanitizeSeededApps.ts
@@ -1,0 +1,35 @@
+import type { Id } from "../_generated/dataModel";
+
+export type SeededAppReturn = {
+  repoId: Id<"githubRepos">;
+  seededSnapshotName: string | null;
+  app?: string;
+  status?: "running" | "seeded" | "fallback";
+};
+
+/** Legacy rows may still carry warmup fields that fail return validators. */
+export type SeededAppInput = SeededAppReturn & {
+  warmupStatus?: string;
+};
+
+/** Drops legacy warmup fields still present on older prod rows. */
+export function sanitizeSeededApps(
+  seededApps: SeededAppInput[] | undefined,
+): SeededAppReturn[] | undefined {
+  if (seededApps === undefined) {
+    return undefined;
+  }
+  return seededApps.map((app) => {
+    const cleaned: SeededAppReturn = {
+      repoId: app.repoId,
+      seededSnapshotName: app.seededSnapshotName,
+    };
+    if (app.app !== undefined) {
+      cleaned.app = app.app;
+    }
+    if (app.status !== undefined) {
+      cleaned.status = app.status;
+    }
+    return cleaned;
+  });
+}

--- a/packages/backend/convex/_sandbox/vercelEnvFile.ts
+++ b/packages/backend/convex/_sandbox/vercelEnvFile.ts
@@ -1,0 +1,11 @@
+/** Path for the sourced env file written into Vercel sandboxes. */
+export const EVA_ENV_FILE = "/vercel/sandbox/.eva-env.sh";
+
+/** Renders env vars as sourceable `export K='V'` lines (single-quote-escaped). */
+export function renderEvaEnvFile(env: Record<string, string>): string {
+  return (
+    Object.entries(env)
+      .map(([k, v]) => `export ${k}='${v.replace(/'/g, "'\\''")}'`)
+      .join("\n") + "\n"
+  );
+}

--- a/packages/backend/convex/_sandbox/vercelProvider.ts
+++ b/packages/backend/convex/_sandbox/vercelProvider.ts
@@ -39,6 +39,9 @@ import {
   KEEP_LAST_SNAPSHOTS,
   vercelSnapshotCreateOptions,
 } from "./vercelSnapshotOptions";
+import { EVA_ENV_FILE } from "./vercelEnvFile";
+
+export { EVA_ENV_FILE, renderEvaEnvFile } from "./vercelEnvFile";
 
 /** Vercel API credentials, passed on every SDK call. */
 interface VercelCredentials {
@@ -52,16 +55,6 @@ const DEFAULT_VCPUS = Number(process.env.SANDBOX_VERCEL_VCPUS ?? "8");
 // repo/team env (~6 KB+). Instead of passing env at create, we write it to this
 // file in the sandbox and source it on every exec — no size cap, and it persists
 // across get()/resume like any other file.
-export const EVA_ENV_FILE = "/vercel/sandbox/.eva-env.sh";
-
-/** Renders env vars as sourceable `export K='V'` lines (single-quote-escaped). */
-export function renderEvaEnvFile(env: Record<string, string>): string {
-  return (
-    Object.entries(env)
-      .map(([k, v]) => `export ${k}='${v.replace(/'/g, "'\\''")}'`)
-      .join("\n") + "\n"
-  );
-}
 
 /** Prefix that sources the eva env file (if present) before a command. */
 const SOURCE_ENV = `[ -f ${EVA_ENV_FILE} ] && . ${EVA_ENV_FILE};`;

--- a/packages/backend/convex/_sandbox/vercelProvider.ts
+++ b/packages/backend/convex/_sandbox/vercelProvider.ts
@@ -35,27 +35,10 @@ import type {
   SandboxSnapshotInfo,
   SandboxState,
 } from "./provider";
-
-/** Default TTL for auto-snapshots on persistent sandboxes (30 days). */
-const SNAPSHOT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-/**
- * Safety-net TTL if an ephemeral sandbox ever produces a snap_* (should not —
- * persistent:false skips auto-snapshot). Short so leaked storage self-heals.
- */
-const EPHEMERAL_SNAPSHOT_TTL_MS = 60 * 60 * 1000;
-
-/**
- * Cap auto-snapshots (on stop) and explicit `snapshot()` calls to one per
- * sandbox lineage, deleting older ones immediately. Without this, persistent
- * sandboxes accumulate snap_* objects on every stop/resume cycle.
- * Explicit `expiration` prevents inheriting never-expire TTLs from seed snaps.
- * @see https://vercel.com/docs/sandbox/sdk-reference#keeplastsnapshots
- */
-const KEEP_LAST_SNAPSHOTS = {
-  count: 1,
-  deleteEvicted: true,
-  expiration: SNAPSHOT_TTL_MS,
-} as const;
+import {
+  KEEP_LAST_SNAPSHOTS,
+  vercelSnapshotCreateOptions,
+} from "./vercelSnapshotOptions";
 
 /** Vercel API credentials, passed on every SDK call. */
 interface VercelCredentials {
@@ -916,16 +899,10 @@ class VercelSandboxClient implements SandboxClient {
       // and Vercel bills only active CPU + provisioned memory while running.
       timeout: Math.max(params.lifecycle.autoStopMinutes, 45) * 60 * 1000,
       persistent,
-      // Always set an explicit TTL. Creating from a seed snap with expiration:0
-      // otherwise inherits never-expire, so any auto-snap (or leak) bills forever.
-      snapshotExpiration: persistent
-        ? SNAPSHOT_TTL_MS
-        : EPHEMERAL_SNAPSHOT_TTL_MS,
+      ...vercelSnapshotCreateOptions(persistent),
       resources: { vcpus: DEFAULT_VCPUS },
       ports: (params.ports ?? VERCEL_DEFAULT_EXPOSED_PORTS).slice(0, MAX_PORTS),
       ...(params.lifecycle.labels ? { tags: params.lifecycle.labels } : {}),
-      // Persistent sandboxes auto-snapshot on every stop; keep only the latest.
-      ...(persistent ? { keepLastSnapshots: KEEP_LAST_SNAPSHOTS } : {}),
     };
     try {
       const sandbox = params.snapshot

--- a/packages/backend/convex/_sandbox/vercelSnapshotOptions.ts
+++ b/packages/backend/convex/_sandbox/vercelSnapshotOptions.ts
@@ -1,0 +1,39 @@
+/** Default TTL for auto-snapshots on persistent sandboxes (30 days). */
+export const SNAPSHOT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Safety-net TTL if an ephemeral sandbox ever produces a snap_* (should not —
+ * persistent:false skips auto-snapshot). Short so leaked storage self-heals.
+ */
+export const EPHEMERAL_SNAPSHOT_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Cap auto-snapshots (on stop) and explicit `snapshot()` calls to one per
+ * sandbox lineage, deleting older ones immediately. Without this, persistent
+ * sandboxes accumulate snap_* objects on every stop/resume cycle.
+ * Explicit `expiration` prevents inheriting never-expire TTLs from seed snaps.
+ * @see https://vercel.com/docs/sandbox/sdk-reference#keeplastsnapshots
+ */
+export const KEEP_LAST_SNAPSHOTS = {
+  count: 1,
+  deleteEvicted: true,
+  expiration: SNAPSHOT_TTL_MS,
+} as const;
+
+/**
+ * Create-time snapshot billing knobs for Vercel sandboxes.
+ * Always set an explicit TTL so children of expiration:0 seeds do not inherit
+ * never-expire storage; only persistent sandboxes get keepLastSnapshots.
+ */
+export function vercelSnapshotCreateOptions(persistent: boolean): {
+  snapshotExpiration: number;
+  keepLastSnapshots?: typeof KEEP_LAST_SNAPSHOTS;
+} {
+  if (persistent) {
+    return {
+      snapshotExpiration: SNAPSHOT_TTL_MS,
+      keepLastSnapshots: KEEP_LAST_SNAPSHOTS,
+    };
+  }
+  return { snapshotExpiration: EPHEMERAL_SNAPSHOT_TTL_MS };
+}

--- a/packages/backend/tests/automationRunBranchName.test.ts
+++ b/packages/backend/tests/automationRunBranchName.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+import {
+  buildAutomationRunBranchName,
+  buildProjectBranchName,
+} from "../convex/_git/branchNames";
+
+test("buildAutomationRunBranchName is per-run so fresh PRs do not reuse branches", () => {
+  expect(
+    buildAutomationRunBranchName(
+      "mh7automation00000000000000",
+      "mh7run00000000000000000001",
+    ),
+  ).toBe(
+    "eva/automation-mh7automation00000000000000-mh7run00000000000000000001",
+  );
+});
+
+test("buildProjectBranchName omits version suffix for v1 and adds it for v2+", () => {
+  // After PR merge, v2+ sandboxes need a new branch name.
+  expect(buildProjectBranchName("mh7project0000000000000001")).toBe(
+    "eva/project-mh7project0000000000000001",
+  );
+  expect(buildProjectBranchName("mh7project0000000000000001", 1)).toBe(
+    "eva/project-mh7project0000000000000001",
+  );
+  expect(buildProjectBranchName("mh7project0000000000000001", 2)).toBe(
+    "eva/project-mh7project0000000000000001-v2",
+  );
+});

--- a/packages/backend/tests/decodeGitHubContent.test.ts
+++ b/packages/backend/tests/decodeGitHubContent.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { decodeGitHubContent } from "../convex/_repoSkills/decodeGitHubContent";
+
+test("decodeGitHubContent decodes base64 without Node Buffer", () => {
+  // GitHub Contents API returns base64; Convex isolate has no Buffer.
+  const text = "hello skills\n";
+  const encoded = btoa(text);
+  expect(decodeGitHubContent(encoded)).toBe(text);
+});
+
+test("decodeGitHubContent strips newlines from wrapped base64", () => {
+  const text = "line1\nline2";
+  const encoded = btoa(text);
+  const wrapped = `${encoded.slice(0, 8)}\n${encoded.slice(8)}`;
+  expect(decodeGitHubContent(wrapped)).toBe(text);
+});

--- a/packages/backend/tests/envVarListDisplay.test.ts
+++ b/packages/backend/tests/envVarListDisplay.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import {
+  MASKED_ENV_VAR_VALUE,
+  envVarListDisplayValue,
+  isPlaintextEnvVarKey,
+} from "../convex/_envVars/listDisplay";
+
+test("isPlaintextEnvVarKey treats SANDBOX_PROVIDER as plaintext", () => {
+  expect(isPlaintextEnvVarKey("SANDBOX_PROVIDER")).toBe(true);
+  expect(isPlaintextEnvVarKey("VERCEL_TOKEN")).toBe(false);
+});
+
+test("envVarListDisplayValue returns plaintext SANDBOX_PROVIDER as stored", () => {
+  // Isolate list queries cannot decrypt node ciphertext; toggles must store
+  // plain values so the UI does not always fall back to Daytona.
+  expect(envVarListDisplayValue("SANDBOX_PROVIDER", "vercel")).toBe("vercel");
+  expect(envVarListDisplayValue("SANDBOX_PROVIDER", "daytona")).toBe("daytona");
+});
+
+test("envVarListDisplayValue masks legacy encrypted SANDBOX_PROVIDER until heal", () => {
+  expect(envVarListDisplayValue("SANDBOX_PROVIDER", "enc:legacy-blob")).toBe(
+    MASKED_ENV_VAR_VALUE,
+  );
+});
+
+test("envVarListDisplayValue always masks secret env values", () => {
+  expect(envVarListDisplayValue("VERCEL_TOKEN", "plain-but-secret")).toBe(
+    MASKED_ENV_VAR_VALUE,
+  );
+  expect(envVarListDisplayValue("DAYTONA_API_KEY", "enc:abc")).toBe(
+    MASKED_ENV_VAR_VALUE,
+  );
+});

--- a/packages/backend/tests/evaUrls.test.ts
+++ b/packages/backend/tests/evaUrls.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import {
+  buildEvaDocUrl,
+  buildEvaProjectUrl,
+  buildEvaSessionUrl,
+  buildEvaTaskUrl,
+} from "../convex/_taskWorkflow/urls";
+
+const PREV_WEB_APP_URL = process.env.WEB_APP_URL;
+
+beforeEach(() => {
+  process.env.WEB_APP_URL = "https://eva.example.com/";
+});
+
+afterEach(() => {
+  if (PREV_WEB_APP_URL === undefined) {
+    delete process.env.WEB_APP_URL;
+  } else {
+    process.env.WEB_APP_URL = PREV_WEB_APP_URL;
+  }
+});
+
+test("buildEvaDocUrl uses numeric doc id and monorepo app segment", () => {
+  // GitHub Eva links must use numId paths, not Convex document ids.
+  expect(
+    buildEvaDocUrl("evalucom", "carepulse-ts", 42, "content", "apps/web"),
+  ).toBe("https://eva.example.com/evalucom/carepulse-ts--web/docs/42/content");
+});
+
+test("buildEvaTaskUrl routes project tasks to project URL", () => {
+  expect(
+    buildEvaTaskUrl(
+      "evalucom",
+      "carepulse-ts",
+      "task_1",
+      "proj_1",
+      "apps/eprocurement",
+    ),
+  ).toBe(
+    "https://eva.example.com/evalucom/carepulse-ts--eprocurement/projects/proj_1",
+  );
+});
+
+test("buildEvaTaskUrl uses quick-tasks path without project", () => {
+  expect(buildEvaTaskUrl("vvedantb", "eva", "task_9")).toBe(
+    "https://eva.example.com/vvedantb/eva/quick-tasks/task_9",
+  );
+});
+
+test("buildEvaSessionUrl and buildEvaProjectUrl include app segment when set", () => {
+  expect(buildEvaSessionUrl("vvedantb", "eva", "sess_1", "apps/web")).toBe(
+    "https://eva.example.com/vvedantb/eva--web/sessions/sess_1",
+  );
+  expect(buildEvaProjectUrl("vvedantb", "eva", "proj_2", "apps/web")).toBe(
+    "https://eva.example.com/vvedantb/eva--web/projects/proj_2",
+  );
+});

--- a/packages/backend/tests/githubPrivateKeyFormat.test.ts
+++ b/packages/backend/tests/githubPrivateKeyFormat.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+import {
+  ensurePkcs8PrivateKey,
+  normalizePemKey,
+} from "../convex/githubPrivateKeyFormat";
+
+test("normalizePemKey expands escaped newlines from env paste", () => {
+  // Convex/env UIs often store PEM with literal \\n instead of real newlines.
+  const normalized = normalizePemKey(
+    "-----BEGIN PRIVATE KEY-----\\nABCD\\n-----END PRIVATE KEY-----\\n",
+  );
+  expect(normalized).toBe(
+    "-----BEGIN PRIVATE KEY-----\nABCD\n-----END PRIVATE KEY-----",
+  );
+});
+
+test("normalizePemKey wraps single-line RSA PEM into 64-char base64 lines", () => {
+  const body = "A".repeat(70);
+  const normalized = normalizePemKey(
+    `-----BEGIN RSA PRIVATE KEY-----${body}-----END RSA PRIVATE KEY-----`,
+  );
+  expect(normalized).toContain("-----BEGIN RSA PRIVATE KEY-----");
+  expect(normalized).toContain("-----END RSA PRIVATE KEY-----");
+  expect(normalized.split("\n")[1]).toHaveLength(64);
+  expect(normalized.split("\n")[2]).toHaveLength(6);
+});
+
+test("ensurePkcs8PrivateKey leaves PKCS#8 PEM unchanged", () => {
+  const pkcs8 = [
+    "-----BEGIN PRIVATE KEY-----",
+    "ABCD",
+    "-----END PRIVATE KEY-----",
+  ].join("\n");
+  expect(ensurePkcs8PrivateKey(pkcs8)).toBe(pkcs8);
+});

--- a/packages/backend/tests/implementationPrompt.test.ts
+++ b/packages/backend/tests/implementationPrompt.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "vitest";
+import { buildImplementationPrompt } from "../convex/_taskWorkflow/prompts";
+
+test("buildImplementationPrompt uses commitText for edit commits, not reviewer annotations", () => {
+  // promptText may include "[author · date]"; that must not leak into git commits.
+  const prompt = buildImplementationPrompt(
+    { title: "Add dark mode", description: "Toggle theme", taskNumber: 12 },
+    "eva/task-12",
+    false,
+    "apps/web",
+    "vvedantb",
+    "eva",
+    [
+      {
+        commitText: "fix hover contrast on sidebar",
+        promptText:
+          "fix hover contrast on sidebar [alice · 2026-07-01] please bump contrast",
+      },
+    ],
+  );
+
+  expect(prompt).toContain("edit: fix hover contrast on sidebar");
+  expect(prompt).not.toContain("edit: fix hover contrast on sidebar [alice");
+  expect(prompt).toContain(
+    "1. fix hover contrast on sidebar [alice · 2026-07-01] please bump contrast",
+  );
+});
+
+test("buildImplementationPrompt uses feat scope without change requests", () => {
+  const prompt = buildImplementationPrompt(
+    { title: "Add dark mode", taskNumber: 12 },
+    "eva/task-12",
+    false,
+    "apps/web",
+    "vvedantb",
+    "eva",
+  );
+
+  expect(prompt).toContain("feat(task-12): Add dark mode");
+  expect(prompt).not.toContain("edit:");
+});
+
+test("buildImplementationPrompt uses feat for quick tasks", () => {
+  const prompt = buildImplementationPrompt(
+    { title: "Tiny tweak" },
+    "eva/qt-1",
+    true,
+    "apps/web",
+    "vvedantb",
+    "eva",
+  );
+
+  expect(prompt).toContain("feat: Tiny tweak");
+});

--- a/packages/backend/tests/normalizeAIModel.test.ts
+++ b/packages/backend/tests/normalizeAIModel.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import {
+  getAIModelProvider,
+  normalizeAIModel,
+} from "../convex/_validators/aiModels";
+
+test("normalizeAIModel maps legacy cursor:composer-2 to composer-2.5", () => {
+  // Existing sessions stored composer-2; without this they fail to load.
+  expect(normalizeAIModel("cursor:composer-2")).toBe("cursor:composer-2.5");
+  expect(normalizeAIModel("cursor:composer-2.5")).toBe("cursor:composer-2.5");
+});
+
+test("normalizeAIModel remaps retired cursor model ids", () => {
+  expect(normalizeAIModel("cursor:gpt-5.3-codex-high")).toBe(
+    "cursor:composer-2.5",
+  );
+  expect(normalizeAIModel("cursor:claude-4.6-sonnet-medium-thinking")).toBe(
+    "cursor:grok-4.5-medium",
+  );
+});
+
+test("normalizeAIModel upgrades bare legacy claude aliases", () => {
+  expect(normalizeAIModel("opus")).toBe("claude:opus");
+  expect(normalizeAIModel("haiku")).toBe("claude:haiku");
+  expect(normalizeAIModel("sonnet")).toBe("claude:sonnet");
+});
+
+test("getAIModelProvider follows normalized model prefix", () => {
+  expect(getAIModelProvider("cursor:composer-2")).toBe("cursor");
+  expect(getAIModelProvider("opus")).toBe("claude");
+  expect(getAIModelProvider("codex:gpt-5.4")).toBe("codex");
+});

--- a/packages/backend/tests/pickDefaultVisibleAppRepo.test.ts
+++ b/packages/backend/tests/pickDefaultVisibleAppRepo.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { pickDefaultVisibleAppRepo } from "../convex/_githubRepos/sandboxRepoPick";
+
+type Repo = {
+  _id: string;
+  rootDirectory?: string;
+  hidden?: boolean;
+  connectedBy?: string;
+};
+
+test("pickDefaultVisibleAppRepo prefers apps/web among visible siblings", () => {
+  // Shared automations / PR recaps resolve credentials via this pick first.
+  const root: Repo = { _id: "root" };
+  const eproc: Repo = { _id: "eproc", rootDirectory: "apps/eprocurement" };
+  const web: Repo = { _id: "web", rootDirectory: "apps/web" };
+
+  expect(pickDefaultVisibleAppRepo([root, eproc, web])?._id).toBe("web");
+});
+
+test("pickDefaultVisibleAppRepo skips hidden apps", () => {
+  const hiddenWeb: Repo = {
+    _id: "web",
+    rootDirectory: "apps/web",
+    hidden: true,
+  };
+  const eproc: Repo = { _id: "eproc", rootDirectory: "apps/eprocurement" };
+
+  expect(pickDefaultVisibleAppRepo([hiddenWeb, eproc])?._id).toBe("eproc");
+});
+
+test("pickDefaultVisibleAppRepo prefers connected app when no web", () => {
+  const eproc: Repo = { _id: "eproc", rootDirectory: "apps/eprocurement" };
+  const mobile: Repo = {
+    _id: "mobile",
+    rootDirectory: "apps/mobile",
+    connectedBy: "user_1",
+  };
+
+  expect(pickDefaultVisibleAppRepo([eproc, mobile])?._id).toBe("mobile");
+});
+
+test("pickDefaultVisibleAppRepo returns undefined when only root remains", () => {
+  const root: Repo = { _id: "root" };
+  expect(pickDefaultVisibleAppRepo([root])).toBeUndefined();
+});

--- a/packages/backend/tests/prBody.test.ts
+++ b/packages/backend/tests/prBody.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "vitest";
+import {
+  buildPrBody,
+  buildProjectPrSections,
+  buildTaskPrSections,
+} from "../convex/prBody";
+
+test("buildTaskPrSections numbers change requests and formats image/video proofs", () => {
+  const sections = buildTaskPrSections(
+    "Ship the toggle",
+    ["Bump contrast", "Fix focus ring"],
+    [
+      {
+        fileName: "ui.png",
+        message: null,
+        url: "https://cdn.example/ui.png",
+        contentType: "image/png",
+      },
+      {
+        fileName: "walk.mp4",
+        message: null,
+        url: "https://cdn.example/walk.mp4",
+        contentType: "video/mp4",
+      },
+      {
+        fileName: null,
+        message: "Manual check passed",
+        url: null,
+        contentType: null,
+      },
+    ],
+  );
+
+  expect(sections).toEqual([
+    { heading: "Task", content: "Ship the toggle" },
+    {
+      heading: "Change Requests",
+      content: "1. Bump contrast\n2. Fix focus ring",
+    },
+    {
+      heading: "Proof",
+      content:
+        "![ui.png](https://cdn.example/ui.png)\n- [walk.mp4](https://cdn.example/walk.mp4) (video)\n- Manual check passed",
+    },
+  ]);
+});
+
+test("buildProjectPrSections lists completed tasks with optional descriptions", () => {
+  expect(
+    buildProjectPrSections("Carepulse rollout", "Phase 1", [
+      { title: "Login", description: "SSO flow" },
+      { title: "Dashboard", description: undefined },
+    ]),
+  ).toEqual([
+    {
+      heading: "Project",
+      content: "**Carepulse rollout**\n\nPhase 1",
+    },
+    {
+      heading: "Completed Tasks",
+      content: "1. **Login** — SSO flow\n2. **Dashboard**",
+    },
+  ]);
+});
+
+test("buildPrBody joins sections and appends Eva footer link", () => {
+  const body = buildPrBody(
+    [{ heading: "Task", content: "Hello" }],
+    "https://eva.example.com/task/1",
+  );
+  expect(body).toContain("## Task\nHello\n");
+  expect(body).toContain(
+    "[View in Eva](https://eva.example.com/task/1) | *Created by Eva*",
+  );
+});

--- a/packages/backend/tests/proofPrompt.test.ts
+++ b/packages/backend/tests/proofPrompt.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { buildProofPrompt } from "../convex/_taskWorkflow/prompts";
+
+test("buildProofPrompt defaults to video walkthrough and forbids code edits", () => {
+  const prompt = buildProofPrompt(
+    { title: "Dark mode toggle", description: "Theme switch" },
+    "apps/web",
+    "Added theme toggle in header",
+  );
+
+  expect(prompt).toContain("## Steps (default: video):");
+  expect(prompt).toContain("agent-browser record start recordings/proof.webm");
+  expect(prompt).toContain("Do NOT edit source files");
+  expect(prompt).toContain("Added theme toggle in header");
+  expect(prompt).not.toContain("--annotate");
+});

--- a/packages/backend/tests/renderEvaEnvFile.test.ts
+++ b/packages/backend/tests/renderEvaEnvFile.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { renderEvaEnvFile } from "../convex/_sandbox/vercelEnvFile";
+
+test("renderEvaEnvFile escapes single quotes for shell sourcing", () => {
+  // Values like it's must become 'it'\''s' so `. .eva-env.sh` stays valid.
+  expect(
+    renderEvaEnvFile({
+      FOO: "bar",
+      NOTE: "it's fine",
+    }),
+  ).toBe("export FOO='bar'\nexport NOTE='it'\\''s fine'\n");
+});
+
+test("renderEvaEnvFile ends with a trailing newline", () => {
+  expect(renderEvaEnvFile({ A: "1" }).endsWith("\n")).toBe(true);
+});

--- a/packages/backend/tests/resolveBaseBranch.test.ts
+++ b/packages/backend/tests/resolveBaseBranch.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "vitest";
+import { FALLBACK_GIT_BASE_BRANCH } from "@conductor/shared";
+import {
+  resolveNewTaskBaseBranch,
+  resolveTaskWorkflowBaseBranch,
+} from "../convex/_taskWorkflow/resolveBaseBranch";
+
+test("resolveTaskWorkflowBaseBranch prefers project base when task is in a project", () => {
+  // Child tasks must inherit the project's base, not drift to the repo default.
+  expect(
+    resolveTaskWorkflowBaseBranch(
+      { baseBranch: "task-branch", projectId: "proj1" },
+      { defaultBaseBranch: "main" },
+      { baseBranch: "release/carepulse" },
+    ),
+  ).toBe("release/carepulse");
+});
+
+test("resolveTaskWorkflowBaseBranch uses task then repo when not in a project", () => {
+  expect(
+    resolveTaskWorkflowBaseBranch(
+      { baseBranch: "feature/x", projectId: undefined },
+      { defaultBaseBranch: "main" },
+      { baseBranch: "ignored-project" },
+    ),
+  ).toBe("feature/x");
+
+  expect(
+    resolveTaskWorkflowBaseBranch(
+      { baseBranch: "  ", projectId: undefined },
+      { defaultBaseBranch: "develop" },
+    ),
+  ).toBe("develop");
+});
+
+test("resolveTaskWorkflowBaseBranch falls back when all candidates empty", () => {
+  expect(
+    resolveTaskWorkflowBaseBranch(
+      { baseBranch: undefined, projectId: undefined },
+      null,
+    ),
+  ).toBe(FALLBACK_GIT_BASE_BRANCH);
+});
+
+test("resolveNewTaskBaseBranch prefers explicit then project then repo", () => {
+  expect(
+    resolveNewTaskBaseBranch(
+      "explicit",
+      { defaultBaseBranch: "main" },
+      { baseBranch: "project" },
+    ),
+  ).toBe("explicit");
+  expect(
+    resolveNewTaskBaseBranch(
+      undefined,
+      { defaultBaseBranch: "main" },
+      { baseBranch: "project" },
+    ),
+  ).toBe("project");
+  expect(
+    resolveNewTaskBaseBranch(undefined, { defaultBaseBranch: "main" }),
+  ).toBe("main");
+});

--- a/packages/backend/tests/resolveExistingSandboxId.test.ts
+++ b/packages/backend/tests/resolveExistingSandboxId.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import {
+  preferPersistedSandboxId,
+  resolveExistingSandboxId,
+  resolveReusableVercelSandboxId,
+} from "../convex/_sandbox/resolveExistingSandboxId";
+
+test("resolveExistingSandboxId prefers vercelSandboxId on vercel", () => {
+  expect(
+    resolveExistingSandboxId({
+      providerKind: "vercel",
+      sandboxId: "legacy-or-daytona",
+      vercelSandboxId: "sb_vercel_name",
+    }),
+  ).toBe("sb_vercel_name");
+});
+
+test("resolveExistingSandboxId falls back to sandboxId when vercel field missing", () => {
+  // Legacy rows only persisted the Vercel name on sandboxId — without this,
+  // resume skips reuse and creates a second sandbox.
+  expect(
+    resolveExistingSandboxId({
+      providerKind: "vercel",
+      sandboxId: "sb_legacy_name",
+      vercelSandboxId: undefined,
+    }),
+  ).toBe("sb_legacy_name");
+});
+
+test("resolveExistingSandboxId uses sandboxId on daytona", () => {
+  expect(
+    resolveExistingSandboxId({
+      providerKind: "daytona",
+      sandboxId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      vercelSandboxId: "sb_should_ignore",
+    }),
+  ).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+});
+
+test("preferPersistedSandboxId prefers vercelSandboxId when present", () => {
+  expect(
+    preferPersistedSandboxId({
+      sandboxId: "daytona-or-legacy",
+      vercelSandboxId: "sb_name",
+    }),
+  ).toBe("sb_name");
+  expect(
+    preferPersistedSandboxId({
+      sandboxId: "only-id",
+      vercelSandboxId: undefined,
+    }),
+  ).toBe("only-id");
+});
+
+test("resolveReusableVercelSandboxId ignores Daytona UUID sandboxId fallback", () => {
+  expect(
+    resolveReusableVercelSandboxId({
+      sandboxId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      vercelSandboxId: undefined,
+    }),
+  ).toBeUndefined();
+  expect(
+    resolveReusableVercelSandboxId({
+      sandboxId: "sb_vercel_name",
+      vercelSandboxId: undefined,
+    }),
+  ).toBe("sb_vercel_name");
+  expect(
+    resolveReusableVercelSandboxId({
+      sandboxId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      vercelSandboxId: "sb_vercel_name",
+    }),
+  ).toBe("sb_vercel_name");
+});

--- a/packages/backend/tests/sanitizeSeededApps.test.ts
+++ b/packages/backend/tests/sanitizeSeededApps.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+import { sanitizeSeededApps } from "../convex/_repoSnapshots/sanitizeSeededApps";
+
+test("sanitizeSeededApps strips legacy warmupStatus from seeded app rows", () => {
+  // Older prod rows still carry warmup fields that break return validators.
+  const sanitized = sanitizeSeededApps([
+    {
+      repoId: "mh7repo000000000000000001",
+      seededSnapshotName: "snap_abc",
+      app: "apps/web",
+      status: "seeded",
+      warmupStatus: "done",
+    },
+  ]);
+
+  expect(sanitized).toEqual([
+    {
+      repoId: "mh7repo000000000000000001",
+      seededSnapshotName: "snap_abc",
+      app: "apps/web",
+      status: "seeded",
+    },
+  ]);
+  expect(sanitized?.[0]).not.toHaveProperty("warmupStatus");
+});
+
+test("sanitizeSeededApps returns undefined for missing seededApps", () => {
+  expect(sanitizeSeededApps(undefined)).toBeUndefined();
+});

--- a/packages/backend/tests/taskWorkflowAudit.test.ts
+++ b/packages/backend/tests/taskWorkflowAudit.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "vitest";
+import {
+  extractFailuresFromJson,
+  parseSectionsFromJson,
+} from "../convex/_taskWorkflow/auditParser";
+import {
+  AUDIT_SECTION_REGEX,
+  escapeTableCell,
+  mergeBodyWithAuditSection,
+} from "../convex/_taskWorkflow/prAudit";
+
+test("escapeTableCell escapes pipes and flattens newlines", () => {
+  expect(escapeTableCell("a|b\nc")).toBe("a\\|b c");
+});
+
+test("parseSectionsFromJson drops invalid rows and keeps failures extractable", () => {
+  const sections = parseSectionsFromJson({
+    sections: [
+      {
+        name: "Testing",
+        results: [
+          {
+            requirement: "Typecheck",
+            passed: true,
+            detail: "ok",
+            severity: "low",
+          },
+          {
+            requirement: "Broken",
+            passed: false,
+            detail: "fail detail",
+            severity: "high",
+          },
+          null,
+        ],
+      },
+      null,
+    ],
+  });
+
+  expect(sections).toEqual([
+    {
+      name: "Testing",
+      results: [
+        {
+          requirement: "Typecheck",
+          passed: true,
+          detail: "ok",
+          severity: "low",
+        },
+        {
+          requirement: "Broken",
+          passed: false,
+          detail: "fail detail",
+          severity: "high",
+        },
+      ],
+    },
+  ]);
+
+  expect(
+    extractFailuresFromJson({
+      sections: [
+        {
+          name: "Testing",
+          results: [
+            {
+              requirement: "Broken",
+              passed: false,
+              detail: "fail detail",
+              severity: "high",
+            },
+          ],
+        },
+      ],
+    }),
+  ).toEqual([
+    {
+      section: "Testing",
+      requirement: "Broken",
+      detail: "fail detail",
+    },
+  ]);
+});
+
+test("mergeBodyWithAuditSection replaces prior EVA audit markers", () => {
+  const previous = [
+    "## Task",
+    "Hello",
+    "",
+    "<!-- EVA_AUDIT_START -->",
+    "old audit",
+    "<!-- EVA_AUDIT_END -->",
+    "",
+    "*Created by Eva*",
+  ].join("\n");
+
+  const next = mergeBodyWithAuditSection(
+    previous,
+    "<!-- EVA_AUDIT_START -->\n## Post-Execution Audit\nnew\n<!-- EVA_AUDIT_END -->",
+  );
+
+  expect(next).toContain("## Post-Execution Audit\nnew");
+  expect(next).not.toContain("old audit");
+  expect(AUDIT_SECTION_REGEX.test(previous)).toBe(true);
+});

--- a/packages/backend/tests/taskWorkflowRecovery.test.ts
+++ b/packages/backend/tests/taskWorkflowRecovery.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import {
+  isDaytonaNetworkIssue,
+  isUsageLimitError,
+  parseUsageLimitResetTime,
+} from "../convex/_taskWorkflow/recovery";
+
+test("isDaytonaNetworkIssue requires daytona/sandbox marker plus network/status", () => {
+  expect(
+    isDaytonaNetworkIssue("Daytona sandbox timed out: status code 503"),
+  ).toBe(true);
+  expect(
+    isDaytonaNetworkIssue(
+      "sandbox failed to become ready within the timeout period",
+    ),
+  ).toBe(true);
+  expect(isDaytonaNetworkIssue("plain fetch failed with econnreset")).toBe(
+    false,
+  );
+});
+
+test("isDaytonaNetworkIssue ignores sandbox exec failures and base-branch fetch", () => {
+  // Agent command failures must not trigger infrastructure auto-retry.
+  expect(isDaytonaNetworkIssue("sandbox exec failed: command not found")).toBe(
+    false,
+  );
+  expect(
+    isDaytonaNetworkIssue("Failed to fetch latest base branch from remote"),
+  ).toBe(false);
+});
+
+test("isUsageLimitError matches Claude usage/rate limit copy", () => {
+  expect(
+    isUsageLimitError("You're out of extra usage · resets 4pm (UTC)"),
+  ).toBe(true);
+  expect(isUsageLimitError("rate limit exceeded")).toBe(true);
+  expect(isUsageLimitError("sandbox timed out")).toBe(false);
+});
+
+test("parseUsageLimitResetTime parses UTC reset clock and advances past times", () => {
+  const parsed = parseUsageLimitResetTime(
+    "You're out of extra usage · resets 4pm (UTC)",
+  );
+  expect(parsed).not.toBeNull();
+  if (parsed === null) return;
+  expect(parsed).toBeGreaterThan(Date.now() - 60_000);
+
+  expect(parseUsageLimitResetTime("no reset info here")).toBeNull();
+});

--- a/packages/backend/tests/vercelSnapshotOptions.test.ts
+++ b/packages/backend/tests/vercelSnapshotOptions.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+import {
+  EPHEMERAL_SNAPSHOT_TTL_MS,
+  KEEP_LAST_SNAPSHOTS,
+  SNAPSHOT_TTL_MS,
+  vercelSnapshotCreateOptions,
+} from "../convex/_sandbox/vercelSnapshotOptions";
+
+test("vercelSnapshotCreateOptions always sets an explicit TTL", () => {
+  // Creating from a seed snap with expiration:0 otherwise inherits never-expire.
+  expect(vercelSnapshotCreateOptions(true).snapshotExpiration).toBe(
+    SNAPSHOT_TTL_MS,
+  );
+  expect(vercelSnapshotCreateOptions(false).snapshotExpiration).toBe(
+    EPHEMERAL_SNAPSHOT_TTL_MS,
+  );
+  expect(vercelSnapshotCreateOptions(false).snapshotExpiration).toBeGreaterThan(
+    0,
+  );
+});
+
+test("vercelSnapshotCreateOptions keeps only one snap on persistent sandboxes", () => {
+  expect(vercelSnapshotCreateOptions(true).keepLastSnapshots).toEqual(
+    KEEP_LAST_SNAPSHOTS,
+  );
+  expect(KEEP_LAST_SNAPSHOTS).toEqual({
+    count: 1,
+    deleteEvicted: true,
+    expiration: SNAPSHOT_TTL_MS,
+  });
+});
+
+test("vercelSnapshotCreateOptions omits keepLastSnapshots for ephemeral", () => {
+  expect(vercelSnapshotCreateOptions(false).keepLastSnapshots).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- Add easy Vitest regression coverage for recent fix commits on main, one commit per batch.
- First commit: lock `SANDBOX_PROVIDER` plaintext list-display rules (fix 3279aeda) so the toggle cannot regress to always-Daytona via masked `enc:` values.
- Follow-up loop commits will cover additional easy pure-helper regressions; skip anything needing major refactor or SDK mocks.

## Test plan
- [ ] `cd packages/backend && pnpm test`
- [ ] Confirm PR only includes test files (no unrelated dirty local changes)