### PR TITLE
Put the full landing page behind VITE_NEW_LANDING, add a compact default

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ openssl ec -in private.pem -pubout -out public.pem
 ```env
 VITE_CONVEX_URL=https://your-deployment.convex.cloud
 VITE_CLERK_PUBLISHABLE_KEY=pk_test_...
+
+# Optional. Set to "true" for the full marketing page on `/`.
+# Anything else, including unset, gets the compact one-screen version.
+VITE_NEW_LANDING=false
 ```
 
 #### Convex (`npx convex env set VAR value`)

--- a/apps/web/src/env/client.ts
+++ b/apps/web/src/env/client.ts
@@ -6,6 +6,19 @@ export const clientEnv = createEnv({
   client: {
     VITE_CONVEX_URL: z.string().min(1),
     VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+    // Opt-in, so an instance that sets nothing gets the compact page. A plain
+    // boolean would be wrong here: every Vite env value arrives as a string,
+    // and `Boolean("false")` is `true`.
+    VITE_NEW_LANDING: z.enum(["true", "false"]).optional(),
   },
   runtimeEnv: import.meta.env,
 });
+
+/**
+ * Whether the public marketing page renders in full.
+ *
+ * Off by default. The full page is a long scroll with sixteen animated feature
+ * previews; the compact page says the same thing in one screen and is what a
+ * self-hosted instance gets unless it asks otherwise.
+ */
+export const newLandingEnabled = clientEnv.VITE_NEW_LANDING === "true";

--- a/apps/web/src/routes/_components/LandingPage.tsx
+++ b/apps/web/src/routes/_components/LandingPage.tsx
@@ -2,6 +2,8 @@
 
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@conductor/ui";
+import { newLandingEnabled } from "@/env/client";
+import { LandingCompact } from "./landing/LandingCompact";
 import { LandingCta } from "./landing/LandingCta";
 import { LandingFooter } from "./landing/LandingFooter";
 import { LandingHero } from "./landing/LandingHero";
