### PR TITLE
feat(web): route-driven browser tab titles

### DIFF
--- a/apps/web/src/lib/hooks/useDocumentTitle.ts
+++ b/apps/web/src/lib/hooks/useDocumentTitle.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useMatches } from "@tanstack/react-router";
+
+declare module "@tanstack/react-router" {
+  interface StaticDataRouteOption {
+    /** Section label for the browser tab, e.g. `"Projects"` → "Projects | Eva". */
+    title?: string;
+  }
+}
+
+/** Shown on routes that declare no title (landing page, auth callbacks). */
+const FALLBACK_TITLE = "Eva - Your New Coworker";
+
+/**
+ * Keeps the browser tab title in sync with the active route.
+ *
+ * Routes declare their label via `staticData: { title: "Projects" }`. The
+ * deepest match with a title wins, so a nested route can override the label it
+ * would otherwise inherit from its parent layout. Called once from the root
+ * route so every navigation — including ones that never unmount the shell —
+ * updates the tab.
+ */
+export function useDocumentTitle() {
+  const title = useMatches({
+    select: (matches) =>
+      matches.reduce<string | null>(
+        (deepest, match) => match.staticData.title ?? deepest,
+        null,
+      ),
+  });
+
+  useEffect(() => {
+    document.title = title ? `${title} | Eva` : FALLBACK_TITLE;
+  }, [title]);
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import { ClientProvider } from "@/lib/components/ClientProvider";
 import { ChangelogDialog } from "@/lib/components/ChangelogDialog";
 import { AppToaster } from "@/lib/components/AppToaster";
 import { AppShell } from "@/lib/components/AppShell";
+import { useDocumentTitle } from "@/lib/hooks/useDocumentTitle";
 
 export interface RouterContext {
   isSignedIn: boolean;
@@ -25,6 +26,8 @@ const DevAgentation = import.meta.env.DEV
   : null;
 
 function RootComponent() {
+  useDocumentTitle();
+
   return (
     <ClientProvider>
       <NuqsAdapter>

--- a/apps/web/src/routes/_global/artifacts/$artifactId.tsx
+++ b/apps/web/src/routes/_global/artifacts/$artifactId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ArtifactViewer } from "@/lib/components/artifacts/ArtifactViewer";
 
 export const Route = createFileRoute("/_global/artifacts/$artifactId")({
+  staticData: { title: "Artifacts" },
   component: ArtifactRoute,
 });
 

--- a/apps/web/src/routes/_global/artifacts/index.tsx
+++ b/apps/web/src/routes/_global/artifacts/index.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ArtifactsGlobalClient } from "./ArtifactsGlobalClient";
 
 export const Route = createFileRoute("/_global/artifacts/")({
+  staticData: { title: "Artifacts" },
   component: ArtifactsGlobalClient,
 });

--- a/apps/web/src/routes/_global/home.tsx
+++ b/apps/web/src/routes/_global/home.tsx
@@ -3,6 +3,7 @@ import { consumeMcpOauthParams } from "@/lib/mcpOauthStorage";
 import { ReposClient } from "./home/ReposClient";
 
 export const Route = createFileRoute("/_global/home")({
+  staticData: { title: "Codebases" },
   // If the user landed here mid-MCP OAuth flow (Clerk's prod handshake can
   // redirect to the global `signInFallbackRedirectUrl` before our authorize
   // route can mint the code), bounce them back into the flow.

--- a/apps/web/src/routes/_global/inbox.tsx
+++ b/apps/web/src/routes/_global/inbox.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { InboxClient } from "@/lib/components/inbox/InboxClient";
 
 export const Route = createFileRoute("/_global/inbox")({
+  staticData: { title: "Inbox" },
   component: InboxClient,
 });

--- a/apps/web/src/routes/_global/sessions.tsx
+++ b/apps/web/src/routes/_global/sessions.tsx
@@ -3,6 +3,7 @@ import { IconTerminal2 } from "@tabler/icons-react";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
 
 export const Route = createFileRoute("/_global/sessions")({
+  staticData: { title: "Sessions" },
   component: SessionsGlobalPage,
 });
 

--- a/apps/web/src/routes/_global/settings/accounts.tsx
+++ b/apps/web/src/routes/_global/settings/accounts.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { AccountsClient } from "@/lib/components/accounts/AccountsClient";
 
 export const Route = createFileRoute("/_global/settings/accounts")({
+  staticData: { title: "Settings" },
   component: AccountsClient,
 });

--- a/apps/web/src/routes/_global/settings/notifications.tsx
+++ b/apps/web/src/routes/_global/settings/notifications.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { NotificationsSettingsClient } from "@/lib/components/notifications/NotificationsSettingsClient";
 
 export const Route = createFileRoute("/_global/settings/notifications")({
+  staticData: { title: "Settings" },
   component: NotificationsSettingsClient,
 });

--- a/apps/web/src/routes/_global/settings/personalisation.tsx
+++ b/apps/web/src/routes/_global/settings/personalisation.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { PersonalisationClient } from "@/lib/components/personalisation/PersonalisationClient";
 
 export const Route = createFileRoute("/_global/settings/personalisation")({
+  staticData: { title: "Settings" },
   component: PersonalisationClient,
 });

--- a/apps/web/src/routes/_global/settings/sandboxes.tsx
+++ b/apps/web/src/routes/_global/settings/sandboxes.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SandboxAutoStopSettingsClient } from "@/lib/components/sandboxes/SandboxAutoStopSettingsClient";
 
 export const Route = createFileRoute("/_global/settings/sandboxes")({
+  staticData: { title: "Settings" },
   component: SandboxAutoStopSettingsClient,
 });

--- a/apps/web/src/routes/_global/settings/sync.tsx
+++ b/apps/web/src/routes/_global/settings/sync.tsx
@@ -32,6 +32,7 @@ function dedupeRepos(
 }
 
 export const Route = createFileRoute("/_global/settings/sync")({
+  staticData: { title: "Settings" },
   component: SyncSettingsRoute,
 });
 

--- a/apps/web/src/routes/_global/settings/theme.tsx
+++ b/apps/web/src/routes/_global/settings/theme.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ThemeSettingsClient } from "@/lib/components/theme/ThemeSettingsClient";
 
 export const Route = createFileRoute("/_global/settings/theme")({
+  staticData: { title: "Settings" },
   component: ThemeSettingsClient,
 });

--- a/apps/web/src/routes/_global/setup/$id.tsx
+++ b/apps/web/src/routes/_global/setup/$id.tsx
@@ -6,6 +6,7 @@ interface SetupSearch {
 }
 
 export const Route = createFileRoute("/_global/setup/$id")({
+  staticData: { title: "Setup" },
   component: RepoSetupPage,
   validateSearch: (search: Record<string, string>): SetupSearch => ({
     auto: search.auto,

--- a/apps/web/src/routes/_global/teams/$teamId/route.tsx
+++ b/apps/web/src/routes/_global/teams/$teamId/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_global/teams/$teamId")({
+  staticData: { title: "Teams" },
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/_global/teams/index.tsx
+++ b/apps/web/src/routes/_global/teams/index.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { TeamsClient } from "./TeamsClient";
 
 export const Route = createFileRoute("/_global/teams/")({
+  staticData: { title: "Teams" },
   component: TeamsClient,
 });

--- a/apps/web/src/routes/_global/testing.tsx
+++ b/apps/web/src/routes/_global/testing.tsx
@@ -10,6 +10,7 @@ const searchSchema = z.object({
 });
 
 export const Route = createFileRoute("/_global/testing")({
+  staticData: { title: "Testing" },
   validateSearch: searchSchema,
   beforeLoad: () => {
     if (!import.meta.env.DEV) {

--- a/apps/web/src/routes/_repo/$owner/$repo/automations/$numId/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/automations/$numId/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/automations/$numId")({
+  staticData: { title: "Automations" },
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/automations/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/automations/index.tsx
@@ -3,6 +3,7 @@ import { IconPlayerPlay } from "@tabler/icons-react";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/automations/")({
+  staticData: { title: "Automations" },
   component: AutomationsPage,
 });
 

--- a/apps/web/src/routes/_repo/$owner/$repo/designs/$numId.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/designs/$numId.tsx
@@ -5,6 +5,7 @@ import { useDesignSessionByNumId } from "@/lib/useResolveByNumId";
 import { DesignDetailClient } from "./DesignDetailClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/designs/$numId")({
+  staticData: { title: "Designs" },
   component: DesignDetailRoute,
 });
 

--- a/apps/web/src/routes/_repo/$owner/$repo/designs/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/designs/index.tsx
@@ -3,6 +3,7 @@ import { IconPalette } from "@tabler/icons-react";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/designs/")({
+  staticData: { title: "Designs" },
   component: DesignsIndexPage,
 });
 

--- a/apps/web/src/routes/_repo/$owner/$repo/docs/$numId/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/docs/$numId/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/docs/$numId")({
+  staticData: { title: "Documents" },
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/docs/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/docs/index.tsx
@@ -3,6 +3,7 @@ import { IconFileText } from "@tabler/icons-react";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/docs/")({
+  staticData: { title: "Documents" },
   component: DocsIndexPage,
 });
 

--- a/apps/web/src/routes/_repo/$owner/$repo/drafts/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/drafts/index.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { DraftsClient } from "./DraftsClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/drafts/")({
+  staticData: { title: "Drafts" },
   component: DraftsClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/inbox.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/inbox.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { InboxClient } from "@/lib/components/inbox/InboxClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/inbox")({
+  staticData: { title: "Inbox" },
   component: InboxClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/index.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { NewSessionComposer } from "./sessions/_components/NewSessionComposer";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/")({
+  staticData: { title: "New Session" },
   component: NewSessionComposer,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/projects/$numId/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/projects/$numId/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/projects/$numId")({
+  staticData: { title: "Projects" },
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/projects/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/projects/index.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ProjectsClient } from "./ProjectsClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/projects/")({
+  staticData: { title: "Projects" },
   component: ProjectsClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/route.tsx
@@ -7,6 +7,7 @@ import { parseDiffSearchFields } from "@/lib/search-params";
 // changes, so selecting a task never remounts/scroll-resets the list. The open
 // task is read from the child route params inside QuickTasksClient.
 export const Route = createFileRoute("/_repo/$owner/$repo/quick-tasks")({
+  staticData: { title: "Quick Tasks" },
   component: QuickTasksClient,
   validateSearch: (search: Record<string, string>) => ({
     draft: typeof search.draft === "string" ? search.draft : undefined,

--- a/apps/web/src/routes/_repo/$owner/$repo/reviews/$prNumber/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/reviews/$prNumber/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/reviews/$prNumber")({
+  staticData: { title: "Reviews" },
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/reviews/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/reviews/index.tsx
@@ -3,6 +3,7 @@ import { IconGitPullRequest } from "@tabler/icons-react";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/reviews/")({
+  staticData: { title: "Reviews" },
   component: ReviewsIndexPage,
 });
 

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/route.tsx
@@ -12,6 +12,7 @@ const MAX_CACHED_SESSIONS = 3;
  * `/sessions` (no `$numId`) still renders the new-session composer via Outlet.
  */
 export const Route = createFileRoute("/_repo/$owner/$repo/sessions")({
+  staticData: { title: "Sessions" },
   component: SessionsLayout,
 });
 

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/app.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/app.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { AppClient } from "./AppClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/app")({
+  staticData: { title: "Settings" },
   component: AppClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/audits.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/audits.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { AuditsClient } from "./AuditsClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/audits")({
+  staticData: { title: "Settings" },
   component: AuditsClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/config.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/config.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ConfigClient } from "./ConfigClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/config")({
+  staticData: { title: "Settings" },
   component: ConfigClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/env-variables/$scope.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/env-variables/$scope.tsx
@@ -5,6 +5,7 @@ import { isEnvVarScope } from "@/lib/search-params";
 export const Route = createFileRoute(
   "/_repo/$owner/$repo/settings/env-variables/$scope",
 )({
+  staticData: { title: "Settings" },
   beforeLoad: ({ params }) => {
     if (!isEnvVarScope(params.scope)) {
       throw redirect({

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/logs.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/logs.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { LogsClient } from "./LogsClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/logs")({
+  staticData: { title: "Settings" },
   component: LogsClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/mcp-config.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/mcp-config.tsx
@@ -3,6 +3,7 @@ import { McpConfigClient } from "./McpConfigClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/mcp-config")(
   {
+    staticData: { title: "Settings" },
     component: McpConfigClient,
   },
 );

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/monorepo.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/monorepo.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { MonorepoClient } from "./MonorepoClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/monorepo")({
+  staticData: { title: "Settings" },
   component: MonorepoClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/personalisation.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/personalisation.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 export const Route = createFileRoute(
   "/_repo/$owner/$repo/settings/personalisation",
 )({
+  staticData: { title: "Settings" },
   beforeLoad: () => {
     throw redirect({ to: "/settings/personalisation" });
   },

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/skills.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/skills.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SkillsClient } from "./SkillsClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/skills")({
+  staticData: { title: "Settings" },
   component: SkillsClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/snapshots/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/snapshots/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/snapshots")({
+  staticData: { title: "Settings" },
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/tabs.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/tabs.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { TabsSettingsClient } from "./TabsSettingsClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/tabs")({
+  staticData: { title: "Settings" },
   component: TabsSettingsClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/theme.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/theme.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 /** Theme is user-level — send old repo URLs to the global settings page. */
 export const Route = createFileRoute("/_repo/$owner/$repo/settings/theme")({
+  staticData: { title: "Settings" },
   beforeLoad: () => {
     throw redirect({ to: "/settings/theme" });
   },

--- a/apps/web/src/routes/_repo/$owner/$repo/stats.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/stats.tsx
@@ -2,5 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { StatsClient } from "./stats/StatsClient";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/stats")({
+  staticData: { title: "Stats" },
   component: StatsClient,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/testing-arena/$numId/route.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/testing-arena/$numId/route.tsx
@@ -3,5 +3,6 @@ import { createFileRoute, Outlet } from "@tanstack/react-router";
 export const Route = createFileRoute(
   "/_repo/$owner/$repo/testing-arena/$numId",
 )({
+  staticData: { title: "Testing Arena" },
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/_repo/$owner/$repo/testing-arena/index.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/testing-arena/index.tsx
@@ -3,6 +3,7 @@ import { IconFileText } from "@tabler/icons-react";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
 
 export const Route = createFileRoute("/_repo/$owner/$repo/testing-arena/")({
+  staticData: { title: "Testing Arena" },
   component: TestingArenaPage,
 });
 


### PR DESCRIPTION
Tab titles now follow the active route: `Projects | Eva`, `Quick Tasks | Eva`, `Sessions | Eva`, `Documents | Eva`, `Reviews | Eva`, and so on.

## How it works

- Routes declare a label with `staticData: { title: "Projects" }` (same mechanism the shell already uses for `appShell`).
- `useDocumentTitle` (`apps/web/src/lib/hooks/useDocumentTitle.ts`) reads the deepest matched title from `useMatches` and sets `document.title` to `"<Section> | Eva"`.
- Called once from `__root.tsx`, so it also updates on navigations that never remount the shell.
- Untitled routes (landing page, auth callbacks, redirect-only routes) fall back to `Eva - Your New Coworker`.

Section layouts (`sessions/route.tsx`, `quick-tasks/route.tsx`, `projects/$numId/route.tsx`, …) carry the label, so nested detail, sandbox, review, and tab routes inherit it without extra wiring.

## Labels

Repo: Projects, Quick Tasks, Sessions, Documents, Reviews, Designs, Testing Arena, Automations, Stats, Drafts, Inbox, Settings, New Session.
Global: Codebases, Sessions, Inbox, Artifacts, Teams, Setup, Settings, Testing.

## Verification

`npx tsc --noEmit` in `apps/web` passes clean.
