### PR TITLE
fix(web): align sidebar section labels with nav icons

### DIFF
--- a/apps/web/src/lib/components/sidebar/SharedLayoutNav.tsx
+++ b/apps/web/src/lib/components/sidebar/SharedLayoutNav.tsx
@@ -98,7 +98,7 @@ export function sidebarNavLinkClass(
 
 /** Section group label above a cluster of sidebar nav rows (Build / Ship / …). */
 export const sidebarSectionLabelClass =
-  "px-3 py-1 text-[11px] font-medium tracking-[-0.01em] text-muted-foreground/55";
+  "px-4 py-1 text-[11px] font-medium tracking-[-0.01em] text-muted-foreground/55";
 
 export function sidebarNavLinkClassCompact(isActive: boolean): string {
   return cn(


### PR DESCRIPTION
## Summary
- Bumps sidebar section label padding (`px-3` → `px-4`) so Build/Ship/etc. line up with the nav row icons.

## Test plan
- [ ] Open a repo sidebar and confirm section titles (Build, Ship, …) align with the icons below them
- [ ] Check settings sidebar section labels still look correct

EOF