@@ -22,14 +24,26 @@ interface LandingPageProps {
 /**
  * Marketing page. Thin orchestrator — every section owns its own copy and
  * layout, and all strings live in `landing/landingContent.ts`.
+ *
+ * `VITE_NEW_LANDING` picks between this and `LandingCompact`. Both read the
+ * same content file, so the choice is one of depth, not of message: the full
+ * page walks through each feature with a live mock, the compact one names them
+ * all on a single screen.
  */
 export function LandingPage({ agentRedirect }: LandingPageProps) {
-  const navigate = useNavigate();
-
   // `?agent` is mid-redirect to the agent login route; render a blank canvas
   // rather than flashing the whole marketing page.
   if (agentRedirect) {
     return <div className="min-h-screen w-full bg-background" />;
+  }
+
+  if (!newLandingEnabled) {
+    return (
+      <>
+        <LandingCompact />
+        <AgentSignIn />
+      </>
+    );
   }
 
   return (
@@ -52,20 +66,32 @@ export function LandingPage({ agentRedirect }: LandingPageProps) {
 
       <LandingFooter />
 
-      {isDev ? (
-        <div className="fixed bottom-4 right-4 z-50">
-          <Button
-            size="sm"
-            variant="outline"
-            className="shadow-lg"
-            onClick={() => {
-              navigate({ to: "/", search: { agent: true } });
-            }}
-          >
-            Sign in as Eva
-          </Button>
-        </div>
-      ) : null}
+      <AgentSignIn />
+    </div>
+  );
+}
+
+/**
+ * Dev-only shortcut into the agent account, rendered by both versions of the
+ * page so switching `VITE_NEW_LANDING` never takes it away.
+ */
+function AgentSignIn() {
+  const navigate = useNavigate();
+
+  if (!isDev) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <Button
+        size="sm"
+        variant="outline"
+        className="shadow-lg"
+        onClick={() => {
+          navigate({ to: "/", search: { agent: true } });
+        }}
+      >
+        Sign in as Eva
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/routes/_components/landing/LandingCompact.tsx
+++ b/apps/web/src/routes/_components/landing/LandingCompact.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { SignInButton, SignUpButton } from "@clerk/clerk-react";
+import { IconArrowRight, IconBrandGithub } from "@tabler/icons-react";
+import { Button } from "@conductor/ui";
+import { BrandMark } from "./BrandMark";
+import {
+  EVA_GITHUB_URL,
+  EVA_SETUP_URL,
+  LANDING_HERO_CAPABILITIES,
+  LANDING_PILLARS,
+  LANDING_STACK,
+} from "./landingContent";
+
+/**
+ * The marketing page when `VITE_NEW_LANDING` is off.
+ *
+ * One screen of content rather than the full page's long scroll: the same
+ * headline, the four stages of the workflow with their features named, and the
+ * stack. It reads from `landingContent.ts` like the full page does, so copy
+ * stays in one file and neither version can drift from the other.
+ *
+ * Deliberately static — no previews, no motion, no auto-cycling tabs. Anything
+ * that needed those belongs on the full page.
+ */
+export function LandingCompact() {
+  return (
+    <div id="top" className="flex min-h-screen flex-col bg-background">
+      <header className="border-b border-border">
+        <nav className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between gap-4 px-5 sm:px-8">
+          <span className="flex items-center gap-2.5">
+            <img
+              src="/icon.svg"
+              alt=""
+              width={24}
+              height={24}
+              className="size-6"
+            />
+            <span className="text-sm font-semibold tracking-tight text-foreground">
+              Eva
+            </span>
+          </span>
+
+          <div className="flex items-center gap-1.5">
+            <Button asChild variant="ghost" size="icon-sm">
+              <a
+                href={EVA_GITHUB_URL}
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Eva on GitHub"
+              >
+                <IconBrandGithub size={18} />
+              </a>
+            </Button>
+            <SignInButton mode="modal">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="hidden text-muted-foreground hover:text-foreground sm:inline-flex"
+              >
+                Sign in
+              </Button>
+            </SignInButton>
+            <SignUpButton mode="modal">
+              <Button size="sm">Get started</Button>
+            </SignUpButton>
+          </div>
+        </nav>
+      </header>
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-5 py-10 sm:px-8 sm:py-14">
+        <a
+          href={EVA_GITHUB_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="motion-base inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-xs text-muted-foreground shadow-sm hover:bg-muted/60 hover:text-foreground"
+        >
+          <span className="size-1.5 rounded-full bg-primary" />
+          Open source and MIT licensed
+        </a>
+
+        <h1 className="mt-6 max-w-3xl text-balance text-4xl font-semibold leading-[1.05] tracking-tight text-foreground sm:text-5xl">
+          Your AI coworker ships pull requests.
+        </h1>
+
+        <p className="mt-5 max-w-2xl text-pretty text-base leading-relaxed text-muted-foreground">
+          Eva gives coding agents a real cloud dev environment — your repository
+          cloned, dependencies installed, a dev server running and a browser
+          they can drive. They run the tests, capture proof it works, and open
+          the pull request.
+        </p>
+
+        <ul className="mt-6 flex flex-wrap items-center gap-1.5">
+          {LANDING_HERO_CAPABILITIES.map((capability) => (
+            <li
+              key={capability}
+              className="rounded-full border border-border bg-card/60 px-2.5 py-1 font-mono text-[11px] text-muted-foreground"
+            >
+              {capability}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <SignUpButton mode="modal">
+            <Button size="lg" className="w-full sm:w-auto sm:min-w-[10rem]">
+              Get started
+              <IconArrowRight size={16} aria-hidden />
+            </Button>
+          </SignUpButton>
+          <Button
+            asChild
+            size="lg"
+            variant="outline"
+            className="w-full sm:w-auto"
+          >
+            <a href={EVA_SETUP_URL} target="_blank" rel="noreferrer">
+              Self-host it
+            </a>
+          </Button>
+        </div>
+
+        {/*
+          The whole product, four stages deep, without a single mock panel. One
+          column per stage on a wide screen so the four fit on one row and the
+          page stays roughly a screen tall; the hairlines between them are the
+          `gap-px` over a `bg-border` fill.
+        */}
+        <ul className="mt-12 grid gap-px overflow-hidden rounded-surface border border-border bg-border sm:grid-cols-2 lg:grid-cols-4">
+          {LANDING_PILLARS.map((pillar) => (
+            <li key={pillar.id} className="bg-background p-5">
+              <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground/70">
+                {pillar.step} · {pillar.label}
+              </p>
+              <p className="mt-2 text-sm font-medium text-foreground">
+                {pillar.tagline}
+              </p>
+              <dl className="mt-4 space-y-3">
+                {pillar.features.map((feature) => (
+                  <div key={feature.name} className="text-[13px] leading-snug">
+                    <dt className="flex items-center gap-1.5 font-medium text-foreground">
+                      <feature.icon
+                        size={15}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                      {feature.name}
+                    </dt>
+                    <dd className="mt-0.5 pl-[1.3rem] text-muted-foreground">
+                      {feature.summary}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </li>
+          ))}
+        </ul>
+      </main>
+
+      <footer className="border-t border-border">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-5 py-8 sm:flex-row sm:items-center sm:justify-between sm:px-8">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Eva</span> — MIT
+            licensed and free to self-host.
+          </p>
+          <ul className="flex flex-wrap items-center gap-x-4 gap-y-2">
+            {LANDING_STACK.map((item) => (
+              <li
+                key={item.name}
+                className="flex items-center gap-1.5 text-xs text-muted-foreground"
+              >
+                <BrandMark name={item.brand} size={14} />
+                {item.name}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_components/landing/LandingCompact.tsx
+++ b/apps/web/src/routes/_components/landing/LandingCompact.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { SignInButton, SignUpButton } from "@clerk/clerk-react";
-import { IconArrowRight, IconBrandGithub } from "@tabler/icons-react";
+import { SignInButton } from "@clerk/clerk-react";
+import { IconArrowRight } from "@tabler/icons-react";
 import { Button } from "@conductor/ui";
 import { BrandMark } from "./BrandMark";
 import {
-  EVA_GITHUB_URL,
-  EVA_SETUP_URL,
   LANDING_HERO_CAPABILITIES,
   LANDING_PILLARS,
   LANDING_STACK,
@@ -22,6 +20,10 @@ import {
  *
  * Deliberately static — no previews, no motion, no auto-cycling tabs. Anything
  * that needed those belongs on the full page.
+ *
+ * Sign-in is the only call to action here. There is no sign-up, no link to the
+ * repository and no licence line — the full page carries all of that, and this
+ * version is for instances that want a door rather than a pitch.
  */
 export function LandingCompact() {
   return (
@@ -41,45 +43,14 @@ export function LandingCompact() {
             </span>
           </span>
 
-          <div className="flex items-center gap-1.5">
-            <Button asChild variant="ghost" size="icon-sm">
-              <a
-                href={EVA_GITHUB_URL}
-                target="_blank"
-                rel="noreferrer"
-                aria-label="Eva on GitHub"
-              >
-                <IconBrandGithub size={18} />
-              </a>
-            </Button>
-            <SignInButton mode="modal">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="hidden text-muted-foreground hover:text-foreground sm:inline-flex"
-              >
-                Sign in
-              </Button>
-            </SignInButton>
-            <SignUpButton mode="modal">
-              <Button size="sm">Get started</Button>
-            </SignUpButton>
-          </div>
+          <SignInButton mode="modal">
+            <Button size="sm">Sign in</Button>
+          </SignInButton>
         </nav>
       </header>
 
       <main className="mx-auto w-full max-w-6xl flex-1 px-5 py-10 sm:px-8 sm:py-14">
-        <a
-          href={EVA_GITHUB_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="motion-base inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-xs text-muted-foreground shadow-sm hover:bg-muted/60 hover:text-foreground"
-        >
-          <span className="size-1.5 rounded-full bg-primary" />
-          Open source and MIT licensed
-        </a>
-
-        <h1 className="mt-6 max-w-3xl text-balance text-4xl font-semibold leading-[1.05] tracking-tight text-foreground sm:text-5xl">
+        <h1 className="max-w-3xl text-balance text-4xl font-semibold leading-[1.05] tracking-tight text-foreground sm:text-5xl">
           Your AI coworker ships pull requests.
         </h1>
 
@@ -101,23 +72,13 @@ export function LandingCompact() {
           ))}
         </ul>
 
-        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-          <SignUpButton mode="modal">
+        <div className="mt-8">
+          <SignInButton mode="modal">
             <Button size="lg" className="w-full sm:w-auto sm:min-w-[10rem]">
-              Get started
+              Sign in
               <IconArrowRight size={16} aria-hidden />
             </Button>
-          </SignUpButton>
-          <Button
-            asChild
-            size="lg"
-            variant="outline"
-            className="w-full sm:w-auto"
-          >
-            <a href={EVA_SETUP_URL} target="_blank" rel="noreferrer">
-              Self-host it
-            </a>
-          </Button>
+          </SignInButton>
         </div>
 
         {/*
@@ -159,8 +120,7 @@ export function LandingCompact() {
       <footer className="border-t border-border">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-5 py-8 sm:flex-row sm:items-center sm:justify-between sm:px-8">
           <p className="text-sm text-muted-foreground">
-            <span className="font-medium text-foreground">Eva</span> — MIT
-            licensed and free to self-host.
+            <span className="font-medium text-foreground">Eva</span> — built on
           </p>
           <ul className="flex flex-wrap items-center gap-x-4 gap-y-2">
             {LANDING_STACK.map((item) => (


### PR DESCRIPTION
The full marketing page is a long scroll with sixteen animated feature previews. Not every instance wants to serve that, so `VITE_NEW_LANDING` returns to choose between it and a new compact page.

The flag defaults the other way round from last time: `"true"` gets the full page, and anything else — including unset — gets the compact one.

## The compact page

One screen rather than the old basic page's hero-and-nothing:

- The same headline, intro and capability list as the full page.
- All sixteen features across four columns, one per stage of the workflow, each with its sidebar icon and its one-line summary.
- The stack logos in the footer.
- Static by design — no previews, no motion, no auto-cycling tabs. Anything that needs those belongs on the full page.

Roughly 1.3 screens at 1280x860, against 7,600px for the full page.

## Notes

- Both pages read `landingContent.ts`, so the flag chooses depth, not message. Changing a feature's summary changes it in both and neither can drift.
- The dev-only "Sign in as Eva" button moved into its own component so both pages render it. Flipping the flag no longer takes the shortcut away.
- The flag is `z.enum(["true", "false"])` rather than a boolean, because every Vite env value arrives as a string and `Boolean("false")` is `true`.
- README documents the variable in the web app env block.

## Verified

- Flag unset → compact page, 1,107px. Flag `"true"` → full page, 7,604px with the `#plan` anchor and the tab strips intact.
- Light and dark, all sixteen features and all seven stack logos rendering in both.
- `tsc --noEmit` clean, oxlint and prettier clean.
