### PR TITLE
refactor(settings): unify every settings route on shared section primitives

### DIFF
--- a/apps/web/src/lib/components/EnvVarProviderSlots.tsx
+++ b/apps/web/src/lib/components/EnvVarProviderSlots.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import {
+  Badge,
   Button,
   Dialog,
   DialogContent,
@@ -187,12 +188,12 @@ export function EnvVarProviderSlots({
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium">{entry.label}</span>
                   {configured && (
-                    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                    <Badge variant="secondary" className="gap-1 text-xs">
                       <IconCheck size={10} /> Configured
-                    </span>
+                    </Badge>
                   )}
                 </div>
-                <p className="mt-0.5 text-xs text-muted-foreground">
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
                   {entry.hint}
                 </p>
 
@@ -261,11 +262,11 @@ export function EnvVarProviderSlots({
                 {configured && matched && !isEditing && (
                   <div className="mt-1.5">
                     {revealed[matched.key] !== undefined && (
-                      <pre className="mb-1 max-h-24 overflow-auto rounded border border-border bg-background px-2 py-1 font-mono text-[11px] break-all whitespace-pre-wrap">
+                      <pre className="mb-1 max-h-24 overflow-auto rounded-control border border-border bg-background px-2 py-1 font-mono text-xs break-all whitespace-pre-wrap">
                         {revealed[matched.key]}
                       </pre>
                     )}
-                    <span className="font-mono text-[10px] text-muted-foreground">
+                    <span className="font-mono text-xs text-muted-foreground">
                       {matched.key}
                     </span>
                   </div>

--- a/apps/web/src/lib/components/EnvVarsTable.tsx
+++ b/apps/web/src/lib/components/EnvVarsTable.tsx
@@ -33,6 +33,8 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { CrossfadeIcon } from "@/lib/components/ui/CrossfadeIcon";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import { EnvVarProviderSlots } from "@/lib/components/EnvVarProviderSlots";
 import { parseEnvVars } from "./_utils/parseEnvVars";
 import {
@@ -419,33 +421,32 @@ export function EnvVarsTable({
     </TableRow>
   ) : null;
 
+  /** Add and bulk-paste both create free-form vars, so they sit on that card. */
+  const freeformActions = readOnly ? undefined : (
+    <div className="flex shrink-0 items-center gap-2">
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => setShowBulkPaste(true)}
+      >
+        <IconClipboard size={14} />
+        Paste
+      </Button>
+      <Button size="sm" onClick={startAdd} disabled={adding}>
+        <IconPlus size={14} />
+        Add Variable
+      </Button>
+    </div>
+  );
+
   return (
-    <div>
-      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-xs text-muted-foreground">{description}</p>
-        {!readOnly && (
-          <div className="flex items-center gap-2 shrink-0">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setShowBulkPaste(true)}
-            >
-              <IconClipboard size={16} className="mr-1.5" />
-              Paste
-            </Button>
-            <Button size="sm" onClick={startAdd} disabled={adding}>
-              <IconPlus size={16} className="mr-1.5" />
-              Add Variable
-            </Button>
-          </div>
-        )}
-      </div>
+    <div className="space-y-4">
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        {description}
+      </p>
       {vars !== undefined && (
         <>
-          <div className="mb-6">
-            <p className="mb-2 text-xs font-medium text-muted-foreground">
-              Coding agents
-            </p>
+          <SettingsSection title="Coding agents">
             <EnvVarProviderSlots
               entries={agentSlots}
               vars={vars}
@@ -454,11 +455,8 @@ export function EnvVarsTable({
               onRemove={onRemove}
               readOnly={readOnly}
             />
-          </div>
-          <div className="mb-6">
-            <p className="mb-2 text-xs font-medium text-muted-foreground">
-              Infrastructure
-            </p>
+          </SettingsSection>
+          <SettingsSection title="Infrastructure">
             <EnvVarProviderSlots
               entries={infraSlots}
               defaultSandboxExclude
@@ -469,11 +467,8 @@ export function EnvVarsTable({
               readOnly={readOnly}
               removeDialogDescription="Sandbox provisioning may fail until you paste it again."
             />
-          </div>
-          <div className="mb-6">
-            <p className="mb-2 text-xs font-medium text-muted-foreground">
-              Convex
-            </p>
+          </SettingsSection>
+          <SettingsSection title="Convex">
             <EnvVarProviderSlots
               entries={convexSlots}
               vars={vars}
@@ -483,57 +478,71 @@ export function EnvVarsTable({
               readOnly={readOnly}
               removeDialogDescription="The sandboxed app may lose access to its Convex backend until you paste it again."
             />
-          </div>
+          </SettingsSection>
         </>
       )}
       {vars === undefined ? (
         <div className="flex items-center justify-center py-12">
           <Spinner size="lg" />
         </div>
-      ) : !showTable ? (
-        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-          <IconKey size={48} className="mb-3 opacity-40" />
-          <p className="text-sm">No other environment variables configured</p>
-        </div>
       ) : (
-        <div className="space-y-6">
-          <div className="rounded-surface border border-border bg-muted/40">
-            <Table className="min-w-[360px]">
-              {tableHeader}
-              <TableBody>
-                {addingRow}
-                {sandboxVars.map(renderRow)}
-                {sandboxVars.length === 0 && !adding && (
-                  <TableRow className="hover:bg-transparent">
-                    <TableCell
-                      colSpan={3}
-                      className="px-4 py-6 text-center text-xs text-muted-foreground"
-                    >
-                      No sandbox variables
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
+        <>
+          {/* The table owns the card's full width, so the body carries no padding. */}
+          <SettingsSection
+            title="Other variables"
+            description="Anything not covered by a known slot above."
+            action={freeformActions}
+            bodyClassName="p-0"
+          >
+            {showTable ? (
+              <div className="overflow-x-auto">
+                <Table className="min-w-[360px]">
+                  {tableHeader}
+                  <TableBody>
+                    {addingRow}
+                    {sandboxVars.map(renderRow)}
+                    {sandboxVars.length === 0 && !adding && (
+                      <TableRow className="hover:bg-transparent">
+                        <TableCell
+                          colSpan={3}
+                          className="px-4 py-6 text-center text-xs text-muted-foreground"
+                        >
+                          No sandbox variables
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <SettingsEmptyState
+                icon={IconKey}
+                title="No other variables"
+                description="Add one to inject it into every sandbox for this scope."
+              />
+            )}
+          </SettingsSection>
 
           {excludedVars.length > 0 && (
-            <div>
-              <div className="mb-2 flex items-center gap-1.5">
-                <IconLock size={14} className="text-warning" />
-                <p className="text-xs font-medium text-muted-foreground">
+            <SettingsSection
+              title={
+                <span className="flex items-center gap-1.5">
+                  <IconLock size={14} className="text-warning" />
                   Excluded from Sandbox
-                </p>
-              </div>
-              <div className="rounded-surface border border-border bg-muted/40">
+                </span>
+              }
+              description="Held for the platform only — these are never injected into a sandbox."
+              bodyClassName="p-0"
+            >
+              <div className="overflow-x-auto">
                 <Table className="min-w-[360px]">
                   {tableHeader}
                   <TableBody>{excludedVars.map(renderRow)}</TableBody>
                 </Table>
               </div>
-            </div>
+            </SettingsSection>
           )}
-        </div>
+        </>
       )}
 
       <Dialog

--- a/apps/web/src/lib/components/accounts/AccountsClient.tsx
+++ b/apps/web/src/lib/components/accounts/AccountsClient.tsx
@@ -5,6 +5,8 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useMutation } from "convex/react";
 import { api, type Id } from "@eva/backend";
 import { PageWrapper } from "@/lib/components/PageWrapper";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import {
   Button,
   Dialog,
@@ -54,72 +56,73 @@ export function AccountsClient() {
 
   return (
     <PageWrapper title="Accounts" comfortable>
-      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <p className="max-w-prose text-xs text-muted-foreground">
-          Add your own coding-agent accounts. Tasks, sessions, and projects you
-          create default to your account for that provider (otherwise Team).
-          Collaborators&apos; Make changes still bill your sticky account.
-        </p>
-        <Button size="sm" onClick={openCreate} className="shrink-0">
-          <IconPlus size={16} className="mr-1.5" />
-          Add account
-        </Button>
-      </div>
-
-      {accounts === undefined ? (
-        <div className="flex items-center justify-center py-12">
-          <Spinner size="lg" />
-        </div>
-      ) : accounts.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-          <IconKey size={48} className="mb-3 opacity-40" />
-          <p className="text-sm">No accounts yet</p>
-          <p className="mt-1 text-xs">
-            Add one to run agents on your own credentials.
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {accounts.map((account) => (
-            <div
-              key={account._id}
-              className="flex items-center gap-3 rounded-surface border border-border bg-muted/40 px-4 py-3"
-            >
-              <span
-                className="size-3 shrink-0 rounded-full border border-border"
-                style={{
-                  backgroundColor: account.accentColor ?? "var(--muted)",
-                }}
-              />
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">{account.label}</p>
-                <p className="text-[11px] text-muted-foreground">
-                  {PROVIDER_LABELS[account.provider]} ·{" "}
-                  {account.credentials.length} credential
-                  {account.credentials.length !== 1 ? "s" : ""}
-                </p>
+      <SettingsSection
+        title="Your accounts"
+        description="Tasks, sessions, and projects you create default to your account for that provider, otherwise Team. Collaborators' Make changes still bill your sticky account."
+        action={
+          <Button size="sm" onClick={openCreate}>
+            <IconPlus size={16} className="mr-1.5" />
+            Add account
+          </Button>
+        }
+        // The list and its empty state manage their own padding.
+        bodyClassName="p-0"
+      >
+        {accounts === undefined ? (
+          <div className="flex items-center justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : accounts.length === 0 ? (
+          <SettingsEmptyState
+            icon={IconKey}
+            title="No accounts yet"
+            description="Add one to run agents on your own credentials instead of the team's."
+          />
+        ) : (
+          <div className="divide-y divide-border">
+            {accounts.map((account) => (
+              <div
+                key={account._id}
+                className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+              >
+                <span
+                  className="size-3 shrink-0 rounded-full border border-border"
+                  style={{
+                    backgroundColor: account.accentColor ?? "var(--muted)",
+                  }}
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">
+                    {account.label}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {PROVIDER_LABELS[account.provider]} ·{" "}
+                    {account.credentials.length} credential
+                    {account.credentials.length !== 1 ? "s" : ""}
+                  </p>
+                </div>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => openEdit(account)}
+                  title="Edit"
+                >
+                  <IconPencil size={14} />
+                </Button>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => setDeleteId(account._id)}
+                  title="Delete"
+                  className="text-destructive hover:text-destructive"
+                >
+                  <IconTrash size={14} />
+                </Button>
               </div>
-              <Button
-                size="icon-sm"
-                variant="ghost"
-                onClick={() => openEdit(account)}
-                title="Edit"
-              >
-                <IconPencil size={14} />
-              </Button>
-              <Button
-                size="icon-sm"
-                variant="ghost"
-                onClick={() => setDeleteId(account._id)}
-                title="Delete"
-                className="text-destructive hover:text-destructive"
-              >
-                <IconTrash size={14} />
-              </Button>
-            </div>
-          ))}
-        </div>
-      )}
+            ))}
+          </div>
+        )}
+      </SettingsSection>
 
       <AddAccountDialog
         open={dialogOpen}

--- a/apps/web/src/lib/components/notifications/NotificationsSettingsClient.tsx
+++ b/apps/web/src/lib/components/notifications/NotificationsSettingsClient.tsx
@@ -3,7 +3,8 @@
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import { PageWrapper } from "@/lib/components/PageWrapper";
-import { Checkbox, Spinner } from "@eva/ui";
+import { Spinner, Switch } from "@eva/ui";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 
 export function NotificationsSettingsClient() {
   const enabled = useQuery(api.auth.getEmailNotificationsEnabled);
@@ -29,22 +30,19 @@ export function NotificationsSettingsClient() {
 
   return (
     <PageWrapper title="Notifications" comfortable>
-      <label className="flex cursor-pointer items-start gap-3 rounded-surface border border-border bg-card p-4 transition-colors hover:bg-muted/60">
-        <Checkbox
-          className="mt-0.5"
-          checked={enabled}
-          onCheckedChange={(checked) =>
-            setEnabled({ enabled: checked === true })
+      <div className="space-y-4">
+        <SettingsSection
+          title="Email notifications"
+          description="Receive a daily summary of your unread notifications and the weekly changelog by email. Off by default."
+          action={
+            <Switch
+              checked={enabled}
+              onCheckedChange={(checked) => setEnabled({ enabled: checked })}
+              aria-label="Email notifications"
+            />
           }
         />
-        <div>
-          <h3 className="text-sm font-medium">Email notifications</h3>
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            Receive a daily summary of your unread notifications and the weekly
-            changelog by email. Off by default.
-          </p>
-        </div>
-      </label>
+      </div>
     </PageWrapper>
   );
 }

--- a/apps/web/src/lib/components/onboarding/_components/WelcomeSetupThemeStep.tsx
+++ b/apps/web/src/lib/components/onboarding/_components/WelcomeSetupThemeStep.tsx
@@ -1,5 +1,6 @@
 import { AppearanceSection } from "@/lib/components/theme/_components/AppearanceSection";
 import { AccentColorSection } from "@/lib/components/theme/_components/AccentColorSection";
+import { SectionLabel } from "@/lib/components/theme/_components/SectionLabel";
 import type { AccentColor } from "@/lib/contexts/ThemeContext";
 
 interface WelcomeSetupThemeStepProps {
@@ -20,15 +21,21 @@ export function WelcomeSetupThemeStep({
       <p className="text-sm text-muted-foreground">
         Choose how Eva looks — mode and accent color.
       </p>
-      <AppearanceSection
-        compact
-        currentMode={currentMode}
-        onModeChange={onModeChange}
-      />
-      <AccentColorSection
-        accentColor={accentColor}
-        onAccentChange={onAccentChange}
-      />
+      <section>
+        <SectionLabel>Appearance</SectionLabel>
+        <AppearanceSection
+          compact
+          currentMode={currentMode}
+          onModeChange={onModeChange}
+        />
+      </section>
+      <section>
+        <SectionLabel>Accent Color</SectionLabel>
+        <AccentColorSection
+          accentColor={accentColor}
+          onAccentChange={onAccentChange}
+        />
+      </section>
     </div>
   );
 }

--- a/apps/web/src/lib/components/personalisation/PersonalisationClient.tsx
+++ b/apps/web/src/lib/components/personalisation/PersonalisationClient.tsx
@@ -3,6 +3,7 @@
 import { useQuery, useMutation } from "convex/react";
 import { api, PERSONALISATION_PRESETS } from "@eva/backend";
 import { PageWrapper } from "@/lib/components/PageWrapper";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 import { Textarea, Button, Spinner } from "@eva/ui";
 import { useEffect, useRef } from "react";
 import { RolePresetPicker } from "./RolePresetPicker";
@@ -69,62 +70,50 @@ export function PersonalisationClient() {
 
   return (
     <PageWrapper title="Personalisation" comfortable>
-      <div className="space-y-6">
-        {/* Preset section */}
-        <div className="space-y-3">
-          <div>
-            <h3 className="text-sm font-medium">Role Preset</h3>
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Controls how responses are communicated, not what code edits are
-              made. Included in every session.
-            </p>
-          </div>
+      <div className="space-y-4">
+        <SettingsSection
+          title="Role Preset"
+          description="Controls how responses are communicated, not what code edits are made. Included in every session."
+        >
+          <div className="space-y-3">
+            <RolePresetPicker
+              activeRole={activeRole}
+              onSelect={(role) => setRole({ role })}
+            />
 
-          <RolePresetPicker
-            activeRole={activeRole}
-            onSelect={(role) => setRole({ role })}
-          />
-
-          {activeRole ? (
-            <div className="rounded-surface border border-border bg-card p-3">
-              <p className="mb-2 text-[11px] font-medium text-muted-foreground">
-                Active preset prompt
+            {activeRole ? (
+              <div className="rounded-surface border border-border bg-muted/40 p-3">
+                <p className="mb-2 text-xs font-medium text-muted-foreground">
+                  Active preset prompt
+                </p>
+                <pre className="whitespace-pre-wrap font-mono text-xs leading-relaxed text-foreground/80">
+                  {PERSONALISATION_PRESETS[activeRole].prompt}
+                </pre>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No role selected. Choose a preset above to activate it.
               </p>
-              <pre className="whitespace-pre-wrap text-xs font-mono text-foreground/80 leading-relaxed">
-                {PERSONALISATION_PRESETS[activeRole].prompt}
-              </pre>
-            </div>
-          ) : (
-            <p className="text-xs text-muted-foreground italic">
-              No role selected. Click a preset above to activate it.
-            </p>
-          )}
-        </div>
-
-        {/* Custom instructions section */}
-        <div className="space-y-3">
-          <div>
-            <h3 className="text-sm font-medium">Custom Instructions</h3>
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Additional instructions injected into every session. Use this to
-              describe your preferences, role-specific context, or recurring
-              guidance.
-            </p>
+            )}
           </div>
+        </SettingsSection>
 
-          <Textarea
-            ref={textareaRef}
-            className="min-h-[160px] text-xs font-mono"
-            placeholder="e.g. Always explain changes in plain English before showing code..."
-            defaultValue={savedValue}
-          />
-
-          <div className="flex justify-end">
+        <SettingsSection
+          title="Custom Instructions"
+          description="Additional instructions injected into every session. Use this to describe your preferences, role-specific context, or recurring guidance."
+          footer={
             <Button size="sm" onClick={handleSave}>
               Save
             </Button>
-          </div>
-        </div>
+          }
+        >
+          <Textarea
+            ref={textareaRef}
+            className="min-h-[160px] font-mono text-xs"
+            placeholder="e.g. Always explain changes in plain English before showing code..."
+            defaultValue={savedValue}
+          />
+        </SettingsSection>
       </div>
     </PageWrapper>
   );

--- a/apps/web/src/lib/components/personalisation/RolePresetPicker.tsx
+++ b/apps/web/src/lib/components/personalisation/RolePresetPicker.tsx
@@ -36,17 +36,21 @@ export function RolePresetPicker({
             type="button"
             onClick={() => onSelect(isActive ? null : key)}
             className={cn(
-              "cursor-pointer rounded-surface p-3 text-left transition-[background-color]",
+              // Inactive tiles keep a transparent border so selecting one does
+              // not shift the grid.
+              "cursor-pointer rounded-surface border p-3 text-left transition-[background-color,border-color]",
               isActive
-                ? "bg-accent text-accent-foreground"
-                : "bg-muted/40 text-muted-foreground hover:bg-muted/60",
+                ? "border-border bg-accent text-accent-foreground"
+                : "border-transparent bg-muted/40 text-muted-foreground hover:bg-muted/60",
             )}
           >
             <div className="flex items-center gap-2">
               <Icon size={14} />
               <span className="text-xs font-medium">{preset.label}</span>
             </div>
-            <p className="mt-1 text-[11px] opacity-80">{preset.description}</p>
+            <p className="mt-1 text-xs leading-relaxed opacity-80">
+              {preset.description}
+            </p>
           </button>
         );
       })}

--- a/apps/web/src/lib/components/sandboxes/SandboxAutoStopSettingsClient.tsx
+++ b/apps/web/src/lib/components/sandboxes/SandboxAutoStopSettingsClient.tsx
@@ -3,7 +3,8 @@
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import { PageWrapper } from "@/lib/components/PageWrapper";
-import { Checkbox, Input, Spinner } from "@eva/ui";
+import { Input, Spinner, Switch } from "@eva/ui";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 
 /**
  * App-wide setting for the daily sandbox auto-stop sweep. The entered time is
@@ -40,48 +41,45 @@ export function SandboxAutoStopSettingsClient() {
 
   return (
     <PageWrapper title="Sandboxes" comfortable>
-      <label className="flex cursor-pointer items-start gap-3 rounded-surface bg-muted/40 p-4 transition-colors hover:bg-muted/60">
-        <Checkbox
-          className="mt-0.5"
-          checked={settings.enabled}
-          onCheckedChange={(checked) =>
-            save({
-              enabled: checked === true,
-              time: settings.time,
-              timeZone: browserTimeZone,
-            })
+      <div className="space-y-4">
+        <SettingsSection
+          title="Daily auto-stop"
+          description="Stop every running sandbox at a set time each day so none are left running overnight. Applies to all sandboxes across the app."
+          action={
+            <Switch
+              checked={settings.enabled}
+              onCheckedChange={(checked) =>
+                save({
+                  enabled: checked,
+                  time: settings.time,
+                  timeZone: browserTimeZone,
+                })
+              }
+              aria-label="Daily auto-stop"
+            />
           }
         />
-        <div>
-          <h3 className="text-sm font-medium">Daily auto-stop</h3>
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            Stop every running sandbox at a set time each day so none are left
-            running overnight. Applies to all sandboxes across the app.
-          </p>
-        </div>
-      </label>
 
-      {settings.enabled && (
-        <div className="mt-4 rounded-surface bg-muted/40 p-4">
-          <h3 className="text-sm font-medium">Stop time</h3>
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            Sandboxes stop at this time in {settings.timeZone}. The sweep runs
-            within 15 minutes of the set time.
-          </p>
-          <Input
-            type="time"
-            className="mt-3 w-40"
-            value={settings.time}
-            onChange={(event) =>
-              save({
-                enabled: settings.enabled,
-                time: event.target.value,
-                timeZone: browserTimeZone,
-              })
-            }
-          />
-        </div>
-      )}
+        {settings.enabled && (
+          <SettingsSection
+            title="Stop time"
+            description={`Sandboxes stop at this time in ${settings.timeZone}. The sweep runs within 15 minutes of the set time.`}
+          >
+            <Input
+              type="time"
+              className="w-40"
+              value={settings.time}
+              onChange={(event) =>
+                save({
+                  enabled: settings.enabled,
+                  time: event.target.value,
+                  timeZone: browserTimeZone,
+                })
+              }
+            />
+          </SettingsSection>
+        )}
+      </div>
     </PageWrapper>
   );
 }

--- a/apps/web/src/lib/components/settings/SettingsEmptyState.tsx
+++ b/apps/web/src/lib/components/settings/SettingsEmptyState.tsx
@@ -1,0 +1,35 @@
+interface SettingsEmptyStateProps {
+  /** Tabler icon component, rendered muted above the copy. */
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  title: string;
+  /** One line on what to do about it. */
+  description?: string;
+  /** Primary call to action, e.g. the same button as the section header. */
+  action?: React.ReactNode;
+}
+
+/**
+ * The "nothing here yet" state for a settings section body.
+ *
+ * Sits inside a SettingsSection rather than floating on the canvas, so an empty
+ * list still reads as part of the card it belongs to.
+ */
+export function SettingsEmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: SettingsEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-10 text-center">
+      <Icon size={28} className="mb-3 text-muted-foreground opacity-50" />
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {description ? (
+        <p className="mt-1 max-w-sm text-xs leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+      {action ? <div className="mt-4">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/settings/SettingsField.tsx
+++ b/apps/web/src/lib/components/settings/SettingsField.tsx
@@ -1,0 +1,34 @@
+interface SettingsFieldProps {
+  /** Field name, shown above the control. */
+  label: React.ReactNode;
+  /** Help text shown under the control. */
+  description?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/**
+ * One labelled control inside a SettingsSection body.
+ *
+ * Every settings form repeats the same label / control / help-text stack, so it
+ * lives here rather than being re-spaced per field. Stack several inside a
+ * section body with `grid gap-4`.
+ */
+export function SettingsField({
+  label,
+  description,
+  children,
+}: SettingsFieldProps) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+      {description ? (
+        <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/settings/SettingsSection.tsx
+++ b/apps/web/src/lib/components/settings/SettingsSection.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@eva/ui";
+
+interface SettingsSectionProps {
+  /** Section heading. Kept short — the description carries the detail. */
+  title: React.ReactNode;
+  /** Supporting copy shown under the heading. */
+  description?: React.ReactNode;
+  /** Control pinned to the top-right of the header, e.g. a switch or link. */
+  action?: React.ReactNode;
+  /** Controls pinned to a bottom bar, e.g. a Save button. */
+  footer?: React.ReactNode;
+  children?: React.ReactNode;
+  /** Applied to the body wrapper, for sections that need edge-to-edge content. */
+  bodyClassName?: string;
+  className?: string;
+}
+
+/**
+ * The single container for a block of settings, shared by the global and repo
+ * settings routes.
+ *
+ * Every settings page is a vertical stack of these, so the page reads as a set
+ * of hairline-bordered cards on the canvas rather than free-floating text. The
+ * header, body, and footer are separated by hairline dividers (structural
+ * separation), while grouping inside the body is left to whitespace.
+ *
+ * Content nested inside the body should step to `bg-muted` rather than
+ * `bg-card`, since the section itself already occupies the card tone.
+ */
+export function SettingsSection({
+  title,
+  description,
+  action,
+  footer,
+  children,
+  bodyClassName,
+  className,
+}: SettingsSectionProps) {
+  const hasBody = children != null;
+
+  return (
+    <section
+      className={cn(
+        "rounded-surface border border-border bg-card shadow-sm",
+        className,
+      )}
+    >
+      <header
+        className={cn(
+          "flex items-start justify-between gap-4 px-4 py-3",
+          hasBody && "border-b border-border",
+        )}
+      >
+        <div className="min-w-0">
+          <h3 className="text-sm font-medium text-foreground">{title}</h3>
+          {description ? (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </header>
+
+      {hasBody ? (
+        <div className={cn("px-4 py-4", bodyClassName)}>{children}</div>
+      ) : null}
+
+      {footer ? (
+        <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+          {footer}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/components/theme/ThemeSettingsClient.tsx
+++ b/apps/web/src/lib/components/theme/ThemeSettingsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PageWrapper } from "@/lib/components/PageWrapper";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 import {
   useThemeContext,
   resolveCustomTheme,
@@ -71,34 +72,66 @@ export function ThemeSettingsClient() {
 
   return (
     <PageWrapper title="Theme" comfortable>
-      <div className="max-w-2xl space-y-6 sm:space-y-8">
-        <AppearanceSection
-          currentMode={currentMode}
-          onModeChange={handleModeChange}
-        />
-        <PresetsSection
-          currentTheme={resolved}
-          onApplyPreset={handleApplyPreset}
-        />
-        <AccentColorSection
-          accentColor={accentColor}
-          onAccentChange={handleAccentChange}
-        />
-        <TypographySection
-          fontFamily={fontFamily}
-          onFontChange={handleFontChange}
-          letterSpacing={letterSpacing}
-          onLetterSpacingChange={handleLetterSpacingChange}
-          radius={radius}
-          onRadiusChange={handleRadiusChange}
-        />
-        <ThemePreview
-          accentColor={accentColor}
-          radius={radius}
-          fontFamily={fontFamily}
-          letterSpacing={letterSpacing}
-          currentMode={currentMode}
-        />
+      <div className="space-y-4">
+        <SettingsSection
+          title="Appearance"
+          description="Use light, use dark, or follow your system setting."
+          // Capped so the three mode tiles stay a readable size on wide screens.
+          bodyClassName="max-w-2xl"
+        >
+          <AppearanceSection
+            currentMode={currentMode}
+            onModeChange={handleModeChange}
+          />
+        </SettingsSection>
+
+        <SettingsSection
+          title="Presets"
+          description="Apply a ready-made combination of accent, font, radius, and spacing. Any change below moves you off the preset."
+          bodyClassName="max-w-2xl"
+        >
+          <PresetsSection
+            currentTheme={resolved}
+            onApplyPreset={handleApplyPreset}
+          />
+        </SettingsSection>
+
+        <SettingsSection
+          title="Accent Color"
+          description="Drives buttons, links, focus rings, and charts. Zinc keeps the interface monochrome."
+        >
+          <AccentColorSection
+            accentColor={accentColor}
+            onAccentChange={handleAccentChange}
+          />
+        </SettingsSection>
+
+        <SettingsSection
+          title="Type & Shape"
+          description="Corner radius, typeface, and letter spacing, applied across the whole interface."
+        >
+          <TypographySection
+            fontFamily={fontFamily}
+            onFontChange={handleFontChange}
+            letterSpacing={letterSpacing}
+            onLetterSpacingChange={handleLetterSpacingChange}
+            radius={radius}
+            onRadiusChange={handleRadiusChange}
+          />
+        </SettingsSection>
+
+        <SettingsSection
+          title="Preview"
+          description="Your current selection, shown on the common controls."
+        >
+          <ThemePreview
+            accentColor={accentColor}
+            radius={radius}
+            fontFamily={fontFamily}
+            letterSpacing={letterSpacing}
+            currentMode={currentMode}
+          />
+        </SettingsSection>
       </div>
     </PageWrapper>
   );

--- a/apps/web/src/lib/components/theme/_components/AccentColorSection.tsx
+++ b/apps/web/src/lib/components/theme/_components/AccentColorSection.tsx
@@ -4,7 +4,6 @@ import { ACCENT_COLORS } from "@/lib/contexts/ThemeContext";
 import type { AccentColor } from "@/lib/contexts/ThemeContext";
 import { cn } from "@eva/ui";
 import { IconCheck } from "@tabler/icons-react";
-import { SectionLabel } from "./SectionLabel";
 import { OptionButton } from "./OptionButton";
 
 function isAccentColor(value: string): value is AccentColor {
@@ -19,51 +18,46 @@ export function AccentColorSection({
   onAccentChange: (color: AccentColor) => void;
 }) {
   return (
-    <section>
-      <SectionLabel>Accent Color</SectionLabel>
-      <div className="flex flex-wrap gap-2 sm:gap-3">
-        {Object.entries(ACCENT_COLORS).map(([key, color]) => {
-          if (!isAccentColor(key)) return null;
-          const isActive = accentColor === key;
-          return (
-            <OptionButton
-              key={key}
-              active={isActive}
-              onClick={() => onAccentChange(key)}
-              title={color.label}
-              className="group relative"
+    <div className="flex flex-wrap gap-2 sm:gap-3">
+      {Object.entries(ACCENT_COLORS).map(([key, color]) => {
+        if (!isAccentColor(key)) return null;
+        const isActive = accentColor === key;
+        return (
+          <OptionButton
+            key={key}
+            active={isActive}
+            onClick={() => onAccentChange(key)}
+            title={color.label}
+            className="group relative"
+          >
+            <span
+              className={cn(
+                "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/40 transition-transform group-hover:scale-110",
+                isActive && "scale-110",
+                key === "zinc" && "bg-zinc-900 dark:bg-zinc-100",
+              )}
+              style={
+                key === "zinc" ? undefined : { backgroundColor: color.preview }
+              }
             >
-              <span
-                className={cn(
-                  "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/40 transition-transform group-hover:scale-110",
-                  isActive && "scale-110",
-                  key === "zinc" && "bg-zinc-900 dark:bg-zinc-100",
-                )}
-                style={
-                  key === "zinc"
-                    ? undefined
-                    : { backgroundColor: color.preview }
-                }
-              >
-                {isActive && (
-                  <IconCheck
-                    size={11}
-                    className={
-                      key === "zinc"
-                        ? "text-white dark:text-zinc-900"
-                        : color.checkDark
-                          ? "text-zinc-900"
-                          : "text-white"
-                    }
-                    strokeWidth={3}
-                  />
-                )}
-              </span>
-              {color.label}
-            </OptionButton>
-          );
-        })}
-      </div>
-    </section>
+              {isActive && (
+                <IconCheck
+                  size={11}
+                  className={
+                    key === "zinc"
+                      ? "text-white dark:text-zinc-900"
+                      : color.checkDark
+                        ? "text-zinc-900"
+                        : "text-white"
+                  }
+                  strokeWidth={3}
+                />
+              )}
+            </span>
+            {color.label}
+          </OptionButton>
+        );
+      })}
+    </div>
   );
 }

--- a/apps/web/src/lib/components/theme/_components/AppearanceSection.tsx
+++ b/apps/web/src/lib/components/theme/_components/AppearanceSection.tsx
@@ -7,7 +7,6 @@ import {
   IconDeviceDesktop,
   IconCheck,
 } from "@tabler/icons-react";
-import { SectionLabel } from "./SectionLabel";
 
 type Mode = "light" | "dark" | "system";
 
@@ -21,78 +20,74 @@ export function AppearanceSection({
   compact?: boolean;
 }) {
   return (
-    <section>
-      <SectionLabel>Appearance</SectionLabel>
-      <div
-        className={cn(
-          "grid grid-cols-3",
-          compact ? "gap-1.5" : "gap-2 sm:gap-3",
-        )}
-      >
-        {(["light", "dark", "system"] as const).map((mode) => {
-          const isActive = currentMode === mode;
-          const Icon =
-            mode === "light"
-              ? IconSun
-              : mode === "dark"
-                ? IconMoon
-                : IconDeviceDesktop;
-          const label =
-            mode === "light" ? "Light" : mode === "dark" ? "Dark" : "System";
+    <div
+      className={cn("grid grid-cols-3", compact ? "gap-1.5" : "gap-2 sm:gap-3")}
+    >
+      {(["light", "dark", "system"] as const).map((mode) => {
+        const isActive = currentMode === mode;
+        const Icon =
+          mode === "light"
+            ? IconSun
+            : mode === "dark"
+              ? IconMoon
+              : IconDeviceDesktop;
+        const label =
+          mode === "light" ? "Light" : mode === "dark" ? "Dark" : "System";
 
-          return (
-            <button
-              key={mode}
-              onClick={() => onModeChange(mode)}
-              className={cn(
-                "relative flex flex-col items-center rounded-surface font-medium motion-press transition-[background-color,color,transform] active:scale-[0.96]",
-                compact
-                  ? "gap-1 p-2 text-[11px]"
-                  : "gap-2 p-3 text-xs sm:gap-3 sm:p-4 sm:text-sm",
-                isActive
-                  ? "bg-primary/8 text-primary ring-1 ring-primary/20"
-                  : "bg-card/60 text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-              )}
-            >
-              {isActive ? (
-                <span
-                  className={cn(
-                    "absolute flex items-center justify-center rounded-full bg-primary text-primary-foreground",
-                    compact
-                      ? "right-1 top-1 h-3.5 w-3.5"
-                      : "right-2 top-2 h-4 w-4",
-                  )}
-                >
-                  <IconCheck size={compact ? 8 : 10} strokeWidth={3} />
-                </span>
-              ) : null}
-              <div
+        return (
+          <button
+            key={mode}
+            onClick={() => onModeChange(mode)}
+            className={cn(
+              // The border carries the selected state, so inactive tiles keep a
+              // transparent one to hold their size.
+              "relative flex flex-col items-center rounded-surface border font-medium motion-press transition-[background-color,border-color,color,transform] active:scale-[0.96]",
+              compact
+                ? "gap-1 p-2 text-[11px]"
+                : "gap-2 p-3 text-xs sm:gap-3 sm:p-4 sm:text-sm",
+              isActive
+                ? "border-border bg-primary/8 text-primary"
+                : "border-transparent bg-muted/40 text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+            )}
+          >
+            {isActive ? (
+              <span
                 className={cn(
-                  "flex w-full items-center justify-center rounded-lg",
-                  compact ? "h-8" : "h-12 sm:h-16",
-                  mode === "light"
-                    ? "bg-white"
-                    : mode === "dark"
-                      ? "bg-zinc-900"
-                      : "bg-gradient-to-br from-white to-zinc-900",
+                  "absolute flex items-center justify-center rounded-full bg-primary text-primary-foreground",
+                  compact
+                    ? "right-1 top-1 h-3.5 w-3.5"
+                    : "right-2 top-2 h-4 w-4",
                 )}
               >
-                <Icon
-                  size={compact ? 14 : 22}
-                  className={
-                    mode === "light"
-                      ? "text-amber-500"
-                      : mode === "dark"
-                        ? "text-blue-300"
-                        : "text-muted-foreground"
-                  }
-                />
-              </div>
-              {label}
-            </button>
-          );
-        })}
-      </div>
-    </section>
+                <IconCheck size={compact ? 8 : 10} strokeWidth={3} />
+              </span>
+            ) : null}
+            <div
+              className={cn(
+                "flex w-full items-center justify-center rounded-lg",
+                compact ? "h-8" : "h-12 sm:h-16",
+                mode === "light"
+                  ? "bg-white"
+                  : mode === "dark"
+                    ? "bg-zinc-900"
+                    : "bg-gradient-to-br from-white to-zinc-900",
+              )}
+            >
+              <Icon
+                size={compact ? 14 : 22}
+                className={
+                  mode === "light"
+                    ? "text-amber-500"
+                    : mode === "dark"
+                      ? "text-blue-300"
+                      : "text-muted-foreground"
+                }
+              />
+            </div>
+            {label}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/apps/web/src/lib/components/theme/_components/OptionButton.tsx
+++ b/apps/web/src/lib/components/theme/_components/OptionButton.tsx
@@ -18,10 +18,12 @@ export function OptionButton({
       onClick={onClick}
       title={title}
       className={cn(
-        "flex items-center gap-2 rounded-surface px-2.5 py-2 text-xs font-medium transition-colors sm:gap-2.5 sm:px-3.5 sm:py-2.5 sm:text-sm",
+        // The border carries the selected state; inactive options keep a
+        // transparent one so the row does not reflow on selection.
+        "flex items-center gap-2 rounded-surface border px-2.5 py-2 text-xs font-medium transition-[background-color,border-color,color] sm:gap-2.5 sm:px-3.5 sm:py-2.5 sm:text-sm",
         active
-          ? "bg-primary/8 text-foreground ring-1 ring-primary/20"
-          : "bg-card/60 text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+          ? "border-border bg-primary/8 text-foreground"
+          : "border-transparent bg-muted/40 text-muted-foreground hover:bg-muted/60 hover:text-foreground",
         className,
       )}
     >

--- a/apps/web/src/lib/components/theme/_components/PresetsSection.tsx
+++ b/apps/web/src/lib/components/theme/_components/PresetsSection.tsx
@@ -3,7 +3,6 @@
 import type { CustomTheme } from "@/lib/contexts/ThemeContext";
 import { cn } from "@eva/ui";
 import { IconCheck } from "@tabler/icons-react";
-import { SectionLabel } from "./SectionLabel";
 
 interface Preset {
   name: string;
@@ -74,37 +73,36 @@ export function PresetsSection({
   onApplyPreset: (theme: Required<CustomTheme>) => void;
 }) {
   return (
-    <section>
-      <SectionLabel>Presets</SectionLabel>
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-3">
-        {PRESETS.map((preset) => {
-          const active = isPresetActive(preset.theme, currentTheme);
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-3">
+      {PRESETS.map((preset) => {
+        const active = isPresetActive(preset.theme, currentTheme);
 
-          return (
-            <button
-              key={preset.name}
-              onClick={() => onApplyPreset(preset.theme)}
-              className={cn(
-                "relative flex flex-col items-center gap-2 rounded-surface p-3 text-xs font-medium transition-[background-color,color,box-shadow] sm:gap-3 sm:p-4 sm:text-sm",
-                active
-                  ? "bg-primary/8 text-primary ring-1 ring-primary/20"
-                  : "bg-card/60 text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-              )}
-            >
-              {active && (
-                <span className="absolute right-2 top-2 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                  <IconCheck size={10} strokeWidth={3} />
-                </span>
-              )}
-              <span
-                className="h-4 w-4 shrink-0 rounded-full"
-                style={{ backgroundColor: preset.previewColor }}
-              />
-              {preset.name}
-            </button>
-          );
-        })}
-      </div>
-    </section>
+        return (
+          <button
+            key={preset.name}
+            onClick={() => onApplyPreset(preset.theme)}
+            className={cn(
+              // Matches the other theme pickers: border carries the selected
+              // state, inactive keeps a transparent one to avoid reflow.
+              "relative flex flex-col items-center gap-2 rounded-surface border p-3 text-xs font-medium transition-[background-color,border-color,color] sm:gap-3 sm:p-4 sm:text-sm",
+              active
+                ? "border-border bg-primary/8 text-primary"
+                : "border-transparent bg-muted/40 text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+            )}
+          >
+            {active && (
+              <span className="absolute right-2 top-2 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                <IconCheck size={10} strokeWidth={3} />
+              </span>
+            )}
+            <span
+              className="h-4 w-4 shrink-0 rounded-full"
+              style={{ backgroundColor: preset.previewColor }}
+            />
+            {preset.name}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/apps/web/src/lib/components/theme/_components/ThemePreview.tsx
+++ b/apps/web/src/lib/components/theme/_components/ThemePreview.tsx
@@ -9,7 +9,6 @@ import type {
   FontFamily,
   LetterSpacing,
 } from "@/lib/contexts/ThemeContext";
-import { SectionLabel } from "./SectionLabel";
 import { RADIUS_OPTIONS } from "./TypographySection";
 
 export function ThemePreview({
@@ -29,34 +28,31 @@ export function ThemePreview({
     RADIUS_OPTIONS.find((r) => r.value === radius)?.label ?? radius;
 
   return (
-    <section>
-      <SectionLabel>Preview</SectionLabel>
-      <div className="rounded-surface border border-border bg-card p-3 sm:p-5">
-        <div className="mb-4 flex items-start gap-2">
-          <div
-            className="mt-1 h-3 w-3 shrink-0 rounded-full"
-            style={{ backgroundColor: ACCENT_COLORS[accentColor].preview }}
-          />
-          <p className="text-xs sm:text-sm font-semibold text-foreground">
-            {ACCENT_COLORS[accentColor].label} &middot; {radiusLabel} radius
-            &middot; {FONT_FAMILIES[fontFamily].label} &middot;{" "}
-            {LETTER_SPACING_VALUES[letterSpacing].label} spacing &middot;{" "}
-            {currentMode.charAt(0).toUpperCase() + currentMode.slice(1)} mode
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90">
-            Primary button
-          </button>
-          <button className="rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted">
-            Secondary button
-          </button>
-          <span className="rounded-md border border-primary/30 bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
-            Badge
-          </span>
-          <span className="text-xs text-muted-foreground">Muted text</span>
-        </div>
+    <div className="rounded-surface border border-border bg-muted/40 p-3 sm:p-5">
+      <div className="mb-4 flex items-start gap-2">
+        <div
+          className="mt-1 h-3 w-3 shrink-0 rounded-full"
+          style={{ backgroundColor: ACCENT_COLORS[accentColor].preview }}
+        />
+        <p className="text-xs sm:text-sm font-semibold text-foreground">
+          {ACCENT_COLORS[accentColor].label} &middot; {radiusLabel} radius
+          &middot; {FONT_FAMILIES[fontFamily].label} &middot;{" "}
+          {LETTER_SPACING_VALUES[letterSpacing].label} spacing &middot;{" "}
+          {currentMode.charAt(0).toUpperCase() + currentMode.slice(1)} mode
+        </p>
       </div>
-    </section>
+      <div className="flex flex-wrap items-center gap-2">
+        <button className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90">
+          Primary button
+        </button>
+        <button className="rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted">
+          Secondary button
+        </button>
+        <span className="rounded-md border border-primary/30 bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+          Badge
+        </span>
+        <span className="text-xs text-muted-foreground">Muted text</span>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/lib/components/theme/_components/TypographySection.tsx
+++ b/apps/web/src/lib/components/theme/_components/TypographySection.tsx
@@ -52,7 +52,9 @@ export function TypographySection({
   onRadiusChange: (r: RadiusSize) => void;
 }) {
   return (
-    <>
+    // Three labelled sub-groups that read as one block, so the spacing lives
+    // here rather than depending on the parent's stack.
+    <div className="space-y-5">
       <section>
         <SectionLabel>Border Radius</SectionLabel>
         <div className="flex flex-wrap gap-2 sm:gap-3">
@@ -138,6 +140,6 @@ export function TypographySection({
           ))}
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/routes/_global/settings/sync.tsx
+++ b/apps/web/src/routes/_global/settings/sync.tsx
@@ -4,8 +4,10 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useAction, useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import { PageWrapper } from "@/lib/components/PageWrapper";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import { Button, Checkbox, Spinner } from "@eva/ui";
-import { IconRefresh } from "@tabler/icons-react";
+import { IconGitBranch, IconRefresh } from "@tabler/icons-react";
 
 type RepoEntry = {
   owner: string;
@@ -163,25 +165,31 @@ function SyncSettingsRoute() {
           <Spinner size="md" />
         </div>
       ) : repos.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-3 py-20 text-muted-foreground">
-          <p className="text-sm">
-            No repos found. Sync your repos first, or fetch from GitHub to
-            discover new ones.
-          </p>
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={fetching}
-            onClick={handleRefreshFromGithub}
-          >
-            <IconRefresh size={16} className={fetching ? "animate-spin" : ""} />
-            Fetch from GitHub
-          </Button>
-        </div>
+        <SettingsSection title="Repositories" bodyClassName="p-0">
+          <SettingsEmptyState
+            icon={IconGitBranch}
+            title="No repos found"
+            description="Sync your repos first, or fetch from GitHub to discover new ones."
+            action={
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={fetching}
+                onClick={handleRefreshFromGithub}
+              >
+                <IconRefresh
+                  size={16}
+                  className={fetching ? "animate-spin" : ""}
+                />
+                Fetch from GitHub
+              </Button>
+            }
+          />
+        </SettingsSection>
       ) : (
-        <div className="space-y-6">
-          <p className="text-xs text-muted-foreground">
-            Disabled repos will be skipped during sync. New repos default to
+        <div className="space-y-4">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Disabled repos are skipped during sync. New repos default to
             enabled.
           </p>
           {owners.map((owner) => (
@@ -221,38 +229,48 @@ function OwnerGroup({
 }) {
   const sorted = [...repos].sort((a, b) => a.name.localeCompare(b.name));
 
+  const enabledCount = repos.filter((r) =>
+    isRepoEnabled(r.owner, r.name),
+  ).length;
+
   return (
-    <div className="rounded-surface border border-border bg-card p-3 sm:p-4">
-      <label className="flex cursor-pointer items-center gap-2.5 pb-3">
-        <Checkbox
-          checked={allEnabled ? true : someEnabled ? "indeterminate" : false}
-          onCheckedChange={onToggleOwner}
-        />
-        <span className="text-sm font-medium">{owner}</span>
+    // The owner is the section header, so its select-all checkbox sits in the
+    // header and the repos read as the section body.
+    <SettingsSection
+      title={
+        <label className="flex cursor-pointer items-center gap-2.5">
+          <Checkbox
+            checked={allEnabled ? true : someEnabled ? "indeterminate" : false}
+            onCheckedChange={onToggleOwner}
+          />
+          {owner}
+        </label>
+      }
+      action={
         <span className="text-xs text-muted-foreground">
-          {repos.filter((r) => isRepoEnabled(r.owner, r.name)).length}/
-          {repos.length}
+          {enabledCount}/{repos.length} enabled
         </span>
-      </label>
-      <div className="space-y-1 pl-1">
-        {sorted.map((repo) => {
-          const enabled = isRepoEnabled(repo.owner, repo.name);
-          return (
-            <label
-              key={repo.name}
-              className="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-muted/60"
-            >
-              <Checkbox
-                checked={enabled}
-                onCheckedChange={(checked) =>
-                  onToggleRepo(repo.owner, repo.name, checked === true)
-                }
-              />
-              <span className="text-xs">{repo.name}</span>
-            </label>
-          );
-        })}
-      </div>
-    </div>
+      }
+      // Rows carry their own padding so the hover fill spans the full width.
+      bodyClassName="p-2"
+    >
+      {sorted.map((repo) => {
+        const enabled = isRepoEnabled(repo.owner, repo.name);
+        return (
+          <label
+            key={repo.name}
+            className="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm transition-colors hover:bg-muted/60"
+          >
+            <Checkbox
+              checked={enabled}
+              onCheckedChange={(checked) =>
+                onToggleRepo(repo.owner, repo.name, checked === true)
+              }
+            />
+            {repo.name}
+          </label>
+        );
+      })}
+    </SettingsSection>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/AppClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/AppClient.tsx
@@ -4,9 +4,14 @@ import { useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { PageWrapper } from "@/lib/components/PageWrapper";
-import { Input } from "@eva/ui";
+import { Input, Textarea } from "@eva/ui";
 import { parseCommandLines } from "./_utils";
 import { LogoSettingsSection } from "./_components/LogoSettingsSection";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
+
+/** Every command box on this page is a monospace, resizable textarea. */
+const COMMAND_TEXTAREA_CLASS = "resize-y bg-background font-mono text-xs";
 
 export function AppClient() {
   const { repo, repoId, owner, name } = useRepo();
@@ -88,137 +93,142 @@ export function AppClient() {
       <div className="space-y-4">
         <LogoSettingsSection repoId={repoId} />
 
-        <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-          <div>
-            <h3 className="text-sm font-medium">System Prompt</h3>
-            <p className="mt-1 text-[11px] text-muted-foreground">
+        <SettingsSection
+          title="System Prompt"
+          description={
+            <>
               Appended to every quick task and session run for this app. Use for
               recurring instructions like{" "}
               <code>run pnpm migrate after making backend changes</code>.
-            </p>
-          </div>
-          <textarea
+            </>
+          }
+        >
+          <Textarea
             key={`system-prompt-${repoId}`}
             defaultValue={repo.systemPrompt ?? ""}
             onBlur={handleSystemPromptBlur}
-            className="w-full h-32 rounded-control border border-input bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+            className={`h-32 ${COMMAND_TEXTAREA_CLASS}`}
             placeholder="e.g. run pnpm migrate after making backend changes"
           />
-        </div>
+        </SettingsSection>
 
-        <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-          <div>
-            <h3 className="text-sm font-medium">Dev Server</h3>
-            <p className="mt-1 text-[11px] text-muted-foreground">
+        <SettingsSection
+          title="Dev Server"
+          description={
+            <>
               Override the auto-detected dev server port and command for this
               app. Leave empty to auto-detect from <code>package.json</code>.
-            </p>
-          </div>
+            </>
+          }
+        >
+          <div className="grid gap-4">
+            <SettingsField
+              label="Dev Port"
+              description="Leave empty to auto-detect."
+            >
+              <Input
+                key={`port-${repoId}`}
+                type="number"
+                className="h-8 text-xs"
+                placeholder="Auto (5173 for vite, 3000 for next)"
+                defaultValue={repo.devPort ?? ""}
+                onBlur={handleDevPortBlur}
+              />
+            </SettingsField>
 
-          <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-              Dev Port
-            </label>
-            <Input
-              key={`port-${repoId}`}
-              type="number"
-              className="h-8 text-xs"
-              placeholder="Auto (5173 for vite, 3000 for next)"
-              defaultValue={repo.devPort ?? ""}
-              onBlur={handleDevPortBlur}
-            />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Leave empty to auto-detect.
-            </p>
+            <SettingsField
+              label="Dev Command"
+              description={
+                <>
+                  When set, runs verbatim. You are responsible for{" "}
+                  <code>cd</code> and <code>PORT=</code>. Leave empty to
+                  auto-detect.
+                </>
+              }
+            >
+              <Input
+                key={`cmd-${repoId}`}
+                className="h-8 font-mono text-xs"
+                placeholder="Auto (cd <rootDir> && PORT=<port> pnpm run dev)"
+                defaultValue={repo.devCommand ?? ""}
+                onBlur={handleDevCommandBlur}
+              />
+            </SettingsField>
           </div>
+        </SettingsSection>
 
-          <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-              Dev Command
-            </label>
-            <Input
-              key={`cmd-${repoId}`}
-              className="h-8 text-xs font-mono"
-              placeholder="Auto (cd <rootDir> && PORT=<port> pnpm run dev)"
-              defaultValue={repo.devCommand ?? ""}
-              onBlur={handleDevCommandBlur}
-            />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              When set, runs verbatim. You're responsible for <code>cd</code>{" "}
-              and <code>PORT=</code>. Leave empty to auto-detect.
-            </p>
-          </div>
-        </div>
-
-        <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-          <h3 className="text-sm font-medium">Startup Commands</h3>
-          <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-              Commands to run when sandbox starts
-            </label>
-            <textarea
+        <SettingsSection
+          title="Startup Commands"
+          description="Commands to run when the sandbox starts, one per line."
+        >
+          <SettingsField
+            label="Commands"
+            description={
+              <>
+                Runs during seeded snapshot builds{" "}
+                <strong>and on every fresh sandbox boot</strong>, so commands
+                must be safe to re-run (readiness gates, docker restarts). Put
+                one-time data <strong>seeding</strong> in Seed Commands
+                (Snapshots settings) and long-running services in Background
+                Commands. Commands have a 10-minute timeout each.
+              </>
+            }
+          >
+            <Textarea
               key={`startup-${repoId}`}
               defaultValue={startupCommands}
               onBlur={handleStartupCommandsBlur}
-              className="w-full h-48 rounded-control border border-input bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+              className={`h-48 ${COMMAND_TEXTAREA_CLASS}`}
               placeholder="npx supabase start&#10;psql -h localhost -p 54322 -U postgres -d postgres < /home/eva/sandbox-config/seed.sql"
             />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              One command per line. Runs during seeded snapshot builds{" "}
-              <strong>and on every fresh sandbox boot</strong>, so commands must
-              be safe to re-run (readiness gates, docker restarts). Put one-time
-              data <strong>seeding</strong> in Seed Commands (Snapshots
-              settings) and long-running services in Background Commands.
-              Commands have a 10-minute timeout each.
-            </p>
-          </div>
-        </div>
+          </SettingsField>
+        </SettingsSection>
 
-        <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-          <h3 className="text-sm font-medium">Background Commands</h3>
-          <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-              Long-running daemons to launch alongside the dev server
-            </label>
-            <textarea
+        <SettingsSection
+          title="Background Commands"
+          description="Long-running daemons to launch alongside the dev server, one per line."
+        >
+          <SettingsField
+            label="Commands"
+            description={
+              <>
+                Write each line as a plain foreground command. The platform
+                launches every line detached for you (
+                <code>nohup ... &amp;</code>), so there is no need to add your
+                own <code>nohup</code>, trailing <code>&amp;</code>, or output
+                redirect. Commands respawn every time the sandbox starts or
+                resumes. Use for daemons like <code>npx convex dev</code>.
+                Output is written to <code>/tmp/bg-&lt;index&gt;.log</code>.
+              </>
+            }
+          >
+            <Textarea
               key={`background-${repoId}`}
               defaultValue={backgroundCommands}
               onBlur={handleBackgroundCommandsBlur}
-              className="w-full h-32 rounded-control border border-input bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+              className={`h-32 ${COMMAND_TEXTAREA_CLASS}`}
               placeholder="npx convex dev"
             />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              One command per line, each written as a plain foreground command.
-              The platform launches every line detached for you (
-              <code>nohup ... &amp;</code>), so there is no need to add your own{" "}
-              <code>nohup</code>, trailing <code>&amp;</code>, or output
-              redirect. Commands respawn every time the sandbox starts or
-              resumes. Use for daemons like <code>npx convex dev</code>. Output
-              is written to <code>/tmp/bg-&lt;index&gt;.log</code>.
-            </p>
-          </div>
-        </div>
+          </SettingsField>
+        </SettingsSection>
 
-        <div className="rounded-lg bg-muted/40 p-3 space-y-4 sm:p-4">
-          <h3 className="text-sm font-medium">Stop Commands</h3>
-          <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-              Clean-shutdown commands run before snapshotting a seeded sandbox
-            </label>
-            <textarea
+        <SettingsSection
+          title="Stop Commands"
+          description="Clean-shutdown commands run before snapshotting a seeded sandbox."
+        >
+          <SettingsField
+            label="Commands"
+            description="One command per line. Run by the seeded-snapshot build before the filesystem snapshot is taken, so on-disk volumes (e.g. local Postgres) flush consistently. Not run on normal sandbox starts."
+          >
+            <Textarea
               key={`stop-${repoId}`}
               defaultValue={stopCommands}
               onBlur={handleStopCommandsBlur}
-              className="w-full h-32 rounded-md bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+              className={`h-32 ${COMMAND_TEXTAREA_CLASS}`}
               placeholder="pkill -TERM -f 'convex dev'&#10;pnpm stop-db"
             />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              One command per line. Run by the seeded-snapshot build before the
-              filesystem snapshot is taken, so on-disk volumes (e.g. local
-              Postgres) flush consistently. Not run on normal sandbox starts.
-            </p>
-          </div>
-        </div>
+          </SettingsField>
+        </SettingsSection>
       </div>
     </PageWrapper>
   );

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/AuditsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/AuditsClient.tsx
@@ -5,9 +5,11 @@ import { useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { PageWrapper } from "@/lib/components/PageWrapper";
-import { Checkbox } from "@eva/ui";
-import { IconTrash } from "@tabler/icons-react";
+import { Button, Checkbox } from "@eva/ui";
+import { IconShieldCheck, IconTrash } from "@tabler/icons-react";
 import type { FunctionReturnType } from "convex/server";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import { AddCategoryForm } from "./audits/_components/AddCategoryForm";
 import { isAppRepo } from "./_utils";
 
@@ -59,17 +61,17 @@ export function AuditsClient() {
 
   return (
     <PageWrapper title="Audits" comfortable>
-      <div className="space-y-6">
-        <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-          <div>
-            <h3 className="text-sm font-medium">Repo-level Audits</h3>
-            <p className="text-[11px] text-muted-foreground mt-0.5">
-              These audits run for all tasks across the repo and all apps.
-            </p>
-          </div>
-
-          {repoCategories.length > 0 && (
-            <div className="grid gap-2">
+      <div className="space-y-4">
+        {/* Each scope is one list section plus its own add form, so it is
+            always clear which scope a new category lands in. */}
+        <SettingsSection
+          title="Repo-level Audits"
+          description="These audits run for all tasks across the repo and all apps."
+          // Rows own their padding so the divider spans the card's full width.
+          bodyClassName="p-0"
+        >
+          {repoCategories.length > 0 ? (
+            <div className="divide-y divide-border">
               {repoCategories.map((category) => (
                 <CategoryRow
                   key={category._id}
@@ -81,43 +83,52 @@ export function AuditsClient() {
                 />
               ))}
             </div>
+          ) : (
+            <SettingsEmptyState
+              icon={IconShieldCheck}
+              title="No audit categories yet"
+              description="Add one below to have every task audited against it."
+            />
           )}
+        </SettingsSection>
 
-          {repoCategories.length === 0 && (
-            <p className="text-xs text-muted-foreground text-center py-6">
-              No audit categories configured yet.
-            </p>
-          )}
-
+        <SettingsSection title="Add a repo-level audit">
           <AddCategoryForm repoId={repo.parentRepoId ?? repoId} />
-        </div>
+        </SettingsSection>
 
         {isApp && (
-          <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-            <div>
-              <h3 className="text-sm font-medium">App-specific Audits</h3>
-              <p className="text-[11px] text-muted-foreground mt-0.5">
-                Audits that only run for this app.
-              </p>
-            </div>
+          <>
+            <SettingsSection
+              title="App-specific Audits"
+              description="Audits that only run for this app."
+              bodyClassName="p-0"
+            >
+              {appCategories.length > 0 ? (
+                <div className="divide-y divide-border">
+                  {appCategories.map((category) => (
+                    <CategoryRow
+                      key={category._id}
+                      category={category}
+                      onToggle={(enabled) =>
+                        toggleEnabled({ id: category._id, enabled })
+                      }
+                      onRemove={() => removeCategory({ id: category._id })}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <SettingsEmptyState
+                  icon={IconShieldCheck}
+                  title="No app-specific audits"
+                  description="This app runs the repo-level audits only."
+                />
+              )}
+            </SettingsSection>
 
-            {appCategories.length > 0 && (
-              <div className="grid gap-2">
-                {appCategories.map((category) => (
-                  <CategoryRow
-                    key={category._id}
-                    category={category}
-                    onToggle={(enabled) =>
-                      toggleEnabled({ id: category._id, enabled })
-                    }
-                    onRemove={() => removeCategory({ id: category._id })}
-                  />
-                ))}
-              </div>
-            )}
-
-            <AddCategoryForm repoId={repoId} appId={repoId} />
-          </div>
+            <SettingsSection title="Add an app-specific audit">
+              <AddCategoryForm repoId={repoId} appId={repoId} />
+            </SettingsSection>
+          </>
         )}
       </div>
     </PageWrapper>
@@ -134,24 +145,28 @@ function CategoryRow({
   onRemove: () => void;
 }) {
   return (
-    <div className="flex items-start gap-3 rounded-surface border border-border bg-card p-3">
+    // A row inside the audits list section, so the section owns the border.
+    <div className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-muted/40">
       <Checkbox
         checked={category.enabled}
         onCheckedChange={(value) => onToggle(value === true)}
         className="mt-0.5"
       />
-      <div className="flex-1 min-w-0">
-        <p className="text-xs font-medium">{category.name}</p>
-        <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium">{category.name}</p>
+        <p className="mt-0.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
           {category.description}
         </p>
       </div>
-      <button
+      <Button
+        size="icon"
+        variant="ghost"
+        className="size-7 shrink-0 text-muted-foreground hover:text-destructive"
+        aria-label={`Remove ${category.name}`}
         onClick={onRemove}
-        className="text-muted-foreground hover:text-destructive transition-colors p-1"
       >
         <IconTrash size={14} />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/LogsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/LogsClient.tsx
@@ -14,6 +14,7 @@ import {
 import { getStartTime } from "@/lib/components/analytics/TimeRangeFilter";
 import { Kpi } from "@/lib/components/analytics/Kpi";
 import { IconFileOff } from "@tabler/icons-react";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import { parseResultEvent, groupKeyFor } from "./logs/_utils";
 import { LogsSummaryGrid } from "./logs/_components/LogsSummaryGrid";
 import { LogsHeader } from "./logs/_components/LogsHeader";
@@ -218,15 +219,18 @@ export function LogsClient() {
           <div className="h-64 animate-pulse rounded-surface border border-border bg-muted/60" />
         </div>
       ) : isEmpty ? (
-        <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
-          <div className="rounded-surface bg-secondary p-3">
-            <IconFileOff size={24} />
-          </div>
-          <p className="text-sm">
-            {isProjectView
-              ? "No project spending found for this time range"
-              : "No logs found for this time range"}
-          </p>
+        <div className="rounded-surface border border-border bg-card shadow-sm">
+          <SettingsEmptyState
+            icon={IconFileOff}
+            title={
+              isProjectView ? "No project spending" : "No completions logged"
+            }
+            description={
+              isProjectView
+                ? "Nothing was billed to a project in this time range. Widen the range to see more."
+                : "Nothing ran in this time range. Widen the range or clear the filters to see more."
+            }
+          />
         </div>
       ) : (
         <div className="space-y-5">

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/McpConfigClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/McpConfigClient.tsx
@@ -18,6 +18,7 @@ import {
   DialogFooter,
 } from "@eva/ui";
 import { IconPencil } from "@tabler/icons-react";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 
 export function McpConfigClient() {
   const { repo, repoId } = useRepo();
@@ -54,17 +55,10 @@ export function McpConfigClient() {
   return (
     <PageWrapper title="MCP Config" comfortable>
       <div className="space-y-4">
-        <div className="rounded-surface border border-border bg-card p-3 space-y-3 sm:p-4">
-          <div className="flex items-start justify-between gap-2">
-            <div>
-              <h3 className="text-sm font-medium">Root Prompt</h3>
-              <p className="mt-1 text-[11px] text-muted-foreground">
-                Freeform instructions injected into MCP server context to guide
-                the AI on your data topology. Shared across all apps in a
-                monorepo.
-              </p>
-            </div>
-
+        <SettingsSection
+          title="Root Prompt"
+          description="Freeform instructions injected into MCP server context to guide the AI on your data topology. Shared across all apps in a monorepo."
+          action={
             <Dialog open={open} onOpenChange={setOpen}>
               <DialogTrigger asChild>
                 <Button
@@ -114,18 +108,19 @@ export function McpConfigClient() {
                 </DialogFooter>
               </DialogContent>
             </Dialog>
-          </div>
-
+          }
+        >
           {prompt ? (
-            <pre className="whitespace-pre-wrap text-xs font-mono text-foreground/80 leading-relaxed">
+            // Nested inside the card, so the prompt steps to the muted tone.
+            <pre className="whitespace-pre-wrap rounded-control border border-border bg-muted/40 p-3 font-mono text-xs leading-relaxed text-foreground/80">
               {prompt}
             </pre>
           ) : (
-            <p className="text-xs text-muted-foreground italic">
-              No root prompt configured.
+            <p className="text-xs text-muted-foreground">
+              No root prompt configured. Select Edit to add one.
             </p>
           )}
-        </div>
+        </SettingsSection>
       </div>
     </PageWrapper>
   );

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/MonorepoClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/MonorepoClient.tsx
@@ -7,7 +7,9 @@ import { api } from "@eva/backend";
 import type { FunctionReturnType } from "convex/server";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { PageWrapper } from "@/lib/components/PageWrapper";
-import { Card, CardContent, Button, Input, Spinner, Badge } from "@eva/ui";
+import { Button, Input, Spinner, Badge } from "@eva/ui";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import {
   IconFolders,
   IconPlus,
@@ -119,25 +121,29 @@ export function MonorepoClient() {
         </Button>
       }
     >
-      {connectedApps.length > 0 && (
-        <div className="space-y-2">
-          <h3 className="text-sm font-medium text-foreground">
-            Connected Apps
-          </h3>
-          <p className="text-xs text-muted-foreground">
-            Toggle visibility to hide apps from the sidebar and home page
-            without removing them.
-          </p>
-          <div className="space-y-2">
-            {connectedApps.map((app) => (
-              <Card key={app._id} className="ui-surface-strong">
-                <CardContent className="flex items-center gap-2 p-2.5 sm:gap-3 sm:p-3">
-                  <IconFolders size={18} className="text-muted-foreground" />
+      <div className="space-y-4">
+        {connectedApps.length > 0 && (
+          <SettingsSection
+            title="Connected apps"
+            description="Toggle visibility to hide apps from the sidebar and home page without removing them."
+            // Rows own their padding so the row divider spans the full width.
+            bodyClassName="p-0"
+          >
+            <div className="divide-y divide-border">
+              {connectedApps.map((app) => (
+                <div
+                  key={app._id}
+                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+                >
+                  <IconFolders
+                    size={18}
+                    className="shrink-0 text-muted-foreground"
+                  />
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium text-foreground">
                       {app.rootDirectory?.split("/").pop()}
                     </p>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="truncate text-xs text-muted-foreground">
                       {app.rootDirectory}
                     </p>
                   </div>
@@ -150,11 +156,7 @@ export function MonorepoClient() {
                         hidden: app.hidden !== true,
                       })
                     }
-                    className={
-                      app.hidden
-                        ? "motion-press gap-1.5 border-border text-muted-foreground"
-                        : "motion-press gap-1.5 text-muted-foreground hover:text-foreground"
-                    }
+                    className="motion-press gap-1.5 text-muted-foreground hover:text-foreground"
                   >
                     {app.hidden ? (
                       <>
@@ -168,121 +170,114 @@ export function MonorepoClient() {
                       </>
                     )}
                   </Button>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      )}
-
-      <div className="space-y-3">
-        <h3 className="text-sm font-medium text-foreground">Detect Apps</h3>
-        <p className="text-xs text-muted-foreground">
-          Scan{" "}
-          <span className="font-medium text-foreground">
-            {repo.owner}/{repo.name}
-          </span>{" "}
-          for workspace apps and add them as separate codebases.
-        </p>
-      </div>
-
-      {loading ? (
-        <div className="flex items-center justify-center py-12">
-          <div className="flex flex-col items-center gap-3">
-            <Spinner size="md" />
-            <p className="text-sm text-muted-foreground">
-              Scanning workspace configuration...
-            </p>
-          </div>
-        </div>
-      ) : error ? (
-        <Card className="border-destructive/30">
-          <CardContent className="flex items-center gap-3 p-4">
-            <IconAlertCircle size={20} className="text-destructive" />
-            <div>
-              <p className="text-sm font-medium text-foreground">
-                Detection failed
-              </p>
-              <p className="text-xs text-muted-foreground">{error}</p>
+                </div>
+              ))}
             </div>
-          </CardContent>
-        </Card>
-      ) : detected.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-2 p-8 text-center">
-            <IconFolders size={28} className="text-muted-foreground/50" />
-            <p className="text-sm font-medium text-foreground">
-              No workspace apps detected
-            </p>
-            <p className="text-xs text-muted-foreground">
-              This repository doesn't appear to have a monorepo workspace
-              configuration (package.json workspaces or pnpm-workspace.yaml).
-            </p>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-2">
-          {detected.map((app) => {
-            const isConnected = connectedPaths.has(app.path);
-            const isAdding = addingPath === app.path;
+          </SettingsSection>
+        )}
 
-            return (
-              <Card key={app.path} className="ui-surface-strong">
-                <CardContent className="flex items-center gap-2 p-2.5 sm:gap-3 sm:p-3">
-                  <IconFolders size={18} className="text-muted-foreground" />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <p className="truncate text-sm font-medium text-foreground">
-                        {app.name}
+        <SettingsSection
+          title="Detected apps"
+          description={
+            <>
+              Workspace apps found in{" "}
+              <span className="font-medium text-foreground">
+                {repo.owner}/{repo.name}
+              </span>
+              . Add one to manage it as a separate codebase.
+            </>
+          }
+          bodyClassName="p-0"
+        >
+          {loading ? (
+            <div className="flex flex-col items-center gap-3 py-12">
+              <Spinner size="md" />
+              <p className="text-sm text-muted-foreground">
+                Scanning workspace configuration...
+              </p>
+            </div>
+          ) : error ? (
+            <div className="flex items-center gap-3 px-4 py-4">
+              <IconAlertCircle
+                size={20}
+                className="shrink-0 text-destructive"
+              />
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">
+                  Detection failed
+                </p>
+                <p className="text-xs text-muted-foreground">{error}</p>
+              </div>
+            </div>
+          ) : detected.length === 0 ? (
+            <SettingsEmptyState
+              icon={IconFolders}
+              title="No workspace apps detected"
+              description="This repository has no monorepo workspace configuration (package.json workspaces or pnpm-workspace.yaml)."
+            />
+          ) : (
+            <div className="divide-y divide-border">
+              {detected.map((app) => {
+                const isConnected = connectedPaths.has(app.path);
+                const isAdding = addingPath === app.path;
+
+                return (
+                  <div
+                    key={app.path}
+                    className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+                  >
+                    <IconFolders
+                      size={18}
+                      className="shrink-0 text-muted-foreground"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {app.name}
+                        </p>
+                        {app.hasDevScript && (
+                          <Badge variant="secondary" className="gap-1 text-xs">
+                            <IconTerminal2 size={10} />
+                            dev
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {app.path}
                       </p>
-                      {app.hasDevScript && (
-                        <Badge
-                          variant="secondary"
-                          className="gap-1 text-[10px]"
-                        >
-                          <IconTerminal2 size={10} />
-                          dev
-                        </Badge>
-                      )}
                     </div>
-                    <p className="text-xs text-muted-foreground">{app.path}</p>
+                    {isConnected ? (
+                      <Badge variant="outline" className="gap-1">
+                        <IconCheck size={12} />
+                        Added
+                      </Badge>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={isAdding}
+                        onClick={() => void handleAdd(app.path)}
+                        className="motion-press"
+                      >
+                        {isAdding ? (
+                          <Spinner size="sm" />
+                        ) : (
+                          <IconPlus size={14} />
+                        )}
+                        Add
+                      </Button>
+                    )}
                   </div>
-                  {isConnected ? (
-                    <Badge
-                      variant="outline"
-                      className="gap-1 border-primary/30 text-primary"
-                    >
-                      <IconCheck size={12} />
-                      Added
-                    </Badge>
-                  ) : (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={isAdding}
-                      onClick={() => void handleAdd(app.path)}
-                      className="motion-press"
-                    >
-                      {isAdding ? (
-                        <Spinner size="sm" />
-                      ) : (
-                        <IconPlus size={14} />
-                      )}
-                      Add
-                    </Button>
-                  )}
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
-      )}
+                );
+              })}
+            </div>
+          )}
+        </SettingsSection>
 
-      <Card className="mt-2">
-        <CardContent className="p-3">
-          <p className="mb-2 text-xs font-medium text-muted-foreground">
-            Custom root directory
-          </p>
+        <SettingsSection
+          title="Custom root directory"
+          description="Add an app by path when detection misses it."
+        >
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -294,7 +289,7 @@ export function MonorepoClient() {
               placeholder="e.g. apps/api"
               value={customPath}
               onChange={(e) => setCustomPath(e.target.value)}
-              className="flex-1"
+              className="h-8 flex-1 text-xs"
             />
             <Button
               type="submit"
@@ -309,8 +304,8 @@ export function MonorepoClient() {
               Add
             </Button>
           </form>
-        </CardContent>
-      </Card>
+        </SettingsSection>
+      </div>
     </PageWrapper>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SkillsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SkillsClient.tsx
@@ -7,8 +7,10 @@ import { useRepo } from "@/lib/contexts/RepoContext";
 import { PageWrapper } from "@/lib/components/PageWrapper";
 import { SkillRow } from "./skills/_components/SkillRow";
 import { Button } from "@eva/ui";
-import { IconRefresh } from "@tabler/icons-react";
+import { IconRefresh, IconSparkles } from "@tabler/icons-react";
 import { useState } from "react";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 
 export function SkillsClient() {
   const { repoId } = useRepo();
@@ -57,52 +59,61 @@ export function SkillsClient() {
         </Button>
       }
     >
-      <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-        <div>
-          <h3 className="text-sm font-medium">Repo Skills</h3>
-          <p className="mt-0.5 text-[11px] text-muted-foreground">
-            Synced from <code>.agents/skills</code> on the base branch. Auto-
-            syncs on push (when skills change) and every 6 hours; use Sync from
-            GitHub to refresh now. Type <code>/</code> in session, task, or
-            project chat to invoke a harness skill.
-          </p>
-        </div>
-
-        {syncSummary ? (
-          <p className="rounded-surface border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-            {syncSummary}
-          </p>
-        ) : null}
+      <div className="space-y-4">
+        {/* Sync feedback sits above the list so the list stays a clean table. */}
         {error ? (
-          <p className="rounded-surface bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <p className="rounded-control border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             {error}
           </p>
         ) : null}
+        {syncSummary ? (
+          <p className="rounded-control border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+            {syncSummary}
+          </p>
+        ) : null}
         {warnings.length > 0 ? (
-          <div className="rounded-surface border border-border bg-muted/40 px-3 py-2">
-            <p className="text-xs font-medium">Sync warnings</p>
-            <div className="mt-1 grid gap-1 text-[11px] text-muted-foreground">
-              {warnings.map((warning) => (
-                <p key={warning}>{warning}</p>
-              ))}
-            </div>
-          </div>
+          <SettingsSection title="Sync warnings" bodyClassName="grid gap-1">
+            {warnings.map((warning) => (
+              <p
+                key={warning}
+                className="text-xs leading-relaxed text-muted-foreground"
+              >
+                {warning}
+              </p>
+            ))}
+          </SettingsSection>
         ) : null}
 
-        {skills.length > 0 ? (
-          <div className="grid gap-2">
-            {availableSkills.map((skill) => (
-              <SkillRow key={skill._id} skill={skill} />
-            ))}
-            {staleSkills.map((skill) => (
-              <SkillRow key={skill._id} skill={skill} />
-            ))}
-          </div>
-        ) : (
-          <p className="py-6 text-center text-xs text-muted-foreground">
-            No skills synced yet.
-          </p>
-        )}
+        <SettingsSection
+          title="Repo Skills"
+          description={
+            <>
+              Synced from <code>.agents/skills</code> on the base branch.
+              Auto-syncs on push (when skills change) and every 6 hours; use
+              Sync from GitHub to refresh now. Type <code>/</code> in session,
+              task, or project chat to invoke a harness skill.
+            </>
+          }
+          // Rows own their padding so the divider spans the card's full width.
+          bodyClassName="p-0"
+        >
+          {skills.length > 0 ? (
+            <div className="divide-y divide-border">
+              {availableSkills.map((skill) => (
+                <SkillRow key={skill._id} skill={skill} />
+              ))}
+              {staleSkills.map((skill) => (
+                <SkillRow key={skill._id} skill={skill} />
+              ))}
+            </div>
+          ) : (
+            <SettingsEmptyState
+              icon={IconSparkles}
+              title="No skills synced yet"
+              description="Add a SKILL.md under .agents/skills on the base branch, then select Sync from GitHub."
+            />
+          )}
+        </SettingsSection>
       </div>
     </PageWrapper>
   );

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -15,12 +15,16 @@ import { PageWrapper } from "@/lib/components/PageWrapper";
 import {
   Button,
   Spinner,
+  Switch,
   Tabs,
   TabsList,
   TabsTrigger,
   TabsContent,
-  cn,
+  Textarea,
 } from "@eva/ui";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import { BranchSelect } from "@/lib/components/BranchSelect";
 import {
   CronScheduleCard,
@@ -37,6 +41,25 @@ import { formatDurationMs } from "@eva/shared/duration";
 import { parseCommandLines, formatFileSize } from "./_utils";
 import { RebuildRequiredWarning } from "./_components/RebuildRequiredWarning";
 import { BuildRow, BuildStatusBadge } from "./_components/BuildRow";
+
+/** Every command box on this page is a monospace, resizable textarea. */
+const COMMAND_TEXTAREA_CLASS = "resize-y bg-background font-mono text-xs";
+
+/**
+ * Shown on the Status and Builds tabs when no snapshot config exists yet —
+ * both tabs are empty until the Configuration tab has been filled in.
+ */
+function NoSnapshotConfigured() {
+  return (
+    <div className="rounded-surface border border-border bg-card shadow-sm">
+      <SettingsEmptyState
+        icon={IconCamera}
+        title="No snapshot configured"
+        description="Set a schedule and build commands on the Configuration tab to get started."
+      />
+    </div>
+  );
+}
 
 export function SnapshotsClient({
   activeTab,
@@ -206,37 +229,23 @@ export function SnapshotsClient({
           )}
 
           {snapshot && (
-            <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="text-sm font-medium">Enabled</h3>
-                  <p className="text-[11px] text-muted-foreground mt-0.5">
-                    When off, scheduled rebuilds are paused. Manual rebuilds
-                    still work.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() =>
+            // Header-only section: the label reads left, the switch sits right.
+            <SettingsSection
+              title="Enabled"
+              description="When off, scheduled rebuilds are paused. Manual rebuilds still work."
+              action={
+                <Switch
+                  checked={isEnabled}
+                  onCheckedChange={(enabled) =>
                     setSnapshotEnabled({
                       repoSnapshotId: snapshot._id,
-                      enabled: !isEnabled,
+                      enabled,
                     })
                   }
-                  className={cn(
-                    "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    isEnabled ? "bg-primary" : "bg-muted-foreground/30",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "pointer-events-none block h-5 w-5 rounded-full bg-white transition-transform",
-                      isEnabled ? "translate-x-5" : "translate-x-0",
-                    )}
-                  />
-                </button>
-              </div>
-            </div>
+                  aria-label="Scheduled rebuilds enabled"
+                />
+              }
+            />
           )}
 
           <CronScheduleCard
@@ -245,73 +254,73 @@ export function SnapshotsClient({
             allowManual
           />
 
-          <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-            <h3 className="text-sm font-medium">Clone Branch</h3>
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Branch
-              </label>
+          <SettingsSection title="Clone Branch">
+            <SettingsField
+              label="Branch"
+              description={
+                <>
+                  Branch to clone into the snapshot for dependency pre-caching.
+                  Defaults to <code>main</code> if empty.
+                </>
+              }
+            >
               <BranchSelect
                 value={workflowRef}
                 onValueChange={handleBranchChange}
                 className="h-8 text-xs"
                 placeholder="Select a branch"
               />
-              <p className="mt-1 text-[11px] text-muted-foreground">
-                Branch to clone into the snapshot for dependency pre-caching.
-                Defaults to <code>main</code> if empty.
-              </p>
-            </div>
-          </div>
+            </SettingsField>
+          </SettingsSection>
 
           {snapshot && <RebuildRequiredWarning />}
 
-          <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-            <h3 className="text-sm font-medium">Build Commands</h3>
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Commands to run during snapshot build
-              </label>
-              <textarea
+          <SettingsSection title="Build Commands">
+            <SettingsField
+              label="Commands to run during snapshot build"
+              description={
+                <>
+                  One command per line. Runs as user <code>eva</code> in{" "}
+                  <code>/tmp/repo</code> after <code>pnpm install</code>, before
+                  services start, baked permanently into the snapshot. Use for
+                  codegen and build steps.
+                </>
+              }
+            >
+              <Textarea
                 key={`build-${snapshot?._id ?? "none"}`}
                 defaultValue={buildCommandsText}
                 onBlur={handleBuildCommandsBlur}
-                className="w-full h-48 rounded-control border border-input bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+                className={`h-48 ${COMMAND_TEXTAREA_CLASS}`}
                 placeholder="pnpm convex codegen&#10;pnpm build"
               />
-              <p className="mt-1 text-[11px] text-muted-foreground">
-                One command per line. Runs as user <code>eva</code> in{" "}
-                <code>/tmp/repo</code> after <code>pnpm install</code>, before
-                services start, baked permanently into the snapshot. Use for
-                codegen and build steps.
-              </p>
-            </div>
-          </div>
+            </SettingsField>
+          </SettingsSection>
 
-          <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-            <h3 className="text-sm font-medium">Seed Commands</h3>
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                One-time data seeding, run with services up
-              </label>
-              <textarea
+          <SettingsSection title="Seed Commands">
+            <SettingsField
+              label="One-time data seeding, run with services up"
+              description={
+                <>
+                  One command per line. Runs once per seeded snapshot build,
+                  after background daemons and startup commands, so services
+                  like <code>convex dev</code> are ready. Never re-runs on
+                  sandbox boot — unlike startup commands (repo settings), which
+                  run here and on every boot.
+                </>
+              }
+            >
+              <Textarea
                 key={`seed-${snapshot?._id ?? "none"}`}
                 defaultValue={seedCommandsText}
                 onBlur={handleSeedCommandsBlur}
-                className="w-full h-48 rounded-control border border-input bg-background px-3 py-2 font-mono text-xs resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+                className={`h-48 ${COMMAND_TEXTAREA_CLASS}`}
                 placeholder="cd packages/backend && npx convex env set MY_KEY 'value'&#10;cd packages/backend && npx convex import seed.zip --yes"
               />
-              <p className="mt-1 text-[11px] text-muted-foreground">
-                One command per line. Runs once per seeded snapshot build, after
-                background daemons and startup commands, so services like{" "}
-                <code>convex dev</code> are ready. Never re-runs on sandbox boot
-                — unlike startup commands (repo settings), which run here and on
-                every boot.
-              </p>
-            </div>
-          </div>
+            </SettingsField>
+          </SettingsSection>
 
-          <p className="text-[11px] text-muted-foreground">
+          <p className="text-xs leading-relaxed text-muted-foreground">
             Requires Vercel Sandbox credentials in team or repo environment
             variables: <code className="font-mono">VERCEL_TOKEN</code>,{" "}
             <code className="font-mono">VERCEL_TEAM_ID</code>, and{" "}
@@ -319,11 +328,13 @@ export function SnapshotsClient({
           </p>
         </TabsContent>
 
-        <TabsContent value="status" className="space-y-6">
+        <TabsContent value="status" className="space-y-4">
           {snapshot ? (
             <>
-              <div className="rounded-surface border border-border bg-card p-4 space-y-3">
-                <h3 className="text-sm font-medium">Current Status</h3>
+              <SettingsSection
+                title="Current Status"
+                bodyClassName="space-y-4 px-4 py-4"
+              >
                 <div className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2 sm:gap-4">
                   <div>
                     <span className="text-muted-foreground">Snapshot Name</span>
@@ -392,23 +403,25 @@ export function SnapshotsClient({
                       ? "Seeding..."
                       : "Rebuild Now"}
                 </Button>
-                <p className="text-[11px] text-muted-foreground">
+                <p className="text-xs leading-relaxed text-muted-foreground">
                   Always rebuilds the base Image below.
                   {hasSeedableApps
                     ? " Also re-captures the optional seeded snapshot when apps have Stop Commands."
                     : " No seed file or Stop Commands required."}
                 </p>
-              </div>
-              <div className="rounded-surface border border-border bg-card p-4 space-y-3">
-                <h3 className="text-sm font-medium">Base Image</h3>
-                <p className="text-xs text-muted-foreground">
-                  Base snapshot with toolchain,{" "}
-                  <code className="font-mono text-[11px]">pnpm install</code>,
-                  and your build commands. Eva captures a running sandbox as{" "}
-                  <code className="font-mono text-[11px]">snap_*</code>. This is
-                  what sandboxes boot from unless a seeded snapshot exists.
-                  Rebuild Now always refreshes this — no seed file needed.
-                </p>
+              </SettingsSection>
+              <SettingsSection
+                title="Base Image"
+                description={
+                  <>
+                    Base snapshot with toolchain, <code>pnpm install</code>, and
+                    your build commands. Eva captures a running sandbox as{" "}
+                    <code>snap_*</code>. This is what sandboxes boot from unless
+                    a seeded snapshot exists. Rebuild Now always refreshes this
+                    — no seed file needed.
+                  </>
+                }
+              >
                 {baseImageReady ? (
                   <div className="flex items-start gap-1 text-xs text-green-500">
                     <IconCheck size={12} className="mt-0.5 shrink-0" />
@@ -444,21 +457,18 @@ export function SnapshotsClient({
                       : " — not built yet; click Rebuild Now."}
                   </p>
                 )}
-              </div>
-              <div className="rounded-surface border border-border bg-muted/40 p-4 space-y-3">
-                <h3 className="text-sm font-medium">
-                  Seeded snapshot{" "}
-                  <span className="font-normal text-muted-foreground">
-                    (optional)
-                  </span>
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  Running-sandbox capture with DB and services already started.
-                  Only needed when cold boot is too slow — e.g. carepulse with
-                  Supabase + Convex data. Configure Stop Commands on an app
-                  (Settings → App); upload seed files only if startup commands
-                  reference them.
-                </p>
+              </SettingsSection>
+              <SettingsSection
+                title={
+                  <>
+                    Seeded snapshot{" "}
+                    <span className="font-normal text-muted-foreground">
+                      (optional)
+                    </span>
+                  </>
+                }
+                description="Running-sandbox capture with DB and services already started. Only needed when cold boot is too slow. Configure Stop Commands on an app (Settings → App); upload seed files only if startup commands reference them."
+              >
                 {seededApps === undefined ? (
                   <p className="text-xs text-muted-foreground">Loading…</p>
                 ) : isSeeding ? (
@@ -489,24 +499,17 @@ export function SnapshotsClient({
                     startup/background/stop commands.
                   </p>
                 )}
-              </div>
+              </SettingsSection>
             </>
           ) : (
-            <div className="rounded-surface border border-border bg-card p-8 text-center">
-              <p className="text-sm text-muted-foreground">
-                No snapshot configured yet. Configure one in the Configuration
-                tab.
-              </p>
-            </div>
+            <NoSnapshotConfigured />
           )}
         </TabsContent>
 
-        <TabsContent value="builds" className="space-y-6">
+        <TabsContent value="builds" className="space-y-4">
           {snapshot && builds && builds.length > 0 ? (
-            <div className="rounded-surface border border-border bg-muted/40 overflow-hidden">
-              <div className="px-4 py-3">
-                <h3 className="text-sm font-medium">Build History</h3>
-              </div>
+            // Rows own their padding so the table spans the card's full width.
+            <SettingsSection title="Build History" bodyClassName="p-0">
               <div className="overflow-x-auto">
                 <table className="w-full text-xs min-w-[320px] sm:min-w-[420px]">
                   <thead>
@@ -548,25 +551,21 @@ export function SnapshotsClient({
                   </tbody>
                 </table>
               </div>
-            </div>
+            </SettingsSection>
           ) : snapshot && builds && builds.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
-              <IconCamera size={48} className="mb-3 opacity-40" />
-              <p className="text-sm">
-                No builds yet. Click "Rebuild Now" to start.
-              </p>
-            </div>
+            <SettingsSection title="Build History" bodyClassName="p-0">
+              <SettingsEmptyState
+                icon={IconCamera}
+                title="No builds yet"
+                description="Select Rebuild Now on the Status tab to run the first build."
+              />
+            </SettingsSection>
           ) : (
-            <div className="rounded-surface border border-border bg-card p-8 text-center">
-              <p className="text-sm text-muted-foreground">
-                No snapshot configured yet. Configure one in the Configuration
-                tab.
-              </p>
-            </div>
+            <NoSnapshotConfigured />
           )}
         </TabsContent>
 
-        <TabsContent value="config-files" className="space-y-6">
+        <TabsContent value="config-files" className="space-y-4">
           <ConfigFilesSection repoId={repoId} snapshotId={snapshot?._id} />
         </TabsContent>
       </Tabs>
@@ -720,31 +719,29 @@ function ConfigFilesSection({
     <div className="space-y-4">
       <RebuildRequiredWarning />
 
-      <div className="rounded-surface border border-border bg-card p-4 space-y-4">
-        <div>
-          <h3 className="text-sm font-medium">
+      <SettingsSection
+        title={
+          <>
             Sandbox Config Files{" "}
             <span className="font-normal text-muted-foreground">
               (optional — seeded snapshots only)
             </span>
-          </h3>
-          <p className="mt-1 text-xs text-muted-foreground">
+          </>
+        }
+        description={
+          <>
             Files uploaded here are copied into the codebase root when a sandbox
             starts. They are also available at{" "}
-            <code className="font-mono text-[11px]">
-              /home/eva/sandbox-config/
-            </code>{" "}
-            and{" "}
-            <code className="font-mono text-[11px]">/tmp/sandbox-config/</code>
-            {". "}
-            Only needed when app startup commands reference sensitive seeds
-            (e.g. SQL dumps) that cannot live in git. Base Image rebuilds do not
-            require any files here.
-          </p>
-        </div>
-
+            <code>/home/eva/sandbox-config/</code> and{" "}
+            <code>/tmp/sandbox-config/</code>. Only needed when app startup
+            commands reference sensitive seeds (e.g. SQL dumps) that cannot live
+            in git. Base Image rebuilds do not require any files here.
+          </>
+        }
+        bodyClassName="space-y-4 px-4 py-4"
+      >
         {error && (
-          <div className="rounded bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <div className="rounded-control border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             {error}
           </div>
         )}
@@ -837,7 +834,7 @@ function ConfigFilesSection({
             <Spinner size="sm" />
           </div>
         )}
-      </div>
+      </SettingsSection>
     </div>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/TabsSettingsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/TabsSettingsClient.tsx
@@ -12,6 +12,10 @@ import {
 } from "@/lib/utils/appTabSlug";
 import { resolveTablerIcon } from "@/lib/utils/tablerIcon";
 import { CustomTabRow } from "./_components/CustomTabRow";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
+import { IconLayoutNavbar } from "@tabler/icons-react";
 
 function TabIconPreview({ icon }: { icon: string }) {
   return createElement(resolveTablerIcon(icon), {
@@ -89,14 +93,13 @@ export function TabsSettingsClient() {
   return (
     <PageWrapper title="Tabs" comfortable>
       <div className="space-y-4">
-        <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-          <div>
-            <h3 className="text-sm font-medium">Custom Tabs</h3>
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Add tabs that open a service running inside this app's sandbox on
-              a given port (for example Supabase Studio or the Convex
-              dashboard). They appear in every session for this app. The icon is
-              a{" "}
+        <SettingsSection
+          title="Add a tab"
+          description={
+            <>
+              Tabs open a service running inside this app's sandbox on a given
+              port (for example Supabase Studio or the Convex dashboard), and
+              appear in every session for this app. The icon is a{" "}
               <a
                 href="https://tabler.io/icons"
                 target="_blank"
@@ -108,47 +111,49 @@ export function TabsSettingsClient() {
               name such as <code>IconBolt</code>. Names must be unique (case
               insensitive) and become the session URL slug (e.g.{" "}
               <code>supabase</code>).
-            </p>
-          </div>
-
-          <div className="flex items-end gap-2">
-            <TabIconPreview icon={icon.trim()} />
-            <div className="flex-1">
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Name
-              </label>
-              <Input
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                  setSubmitError(null);
-                }}
-                className="h-8 text-xs"
-                placeholder="Supabase"
-              />
+            </>
+          }
+          bodyClassName="space-y-2"
+        >
+          {/* The three fields sit on one row on wide screens and stack on
+              mobile, so the icon preview trails the name it previews. */}
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex flex-1 items-end gap-2">
+              <TabIconPreview icon={icon.trim()} />
+              <div className="flex-1">
+                <SettingsField label="Name">
+                  <Input
+                    value={name}
+                    onChange={(e) => {
+                      setName(e.target.value);
+                      setSubmitError(null);
+                    }}
+                    className="h-8 text-xs"
+                    placeholder="Supabase"
+                  />
+                </SettingsField>
+              </div>
             </div>
-            <div className="w-40">
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Icon
-              </label>
-              <Input
-                value={icon}
-                onChange={(e) => setIcon(e.target.value)}
-                className="h-8 text-xs font-mono"
-                placeholder="IconBolt"
-              />
+            <div className="sm:w-40">
+              <SettingsField label="Icon">
+                <Input
+                  value={icon}
+                  onChange={(e) => setIcon(e.target.value)}
+                  className="h-8 font-mono text-xs"
+                  placeholder="IconBolt"
+                />
+              </SettingsField>
             </div>
-            <div className="w-24">
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Port
-              </label>
-              <Input
-                type="number"
-                value={port}
-                onChange={(e) => setPort(e.target.value)}
-                className="h-8 text-xs"
-                placeholder="53432"
-              />
+            <div className="sm:w-24">
+              <SettingsField label="Port">
+                <Input
+                  type="number"
+                  value={port}
+                  onChange={(e) => setPort(e.target.value)}
+                  className="h-8 text-xs"
+                  placeholder="53432"
+                />
+              </SettingsField>
             </div>
             <Button
               size="sm"
@@ -160,26 +165,30 @@ export function TabsSettingsClient() {
             </Button>
           </div>
           {slug && !validationError ? (
-            <p className="text-[11px] text-muted-foreground">
+            <p className="text-xs text-muted-foreground">
               URL slug: <code>{slug}</code>
             </p>
           ) : null}
           {formError ? (
-            <p className="text-[11px] text-destructive">{formError}</p>
+            <p className="text-xs text-destructive">{formError}</p>
           ) : null}
-        </div>
+        </SettingsSection>
 
-        {tabs && tabs.length > 0 ? (
-          <div className="space-y-2">
-            {tabs.map((tab) => (
-              <CustomTabRow key={tab._id} tab={tab} takenSlugs={takenSlugs} />
-            ))}
-          </div>
-        ) : (
-          <p className="text-xs text-muted-foreground">
-            No custom tabs yet. Add one above.
-          </p>
-        )}
+        <SettingsSection title="Custom tabs" bodyClassName="p-0">
+          {tabs && tabs.length > 0 ? (
+            <div className="divide-y divide-border">
+              {tabs.map((tab) => (
+                <CustomTabRow key={tab._id} tab={tab} takenSlugs={takenSlugs} />
+              ))}
+            </div>
+          ) : (
+            <SettingsEmptyState
+              icon={IconLayoutNavbar}
+              title="No custom tabs yet"
+              description="Add one above to open a sandbox service in its own tab."
+            />
+          )}
+        </SettingsSection>
       </div>
     </PageWrapper>
   );

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/TeamEnvVarsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/TeamEnvVarsClient.tsx
@@ -3,11 +3,11 @@
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useMutation, useAction } from "convex/react";
 import { api } from "@eva/backend";
-import { Card, CardContent } from "@eva/ui";
 import { Link } from "@tanstack/react-router";
 import { IconUsers } from "@tabler/icons-react";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { EnvVarsTable } from "@/lib/components/EnvVarsTable";
+import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 
 export function TeamEnvVarsClient() {
   const { repo } = useRepo();
@@ -59,20 +59,35 @@ export function TeamEnvVarsClient() {
 
   if (!repo.teamId || !team) {
     return (
-      <Card>
-        <CardContent className="flex flex-col items-center justify-center py-12">
-          <IconUsers size={48} className="mb-4 text-muted-foreground/50" />
-          <p className="mb-2 text-sm font-medium">No team configured</p>
-          <p className="text-xs text-muted-foreground">
-            This repository is not part of any team yet
-          </p>
-        </CardContent>
-      </Card>
+      <div className="rounded-surface border border-border bg-card shadow-sm">
+        <SettingsEmptyState
+          icon={IconUsers}
+          title="No team configured"
+          description="This repository is not part of any team yet, so there are no team variables to inherit."
+        />
+      </div>
     );
   }
 
   return (
     <div className="space-y-4">
+      {/* Which team these variables belong to reads before the variables. */}
+      <div className="flex flex-wrap items-center gap-2 rounded-control border border-border bg-muted px-3 py-2">
+        <IconUsers size={16} className="text-muted-foreground" />
+        <p className="text-xs">
+          Team:{" "}
+          <span className="font-medium">{team.displayName ?? team.name}</span>
+        </p>
+        <span className="text-muted-foreground">•</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId: team._id }}
+          target="_blank"
+          className="text-xs text-primary hover:underline"
+        >
+          Manage team variables →
+        </Link>
+      </div>
       <EnvVarsTable
         vars={teamEnvVars}
         scope="team"
@@ -103,22 +118,6 @@ export function TeamEnvVarsClient() {
           });
         }}
       />
-      <div className="flex items-center gap-2">
-        <IconUsers size={16} className="text-muted-foreground" />
-        <p className="text-sm">
-          Team:{" "}
-          <span className="font-medium">{team.displayName ?? team.name}</span>
-        </p>
-        <span className="text-muted-foreground">•</span>
-        <Link
-          to="/teams/$teamId"
-          params={{ teamId: team._id }}
-          target="_blank"
-          className="text-sm text-primary hover:underline"
-        >
-          Manage team variables →
-        </Link>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/AppSettingsSection.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/AppSettingsSection.tsx
@@ -4,6 +4,8 @@ import { Input } from "@eva/ui";
 import type { Id } from "@eva/backend";
 import { isAppRepo } from "../_utils";
 import { DomainsSection } from "./DomainsSection";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
 
 type UpdateRepoConfig = (args: {
   repoId: Id<"githubRepos">;
@@ -27,21 +29,21 @@ export function AppSettingsSection({
   updateConfig: UpdateRepoConfig;
 }) {
   return (
-    <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-      <div>
-        <h3 className="text-sm font-medium">This app</h3>
-        <p className="mt-0.5 text-[11px] text-muted-foreground">
+    <SettingsSection
+      title="This app"
+      description={
+        <>
           Settings for{" "}
           <span className="font-medium text-foreground">{appLabel}</span> only.
-        </p>
-      </div>
-
+        </>
+      }
+    >
       <div className="grid gap-4">
         {isAppRepo(repo) ? (
-          <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-              Deployment Project Name
-            </label>
+          <SettingsField
+            label="Deployment Project Name"
+            description="Vercel or Netlify project name for this app. Used to match the correct preview deployment in monorepos."
+          >
             <Input
               className="h-8 text-xs"
               placeholder="e.g. my-vercel-project"
@@ -56,11 +58,7 @@ export function AppSettingsSection({
                 }
               }}
             />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Vercel or Netlify project name for this app. Used to match the
-              correct preview deployment in monorepos.
-            </p>
-          </div>
+          </SettingsField>
         ) : null}
 
         <DomainsSection
@@ -69,6 +67,6 @@ export function AppSettingsSection({
           updateConfig={updateConfig}
         />
       </div>
-    </div>
+    </SettingsSection>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/ConfigModelField.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/ConfigModelField.tsx
@@ -3,6 +3,7 @@
 import { ModelSelect } from "@eva/ui";
 import type { AIModel } from "@eva/backend";
 import type { useAvailableAiModels } from "@/lib/hooks/useAvailableAiModels";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
 
 type ModelFieldState = Pick<
   ReturnType<typeof useAvailableAiModels>,
@@ -23,10 +24,7 @@ export function ConfigModelField({
   onValueChange: (model: AIModel) => void;
 }) {
   return (
-    <div>
-      <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-        {label}
-      </label>
+    <SettingsField label={label} description={description}>
       <ModelSelect
         value={state.model}
         options={state.options}
@@ -34,7 +32,6 @@ export function ConfigModelField({
         onValueChange={onValueChange}
         className="h-8 text-xs"
       />
-      <p className="mt-1 text-[11px] text-muted-foreground">{description}</p>
-    </div>
+    </SettingsField>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/CustomTabRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/CustomTabRow.tsx
@@ -4,7 +4,7 @@ import { useState, createElement } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import type { Doc } from "@eva/backend";
-import { Button, Input, cn } from "@eva/ui";
+import { Button, Input, Switch } from "@eva/ui";
 import { IconTrash } from "@tabler/icons-react";
 import {
   RESERVED_APP_TAB_SLUGS,
@@ -86,8 +86,9 @@ export function CustomTabRow({ tab, takenSlugs }: CustomTabRowProps) {
   };
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-2 rounded-surface border border-border bg-card p-2">
+    // A row inside the tabs list section, so the section owns the border.
+    <div className="space-y-1 px-3 py-2.5">
+      <div className="flex items-center gap-2">
         <CustomTabIcon icon={tab.icon} />
         <Input
           key={`name-${tab._id}-${tab.name}`}
@@ -111,22 +112,11 @@ export function CustomTabRow({ tab, takenSlugs }: CustomTabRowProps) {
           className="h-8 w-24 text-xs"
           placeholder="Port"
         />
-        <button
-          type="button"
+        <Switch
+          checked={tab.enabled}
+          onCheckedChange={(enabled) => toggleEnabled({ id: tab._id, enabled })}
           aria-label={tab.enabled ? "Disable tab" : "Enable tab"}
-          onClick={() => toggleEnabled({ id: tab._id, enabled: !tab.enabled })}
-          className={cn(
-            "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            tab.enabled ? "bg-primary" : "bg-muted-foreground/30",
-          )}
-        >
-          <span
-            className={cn(
-              "pointer-events-none block h-5 w-5 rounded-full bg-white transition-transform",
-              tab.enabled ? "translate-x-5" : "translate-x-0",
-            )}
-          />
-        </button>
+        />
         <Button
           size="icon"
           variant="ghost"
@@ -138,9 +128,9 @@ export function CustomTabRow({ tab, takenSlugs }: CustomTabRowProps) {
         </Button>
       </div>
       {nameError ? (
-        <p className="px-2 text-[11px] text-destructive">{nameError}</p>
+        <p className="text-xs text-destructive">{nameError}</p>
       ) : (
-        <p className="px-2 text-[11px] text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           URL slug: <code>{ownSlug}</code>
         </p>
       )}

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/DomainsSection.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/DomainsSection.tsx
@@ -41,9 +41,9 @@ export function DomainsSection({
         <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
           Domains
         </label>
-        <p className="text-[11px] text-muted-foreground">
-          Hostnames where this app is deployed. The Chrome extension will
-          auto-select this repo when browsing these domains.
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Hostnames where this app is deployed. The Chrome extension
+          auto-selects this repo when browsing these domains.
         </p>
       </div>
 
@@ -52,7 +52,7 @@ export function DomainsSection({
           {domains.map((domain) => (
             <span
               key={domain}
-              className="inline-flex items-center gap-1 rounded-lg bg-muted/50 px-2 py-1 text-xs"
+              className="inline-flex items-center gap-1 rounded-lg border border-border bg-muted px-2 py-1 text-xs"
             >
               {domain}
               <button

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/LogoSettingsSection.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/LogoSettingsSection.tsx
@@ -9,6 +9,8 @@ import { IconPhoto } from "@tabler/icons-react";
 import { useRepoLogoUpload } from "@/lib/hooks/useRepoLogoUpload";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { repoDisplayLabel } from "@/lib/utils/repoGrouping";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
 
 /** Display name + logo for this app (App settings). */
 export function LogoSettingsSection({ repoId }: { repoId: Id<"githubRepos"> }) {
@@ -54,18 +56,20 @@ export function LogoSettingsSection({ repoId }: { repoId: Id<"githubRepos"> }) {
   };
 
   return (
-    <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-      <div>
-        <h3 className="text-sm font-medium">Identity</h3>
-        <p className="mt-1 text-[11px] text-muted-foreground">
-          Display name and logo for this app. Applies to this app only.
-        </p>
-      </div>
-
-      <div>
-        <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-          Display name
-        </label>
+    <SettingsSection
+      title="Identity"
+      description="Display name and logo for this app. Applies to this app only."
+      bodyClassName="space-y-4"
+    >
+      <SettingsField
+        label="Display name"
+        description={
+          <>
+            Shown in the sidebar instead of the GitHub name. Leave empty for{" "}
+            <span className="font-medium">{fallbackName}</span>.
+          </>
+        }
+      >
         <Input
           key={`label-${repoId}`}
           className="h-8 text-xs"
@@ -73,11 +77,7 @@ export function LogoSettingsSection({ repoId }: { repoId: Id<"githubRepos"> }) {
           defaultValue={repo.label ?? ""}
           onBlur={handleLabelBlur}
         />
-        <p className="mt-1 text-[11px] text-muted-foreground">
-          Shown in the sidebar instead of the GitHub name. Leave empty for{" "}
-          <span className="font-medium">{fallbackName}</span>.
-        </p>
-      </div>
+      </SettingsField>
 
       <div className="flex items-center gap-3">
         <div className="flex size-16 items-center justify-center overflow-hidden rounded-md border border-border bg-background">
@@ -117,6 +117,6 @@ export function LogoSettingsSection({ repoId }: { repoId: Id<"githubRepos"> }) {
         className="hidden"
         onChange={handleLogoSelected}
       />
-    </div>
+    </SettingsSection>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/PrRecapSettingsSection.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/PrRecapSettingsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Checkbox } from "@eva/ui";
+import { Switch } from "@eva/ui";
 import { normalizeAIModel, type AIModel, type Id } from "@eva/backend";
 import { useAvailableAiModels } from "@/lib/hooks/useAvailableAiModels";
 import { ConfigModelField } from "./ConfigModelField";
@@ -29,31 +29,30 @@ export function PrRecapSettingsSection({
 
   return (
     <div className="space-y-4 border-t border-border pt-4">
-      <div className="flex items-start gap-3">
-        <Checkbox
-          checked={prRecapsEnabled ?? false}
-          disabled={!claudeAvailable}
-          onCheckedChange={(value) =>
-            updateConfig({
-              repoId,
-              prRecapsEnabled: value === true,
-            })
-          }
-          className="mt-0.5"
-        />
+      {/* Label left, switch right — the same toggle row shape used by the
+          global notifications and sandbox settings. */}
+      <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <p className="text-xs font-medium">PR recaps</p>
-          <p className="mt-0.5 text-[11px] text-muted-foreground">
+          <p className="text-sm font-medium">PR recaps</p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
             Auto-generate a recap doc and GitHub comment on each PR update. Uses
             your team Claude Code subscription (
             <code>CLAUDE_CODE_OAUTH_TOKEN</code>).
           </p>
           {!claudeAvailable ? (
-            <p className="mt-1 text-[11px] text-destructive">
+            <p className="mt-1 text-xs text-destructive">
               Add CLAUDE_CODE_OAUTH_TOKEN in team env vars to enable.
             </p>
           ) : null}
         </div>
+        <Switch
+          checked={prRecapsEnabled ?? false}
+          disabled={!claudeAvailable}
+          onCheckedChange={(checked) =>
+            updateConfig({ repoId, prRecapsEnabled: checked })
+          }
+          aria-label="PR recaps"
+        />
       </div>
 
       <ConfigModelField

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/RepositorySettingsSection.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/RepositorySettingsSection.tsx
@@ -4,6 +4,8 @@ import { normalizeAIModel, type AIModel, type Id } from "@eva/backend";
 import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
 import { BranchSelect } from "@/lib/components/BranchSelect";
 import { useAvailableAiModels } from "@/lib/hooks/useAvailableAiModels";
+import { SettingsSection } from "@/lib/components/settings/SettingsSection";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
 import { ConfigModelField } from "./ConfigModelField";
 import { PrRecapSettingsSection } from "./PrRecapSettingsSection";
 
@@ -58,25 +60,30 @@ export function RepositorySettingsSection({
   );
 
   return (
-    <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
-      <div>
-        <h3 className="text-sm font-medium">Repository</h3>
-        {isMonorepo ? (
-          <p className="mt-0.5 text-[11px] text-muted-foreground">
+    <SettingsSection
+      title="Repository"
+      description={
+        isMonorepo ? (
+          <>
             Applies to all apps in{" "}
             <span className="font-medium text-foreground">
               {owner}/{name}
             </span>
             .
-          </p>
-        ) : null}
-      </div>
-
+          </>
+        ) : undefined
+      }
+    >
       <div className="grid gap-4">
-        <div>
-          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-            Default Base Branch
-          </label>
+        <SettingsField
+          label="Default Base Branch"
+          description={
+            <>
+              The default branch used when creating quick tasks. Defaults to{" "}
+              <code>main</code> if not set.
+            </>
+          }
+        >
           <BranchSelect
             value={repo.defaultBaseBranch ?? FALLBACK_GIT_BASE_BRANCH}
             onValueChange={(val) =>
@@ -85,11 +92,7 @@ export function RepositorySettingsSection({
             className="h-8 text-xs"
             placeholder="Select a branch"
           />
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            The default branch used when creating quick tasks. Defaults to{" "}
-            <code>main</code> if not set.
-          </p>
-        </div>
+        </SettingsField>
 
         <ConfigModelField
           label="Default Model"
@@ -146,6 +149,6 @@ export function RepositorySettingsSection({
           updateConfig={updateConfig}
         />
       </div>
-    </div>
+    </SettingsSection>
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/audits/_components/AddCategoryForm.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/audits/_components/AddCategoryForm.tsx
@@ -6,6 +6,7 @@ import { Button, Input, Textarea } from "@eva/ui";
 import { IconPlus } from "@tabler/icons-react";
 import type { Id } from "@eva/backend";
 import { useState } from "react";
+import { SettingsField } from "@/lib/components/settings/SettingsField";
 
 export function AddCategoryForm(props: {
   repoId: Id<"githubRepos">;
@@ -28,32 +29,26 @@ export function AddCategoryForm(props: {
   };
 
   return (
-    <div className="grid gap-3">
-      <div>
-        <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-          Name
-        </label>
+    <div className="grid gap-4">
+      <SettingsField label="Name">
         <Input
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="e.g. Performance"
           className="h-8 text-xs"
         />
-      </div>
-      <div>
-        <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-          Description
-        </label>
+      </SettingsField>
+      <SettingsField
+        label="Description"
+        description="This description is sent to the AI as instructions for what to audit."
+      >
         <Textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="Describe what this audit should check for..."
-          className="text-xs min-h-[60px] resize-none"
+          className="min-h-[60px] resize-none text-xs"
         />
-        <p className="mt-1 text-[11px] text-muted-foreground">
-          This description is sent to the AI as instructions for what to audit.
-        </p>
-      </div>
+      </SettingsField>
       <Button
         variant="outline"
         size="sm"

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/skills/_components/SkillRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/skills/_components/SkillRow.tsx
@@ -3,7 +3,7 @@
 import { type api } from "@eva/backend";
 import type { FunctionReturnType } from "convex/server";
 import { useState } from "react";
-import { Button } from "@eva/ui";
+import { Badge, Button, cn } from "@eva/ui";
 import { IconFileText } from "@tabler/icons-react";
 import { SkillContentDialog } from "./SkillContentDialog";
 
@@ -14,24 +14,25 @@ export function SkillRow({ skill }: { skill: Skill }) {
 
   return (
     <>
+      {/* A row inside the skills list section, so the section owns the border. */}
       <div
-        className={
-          "rounded-surface p-3 " +
-          (skill.available ? "bg-muted/40" : "bg-muted/30 opacity-70")
-        }
+        className={cn(
+          "px-4 py-3 transition-colors hover:bg-muted/40",
+          !skill.available && "opacity-60",
+        )}
       >
         <div className="flex min-w-0 items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <p className="text-xs font-medium">{skill.title}</p>
+              <p className="text-sm font-medium">{skill.title}</p>
               {!skill.available ? (
-                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                <Badge variant="secondary" className="text-xs">
                   Stale
-                </span>
+                </Badge>
               ) : null}
             </div>
             {skill.sourcePath ? (
-              <p className="mt-0.5 truncate text-[10px] text-muted-foreground/70">
+              <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
                 {skill.sourcePath}
               </p>
             ) : null}
@@ -49,7 +50,7 @@ export function SkillRow({ skill }: { skill: Skill }) {
             </Button>
           ) : null}
         </div>
-        <p className="mt-2 line-clamp-3 text-[11px] text-muted-foreground">
+        <p className="mt-1.5 line-clamp-3 text-xs leading-relaxed text-muted-foreground">
           {skill.description || "No description found in SKILL.md."}
         </p>
       </div>


### PR DESCRIPTION
Sweeps all 19 settings routes (6 global, 13 repo) for consistency and layout polish.

## Three new primitives

`apps/web/src/lib/components/settings/`

- **SettingsSection** — the one card shape: hairline `border-border` on `bg-card`, `px-4 py-3` header, divider only when there is a body, optional right-aligned `action` and `footer`. A section with no children is the standard toggle row.
- **SettingsField** — the label / control / help-text stack every form repeated.
- **SettingsEmptyState** — centred icon + title + description, replacing five bespoke empty blocks.

Nesting rule: content inside a section body steps to `bg-muted`, since the section already occupies the `bg-card` tone.

## What changed per route

- Every hand-rolled card, borderless `bg-muted/40` panel, and floating heading now goes through `SettingsSection`.
- Three hand-rolled toggles (snapshots, tabs, PR recaps) replaced with `Switch`.
- Raw `<textarea>` elements replaced with `Textarea` from `@eva/ui`.
- Lists (monorepo apps, custom tabs, skills, audits, env vars) became `divide-y divide-border` rows inside one section, so dividers span the full card width.
- Sub-`text-xs` sizes (`text-[10px]`, `text-[11px]`) normalised to `text-xs leading-relaxed`.
- Hardcoded accents removed (monorepo "Added" badge, env-var "Configured" chip).
- Page stacks standardised on `space-y-4`.

## Verification

`npx tsc --noEmit` clean in `apps/web` after every route. No `any`, `unknown`, or `as` introduced.
