### PR TITLE
Prompt stash, queue flush, and turn reply fix

### DIFF
--- a/apps/web/src/globals.css
+++ b/apps/web/src/globals.css
@@ -359,6 +359,11 @@ html {
       clamp(0.75rem, var(--radius), 1.25rem);
   }
 
+  .rounded-t-surface {
+    border-radius: clamp(0.75rem, var(--radius), 1.25rem)
+      clamp(0.75rem, var(--radius), 1.25rem) 0 0;
+  }
+
   .rounded-menu-item {
     border-radius: min(var(--radius), 0.75rem);
   }

--- a/apps/web/src/lib/components/QueuedMessagesPanel.tsx
+++ b/apps/web/src/lib/components/QueuedMessagesPanel.tsx
@@ -205,8 +205,9 @@ function SortableQueuedItem({
 }
 
 /**
- * Pending-message queue above the composer on sandbox chat pages
- * (sessions, quick tasks, projects, designs). Built on AI Elements Queue.
+ * Pending-message queue flush above the composer on sandbox chat pages
+ * (sessions, quick tasks, projects). Narrower inset bar with square bottom
+ * corners so it blends into the input card — same idea as underCardLeading.
  */
 export function QueuedMessagesPanel({
   items,
@@ -268,7 +269,9 @@ export function QueuedMessagesPanel({
 
   return (
     <>
-      <Queue className="mb-2">
+      {/* Flush above the composer: narrower inset bar, square bottom so it
+          blends into the input card (mirrors underCardLeading below). */}
+      <Queue className="mx-auto mb-0 w-[calc(100%-1.5rem)] rounded-b-none rounded-t-surface bg-muted/50 shadow-none">
         <QueueSection defaultOpen>
           <QueueSectionTrigger>
             <QueueSectionLabel count={items.length} label={label} />

--- a/apps/web/src/lib/components/chat/ChatComposer.tsx
+++ b/apps/web/src/lib/components/chat/ChatComposer.tsx
@@ -29,6 +29,7 @@ import type { ChatDraftSeed } from "@/lib/components/chat/useChatDraftSeed";
 import { ChatTypeToFocus } from "@/lib/components/chat/ChatTypeToFocus";
 import { ChatTypingLayer } from "@/lib/components/chat/ChatTypingLayer";
 import { ComposerPlusMenu } from "@/lib/components/chat/_components/ComposerPlusMenu";
+import { ComposerStash } from "@/lib/components/chat/_components/ComposerStash";
 import { IconPlayerStop } from "@tabler/icons-react";
 import { useRef, type ReactNode } from "react";
 import { m, AnimatePresence } from "motion/react";
@@ -289,6 +290,12 @@ export function ChatComposer({
                     optionsSubmenu={optionsSubmenu}
                   />
                   {toolsBefore}
+                  <ComposerStash
+                    repoId={repoId}
+                    mentionRef={mentionRef}
+                    attachmentMode={attachmentMode}
+                    disabled={isInputDisabled}
+                  />
                 </PromptInputTools>
                 <div className="flex min-w-0 items-center gap-1">
                   <ModelSelect

--- a/apps/web/src/lib/components/chat/ChatComposer.tsx
+++ b/apps/web/src/lib/components/chat/ChatComposer.tsx
@@ -190,6 +190,7 @@ export function ChatComposer({
           </m.div>
         ) : null}
       </AnimatePresence>
+      {preInputContent}
       <QueuedMessagesPanel
         items={queuedMessageItems}
         renderContent={(content) => {
@@ -220,7 +221,6 @@ export function ChatComposer({
           await reorderQueuedMessages({ parentId, orderedIds });
         }}
       />
-      {preInputContent}
       <div className="relative">
         {isDraftLoading ? (
           // Placeholder that matches the input group's visual footprint.

--- a/apps/web/src/lib/components/chat/_components/ComposerStash.tsx
+++ b/apps/web/src/lib/components/chat/_components/ComposerStash.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { useHotkey } from "@tanstack/react-hotkeys";
+import { m } from "motion/react";
+import {
+  Command,
+  CommandEmpty,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  usePromptInputController,
+} from "@eva/ui";
+import { IconBookmark, IconX } from "@tabler/icons-react";
+import type { Id } from "@eva/backend";
+import { relativeTime } from "@/lib/components/artifacts/_format";
+import {
+  isImageContentType,
+  type ChatAttachmentMode,
+} from "@/lib/components/attachments/attachmentMeta";
+import { tokenizedToEditable } from "@/lib/components/mentions";
+import type { MentionTextareaHandle } from "@/lib/components/chat/MentionTextarea";
+import {
+  useComposerStash,
+  type PromptStashEntry,
+} from "@/lib/components/chat/_components/useComposerStash";
+
+function previewSnippet(tokenized: string, maxLength = 90): string {
+  const { displayText } = tokenizedToEditable(tokenized);
+  const singleLine = displayText.replace(/\s+/g, " ").trim();
+  if (singleLine.length === 0) return "(attachments only)";
+  if (singleLine.length <= maxLength) return singleLine;
+  return `${singleLine.slice(0, maxLength - 1)}…`;
+}
+
+function ComposerStashItem({
+  entry,
+  onSelect,
+  onDelete,
+}: {
+  entry: PromptStashEntry;
+  onSelect: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <CommandItem
+      value={entry._id}
+      onSelect={onSelect}
+      className="group flex cursor-pointer items-start gap-2 aria-selected:bg-muted"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm text-foreground">
+          {previewSnippet(entry.content)}
+        </p>
+        <div className="mt-1 flex items-center gap-2">
+          {entry.attachments.length > 0 ? (
+            <div className="flex items-center gap-1">
+              {entry.attachments.slice(0, 3).map((attachment) =>
+                isImageContentType(attachment.contentType) ? (
+                  <img
+                    key={attachment.url}
+                    src={attachment.url}
+                    alt=""
+                    className="size-8 rounded-surface border border-border object-cover"
+                  />
+                ) : (
+                  <span
+                    key={attachment.url}
+                    className="flex size-8 items-center justify-center rounded-surface border border-border bg-muted text-[10px] text-muted-foreground"
+                  >
+                    file
+                  </span>
+                ),
+              )}
+            </div>
+          ) : null}
+          <span className="text-xs text-muted-foreground">
+            {relativeTime(entry._creationTime)}
+          </span>
+        </div>
+      </div>
+      <button
+        type="button"
+        aria-label="Delete stash"
+        className="shrink-0 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+        onClick={(event) => {
+          event.stopPropagation();
+          onDelete();
+        }}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <IconX className="size-3.5" />
+      </button>
+    </CommandItem>
+  );
+}
+
+/**
+ * Footer pill + ⌘S stash/restore for the shared chat composer.
+ * Hotkey is gated on composer focus (or open picker) so it does not steal
+ * browser save from other fields on the page.
+ */
+export function ComposerStash({
+  repoId,
+  mentionRef,
+  attachmentMode,
+  disabled,
+}: {
+  repoId: Id<"githubRepos">;
+  mentionRef: RefObject<MentionTextareaHandle | null>;
+  attachmentMode: ChatAttachmentMode;
+  disabled: boolean;
+}) {
+  const { textInput, attachments } = usePromptInputController();
+  const { entries, stash, restore, removeEntry } = useComposerStash({
+    repoId,
+    mentionRef,
+    attachmentMode,
+  });
+
+  const [open, setOpen] = useState(false);
+  const [composerFocused, setComposerFocused] = useState(false);
+  const [pulseKey, setPulseKey] = useState(0);
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const commandRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const form = anchorRef.current?.closest("form");
+    if (!form) return;
+
+    const onFocusIn = () => {
+      setComposerFocused(true);
+    };
+    const onFocusOut = () => {
+      requestAnimationFrame(() => {
+        if (open) return;
+        if (form.contains(document.activeElement)) {
+          setComposerFocused(true);
+          return;
+        }
+        setComposerFocused(false);
+      });
+    };
+
+    form.addEventListener("focusin", onFocusIn);
+    form.addEventListener("focusout", onFocusOut);
+    return () => {
+      form.removeEventListener("focusin", onFocusIn);
+      form.removeEventListener("focusout", onFocusOut);
+    };
+  }, [open]);
+
+  const hotkeyEnabled = !disabled && (composerFocused || open);
+
+  useHotkey(
+    "Mod+S",
+    (event) => {
+      event.preventDefault();
+      if (disabled) return;
+
+      const isEmpty =
+        textInput.value.trim().length === 0 && attachments.files.length === 0;
+      if (isEmpty) {
+        setOpen((prev) => !prev);
+        return;
+      }
+
+      void stash().then((ok) => {
+        if (ok) setPulseKey((key) => key + 1);
+      });
+    },
+    { enabled: hotkeyEnabled, requireReset: true },
+  );
+
+  const newestId = entries[0]?._id;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen} modal={false}>
+      <PopoverAnchor asChild>
+        <span
+          ref={anchorRef}
+          className={
+            entries.length > 0
+              ? "inline-flex"
+              : "inline-flex size-0 overflow-hidden"
+          }
+        >
+          {entries.length > 0 ? (
+            <m.button
+              key={pulseKey}
+              type="button"
+              initial={{ scale: 0.9 }}
+              animate={{ scale: 1 }}
+              transition={{ type: "spring", stiffness: 420, damping: 22 }}
+              className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-muted px-2 text-xs text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+              onClick={() => setOpen((prev) => !prev)}
+              title="Prompt stash"
+              aria-label={`Prompt stash, ${entries.length} saved`}
+            >
+              <IconBookmark className="size-3.5" />
+              <span>{entries.length}</span>
+            </m.button>
+          ) : null}
+        </span>
+      </PopoverAnchor>
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-80 p-0"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          commandRef.current?.focus();
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <Command
+          ref={commandRef}
+          shouldFilter={false}
+          defaultValue={newestId}
+          className="border-0 outline-none"
+          tabIndex={-1}
+        >
+          <CommandList className="max-h-72 p-1">
+            <CommandEmpty className="px-3 py-6 text-center text-sm text-muted-foreground">
+              Nothing stashed. Press ⌘S with a draft to stash it.
+            </CommandEmpty>
+            {entries.map((entry) => (
+              <ComposerStashItem
+                key={entry._id}
+                entry={entry}
+                onSelect={() => {
+                  void restore(entry).then((ok) => {
+                    if (ok) setOpen(false);
+                  });
+                }}
+                onDelete={() => {
+                  void removeEntry(entry._id);
+                }}
+              />
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/lib/components/chat/_components/useComposerStash.ts
+++ b/apps/web/src/lib/components/chat/_components/useComposerStash.ts
@@ -1,0 +1,226 @@
+"use client";
+
+import { useRef, type RefObject } from "react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import type { FunctionReturnType } from "convex/server";
+import { api, type Id } from "@eva/backend";
+import { toast, usePromptInputController } from "@eva/ui";
+import {
+  isAllowedAttachmentFile,
+  labelForAttachment,
+  MAX_CHAT_ATTACHMENTS,
+  type ChatAttachmentMode,
+} from "@/lib/components/attachments/attachmentMeta";
+import { useUploadChatAttachments } from "@/lib/components/chat/imageAttachments";
+import { tokenizedToEditable } from "@/lib/components/mentions";
+import type { MentionTextareaHandle } from "@/lib/components/chat/MentionTextarea";
+
+export type PromptStashEntry = FunctionReturnType<
+  typeof api.promptStash.listForRepo
+>[number];
+
+type StashAttachment = PromptStashEntry["attachments"][number];
+
+function filenameForAttachment(contentType: string | null): string {
+  return labelForAttachment(undefined, contentType);
+}
+
+function contentTypeForFile(
+  contentType: string | null,
+  blobType: string,
+): string {
+  if (contentType === null || contentType === "") return blobType;
+  return contentType;
+}
+
+/** Fetches stash attachment URLs into File objects. Returns null on any failure. */
+async function filesFromStashAttachments(
+  attachments: StashAttachment[],
+): Promise<File[] | null> {
+  const files: File[] = [];
+  for (const attachment of attachments) {
+    try {
+      const response = await fetch(attachment.url);
+      if (!response.ok) return null;
+      const blob = await response.blob();
+      const type = contentTypeForFile(attachment.contentType, blob.type);
+      files.push(
+        new File([blob], filenameForAttachment(attachment.contentType), {
+          type,
+        }),
+      );
+    } catch {
+      return null;
+    }
+  }
+  return files;
+}
+
+/**
+ * Live prompt-stash queue for one repo + helpers to stash / restore / remove.
+ * Bind list query directly — never mirror into React state.
+ */
+export function useComposerStash({
+  repoId,
+  mentionRef,
+  attachmentMode,
+}: {
+  repoId: Id<"githubRepos">;
+  mentionRef: RefObject<MentionTextareaHandle | null>;
+  attachmentMode: ChatAttachmentMode;
+}) {
+  const { textInput, attachments } = usePromptInputController();
+  const uploadChatAttachments = useUploadChatAttachments(attachmentMode);
+  const entries = useQuery(api.promptStash.listForRepo, { repoId }) ?? [];
+
+  const addStash = useMutation(api.promptStash.add);
+  const removeStash = useMutation(api.promptStash.remove).withOptimisticUpdate(
+    (localStore, args) => {
+      const current = localStore.getQuery(api.promptStash.listForRepo, {
+        repoId,
+      });
+      if (current === undefined) return;
+      localStore.setQuery(
+        api.promptStash.listForRepo,
+        { repoId },
+        current.filter((entry) => entry._id !== args.id),
+      );
+    },
+  );
+
+  const isStashingRef = useRef(false);
+  const isRestoringRef = useRef(false);
+
+  const stash = async (): Promise<boolean> => {
+    if (isStashingRef.current) return false;
+    isStashingRef.current = true;
+
+    const visible = textInput.value;
+    const files = attachments.files;
+    const trimmed = visible.trim();
+    if (trimmed.length === 0 && files.length === 0) {
+      isStashingRef.current = false;
+      return false;
+    }
+
+    // Snapshot before any await so concurrent edits don't race the clear.
+    const visibleSnapshot = visible;
+    const filesSnapshot = files;
+    // Resolved outside try — React Compiler bails on ?? / ?. inside try/catch.
+    const editor = mentionRef.current;
+    const tokenized = editor
+      ? editor.tokenize(visibleSnapshot.trim())
+      : visibleSnapshot.trim();
+
+    let attachmentStorageIds: Id<"_storage">[] = [];
+    try {
+      if (filesSnapshot.length > 0) {
+        attachmentStorageIds = await uploadChatAttachments(filesSnapshot);
+        // Stricter than send: stash clears the composer, so partial upload
+        // must abort and leave the draft untouched.
+        if (attachmentStorageIds.length !== filesSnapshot.length) {
+          toast.error("Could not upload attachments to stash.");
+          isStashingRef.current = false;
+          return false;
+        }
+      }
+    } catch {
+      toast.error("Could not upload attachments to stash.");
+      isStashingRef.current = false;
+      return false;
+    }
+
+    const storageIdsArg =
+      attachmentStorageIds.length > 0 ? attachmentStorageIds : undefined;
+
+    try {
+      // Orphaned blobs if add throws after upload — same accepted risk as send.
+      const result = await addStash({
+        repoId,
+        content: tokenized,
+        attachmentStorageIds: storageIdsArg,
+      });
+
+      textInput.clear();
+      attachments.clear();
+
+      if (result.evicted) {
+        toast.message("Oldest stash removed (limit 20 per app).");
+      }
+
+      isStashingRef.current = false;
+      return true;
+    } catch {
+      toast.error("Could not stash prompt.");
+      isStashingRef.current = false;
+      return false;
+    }
+  };
+
+  const restore = async (entry: PromptStashEntry): Promise<boolean> => {
+    if (isRestoringRef.current) return false;
+    isRestoringRef.current = true;
+
+    for (const attachment of entry.attachments) {
+      const mediaType =
+        attachment.contentType === null ? undefined : attachment.contentType;
+      if (!isAllowedAttachmentFile(attachmentMode, { mediaType })) {
+        toast.error("This stash has attachments this composer cannot accept.");
+        isRestoringRef.current = false;
+        return false;
+      }
+    }
+
+    if (
+      attachments.files.length + entry.attachments.length >
+      MAX_CHAT_ATTACHMENTS
+    ) {
+      toast.error(`You can attach up to ${MAX_CHAT_ATTACHMENTS} files.`);
+      isRestoringRef.current = false;
+      return false;
+    }
+
+    const restoredFiles = await filesFromStashAttachments(entry.attachments);
+    if (restoredFiles === null) {
+      toast.error("Could not load stashed attachments.");
+      isRestoringRef.current = false;
+      return false;
+    }
+
+    const { displayText, mentionMap, skillMap } = tokenizedToEditable(
+      entry.content,
+    );
+    mentionRef.current?.addTokenMaps(mentionMap, skillMap);
+
+    const current = textInput.value;
+    const next =
+      current.trim() === "" ? displayText : `${current}\n\n${displayText}`;
+    textInput.setInput(next);
+
+    if (restoredFiles.length > 0) {
+      attachments.add(restoredFiles);
+    }
+    mentionRef.current?.focus();
+
+    try {
+      await removeStash({ id: entry._id });
+    } catch {
+      // Content already restored — leave the entry so it is not lost.
+      toast.error("Restored, but could not remove stash entry.");
+    }
+
+    isRestoringRef.current = false;
+    return true;
+  };
+
+  const removeEntry = async (id: Id<"promptStashes">): Promise<void> => {
+    try {
+      await removeStash({ id });
+    } catch {
+      toast.error("Could not delete stash.");
+    }
+  };
+
+  return { entries, stash, restore, removeEntry };
+}

--- a/apps/web/src/lib/components/mentions/MentionEditor.tsx
+++ b/apps/web/src/lib/components/mentions/MentionEditor.tsx
@@ -58,6 +58,14 @@ export interface MentionEditorHandle {
   insertMention: (item: MentionItem) => void;
   /** Append a /skill chip (and trailing space) to the current draft. */
   insertSkill: (item: SlashItem) => void;
+  /**
+   * Merge label→id maps from restored tokenized content (e.g. prompt stash)
+   * without wiping chips already in the live draft.
+   */
+  addTokenMaps: (
+    mentions: Map<string, string>,
+    skills: Map<string, string>,
+  ) => void;
 }
 
 export interface MentionEditorProps<TItem extends MentionItem = MentionItem> {
@@ -476,6 +484,10 @@ export function MentionEditor<TItem extends MentionItem = MentionItem>({
       focus: () => editorRef.current?.focus(),
       insertMention: (item: MentionItem) => appendToken("@", item, "mention"),
       insertSkill: (item: SlashItem) => appendToken("/", item, "skill"),
+      addTokenMaps: (mentions, skills) => {
+        setMentionMap((prev) => new Map([...prev, ...mentions]));
+        setSkillMap((prev) => new Map([...prev, ...skills]));
+      },
     }),
     [mentionMap, skillMap, value, onValueChange],
   );

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Working bubble no longer replays the previous reply - 2026-07-30
+
+The warm session daemon sent its final streaming reconcile AFTER the completion mutation, behind a ~5s transcript copy. Queued dequeues (which start inside the completion mutation) and quick manual follow-ups began the next turn within that window, so the late reconcile resurrected the finished turn's full reply into the streaming row — and the new turn's Working bubble rendered the previous answer until the real reply landed. The reconcile now runs before completion; the daemon never writes streaming state after a turn completes. The startExecute/dequeue clears remain as defence in depth for old warm daemons and one-shot providers.
+
+## Session replies no longer regress after delayed publish failures - 2026-07-30
+
+Session replies are saved before Eva publishes the sandbox branch so users are not left waiting on Git. A delayed push failure could therefore arrive after the next regular or queued turn had started, reuse the generic result finaliser, and temporarily replace that turn with the previous answer. Publish failures now become isolated system alerts and cannot clear or overwrite the active turn.
+
 ## Prompt stash (⌘S) - 2026-07-30
 
 Typing a follow-up meant losing an in-progress draft or juggling browser tabs. ⌘S now stashes the composer (text + attachments) into a per-user per-repo Convex queue and clears the input; ⌘S on an empty composer (or the footer pill) opens a picker to restore or delete. Restore appends into the current draft and consumes the entry — model/mode/traits stay untouched. Kept separate from autosaved `drafts` (one live WIP per surface); see `internal/docs/prompt-stash-vs-drafts.md`.

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Prompt stash (⌘S) - 2026-07-30
+
+Typing a follow-up meant losing an in-progress draft or juggling browser tabs. ⌘S now stashes the composer (text + attachments) into a per-user per-repo Convex queue and clears the input; ⌘S on an empty composer (or the footer pill) opens a picker to restore or delete. Restore appends into the current draft and consumes the entry — model/mode/traits stay untouched. Kept separate from autosaved `drafts` (one live WIP per surface); see `internal/docs/prompt-stash-vs-drafts.md`.
+
 ## Auto-detect yarn/npm/pip in snapshot + session installs - 2026-07-30
 
 Snapshot seed hardcoded `pnpm install`, so any repo without `pnpm-lock.yaml` failed at `SEEDRUN-FAILED:install`. Seed and session paths now pick the Node manager from the root lockfile (pnpm still fatal; yarn/npm warn and continue) and best-effort `pip install` for root `requirements.txt` / `pyproject.toml`. Snapshot fingerprint collects all Node + Python manifests so polyglot repos rebuild when either side changes; session restore splits Node vs Python drift so a requirements-only change cannot kill the session on a yarn reinstall.

--- a/internal/docs/prompt-stash-vs-drafts.md
+++ b/internal/docs/prompt-stash-vs-drafts.md
@@ -1,0 +1,26 @@
+# Prompt stash vs drafts
+
+Two different composer persistence products — keep them on separate tables.
+
+## Drafts (`drafts`)
+
+- **What:** the single live WIP for one input surface (session chat, project chat, task chat, task comment).
+- **Cardinality:** one row per `(user, surface target)` — upsert; empty content deletes the row.
+- **Lifecycle:** autosaved on every keystroke; restored when you reopen that surface.
+- **Scope key:** `sessionId` / `projectId` / `taskId` (+ comment parent), not "the whole app".
+- **Contents today:** tokenized text only (attachments are not persisted on drafts yet).
+
+Many drafts can exist inside one app because each session/task/project has its own surface — that is still not a stash queue.
+
+## Prompt stashes (`promptStashes`)
+
+- **What:** an explicit queue of frozen composer snapshots (git-stash for the prompt).
+- **Cardinality:** many rows per `(user, repo)`, capped (20); oldest evicted.
+- **Lifecycle:** ⌘S saves and clears the composer; restore appends into the current draft and **consumes** the entry.
+- **Scope key:** per-user per-repo (shared across new-session + in-session composers for that app).
+- **Contents:** tokenized text + optional Convex attachment storage IDs.
+- **Does not touch:** model, mode, traits, or account selection on restore.
+
+## Why not one table
+
+Merging would force drafts to grow multi-row queue semantics, blob eviction, and "is this a WIP or a frozen snapshot?" branches on every draft read/write — while stash would inherit surface-target FKs it does not use. Share upload/tokenize/restore helpers if useful; keep the tables and APIs separate.

--- a/packages/backend/callback-src/providers/claudeSdkDaemon.ts
+++ b/packages/backend/callback-src/providers/claudeSdkDaemon.ts
@@ -404,6 +404,16 @@ async function finalizeTurn(output: string): Promise<void> {
   if (S.pendingQuestionData) {
     completionArgs.pendingQuestion = S.pendingQuestionData;
   }
+  // Final streaming reconcile BEFORE completion. The completion mutation
+  // finalizes the assistant message, after which the server clears the
+  // streaming row and may immediately dequeue the next queued turn — so this
+  // daemon must not write streaming state past that point. When this ran
+  // post-completion it landed after that clear and resurrected this turn's
+  // full reply text into the row, which the NEXT turn's placeholder rendered
+  // as its response until the real reply arrived (stale-reply bug).
+  // setFinalizingState (not plain flushStreaming, which would early-return on
+  // the already-drained buffer) pushes the now-complete steps and final text.
+  await setFinalizingState();
   // Proof: media before completion so the workflow's hasMediaForRun check does
   // not spuriously retry. Chat/coding: completion first so attachMedia can patch
   // the assistant message that was just written.
@@ -418,18 +428,13 @@ async function finalizeTurn(output: string): Promise<void> {
       (Date.now() - completionSentAt) +
       "ms)",
   );
-  // Persist the Claude transcript to the volume for restart recovery, and send a
-  // final streaming reconcile. Both run AFTER completion so the ~5s synchronous
-  // transcript copy never delays the reply the user is waiting on. The sandbox
-  // stays warm between turns, so this only guards against a sandbox restart.
-  // accumulatedSteps is still populated (resetTurnState runs after this returns).
-  // setFinalizingState pushes the now-complete steps to the streaming heartbeat;
-  // the buffer was already drained at the top of finalizeTurn, so a plain
-  // flushStreaming() here would early-return without reflecting the completed
-  // status.
+  // Persist the Claude transcript to the volume for restart recovery. Runs
+  // AFTER completion so the ~5s synchronous transcript copy never delays the
+  // reply the user is waiting on. The sandbox stays warm between turns, so
+  // this only guards against a sandbox restart. accumulatedSteps is still
+  // populated (resetTurnState runs after this returns).
   const bookkeepingAt = Date.now();
   syncClaudeStateToPersist("daemon-turn");
-  await setFinalizingState();
   log(
     "daemon: post-turn bookkeeping took " + (Date.now() - bookkeepingAt) + "ms",
   );

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -254,6 +254,7 @@ import type * as projectChatWorkflow from "../projectChatWorkflow.js";
 import type * as projectInterviewWorkflow from "../projectInterviewWorkflow.js";
 import type * as projectSandboxWorkflow from "../projectSandboxWorkflow.js";
 import type * as projects from "../projects.js";
+import type * as promptStash from "../promptStash.js";
 import type * as prompts_design from "../prompts/design.js";
 import type * as prompts_doc from "../prompts/doc.js";
 import type * as prompts_index from "../prompts/index.js";
@@ -561,6 +562,7 @@ declare const fullApi: ApiFromModules<{
   projectInterviewWorkflow: typeof projectInterviewWorkflow;
   projectSandboxWorkflow: typeof projectSandboxWorkflow;
   projects: typeof projects;
+  promptStash: typeof promptStash;
   "prompts/design": typeof prompts_design;
   "prompts/doc": typeof prompts_doc;
   "prompts/index": typeof prompts_index;

--- a/packages/backend/convex/_queues/helpers.ts
+++ b/packages/backend/convex/_queues/helpers.ts
@@ -60,11 +60,11 @@ export async function startNextQueuedSessionMessage(
   }
 
   // Wipe any stale streaming row before the new turn's placeholder appears —
-  // the daemon's post-completion reconcile heartbeat can land after
-  // saveResult's clear and resurrect the finished turn's activity (see
-  // startExecute in _sessions/execution.ts for the full race). Every dequeue
-  // below does this, because not every caller clears first: _sessions/sandbox.ts
-  // drains queued turns straight after a resume, with no clear of its own.
+  // a leftover row (old warm daemon, one-shot provider, crashed turn) would
+  // render the finished turn's reply/activity under the new placeholder (see
+  // startExecute in _sessions/execution.ts). Every dequeue below does this,
+  // because not every caller clears first: _sessions/sandbox.ts drains queued
+  // turns straight after a resume, with no clear of its own.
   await clearStreamingActivity(ctx, String(sessionId));
 
   const now = Date.now();

--- a/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
+++ b/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
@@ -4669,6 +4669,7 @@ async function finalizeTurn(output) {
   if (callbackState.pendingQuestionData) {
     completionArgs.pendingQuestion = callbackState.pendingQuestionData;
   }
+  await setFinalizingState();
   const completionSentAt = Date.now();
   await deliverCompletionWithMedia(completionArgs);
   log(
@@ -4676,7 +4677,6 @@ async function finalizeTurn(output) {
   );
   const bookkeepingAt = Date.now();
   syncClaudeStateToPersist("daemon-turn");
-  await setFinalizingState();
   log(
     "daemon: post-turn bookkeeping took " + (Date.now() - bookkeepingAt) + "ms"
   );

--- a/packages/backend/convex/_sessions/execution.ts
+++ b/packages/backend/convex/_sessions/execution.ts
@@ -94,11 +94,13 @@ export const startExecute = authMutation({
       }
     }
 
-    // Wipe any stale streaming row before staging the placeholder. The daemon's
-    // post-completion reconcile heartbeat (finalizeTurn -> setFinalizingState)
-    // races saveResult's clearStreamingActivity; when it loses, a row holding
-    // the finished turn's full activity survives, and the new placeholder below
-    // would flash the previous turn's thinking trace until the next heartbeat.
+    // Wipe any stale streaming row before staging the placeholder. The daemon
+    // sends its final reconcile heartbeat BEFORE the completion mutation (see
+    // finalizeTurn in callback-src/providers/claudeSdkDaemon.ts), so it no
+    // longer resurrects the row post-clear; this clear stays as defence in
+    // depth — old warm daemons, one-shot providers, and crashed turns can
+    // still leave a row holding the finished turn's reply/activity, which the
+    // new placeholder below would render as its own response.
     await clearStreamingActivity(ctx, String(args.sessionId));
 
     // Daemon-pull dispatch: stage the turn for a warm daemon to claim in one

--- a/packages/backend/convex/_sessions/resultTarget.ts
+++ b/packages/backend/convex/_sessions/resultTarget.ts
@@ -13,6 +13,29 @@ type AssistantReply = {
   finishedAt?: number;
 };
 
+const SESSION_PUBLISH_FAILURE_PREFIX =
+  "Session completed locally, but Eva could not publish";
+
+/**
+ * A publish failure reported after the assistant reply was already saved.
+ *
+ * This is not another turn result: treating it as one can overwrite a newer
+ * placeholder when the user sends again while the previous branch is pushing.
+ */
+export function delayedPublishFailureError(
+  result: string | null,
+  error: string | null,
+): string | undefined {
+  if (
+    result === null ||
+    error === null ||
+    !error.startsWith(SESSION_PUBLISH_FAILURE_PREFIX)
+  ) {
+    return undefined;
+  }
+  return error;
+}
+
 /**
  * The message a turn's result should be written to, given the newest messages
  * first.

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -25,7 +25,11 @@ import { resolveMessageTokens } from "../_mentions/resolveMessageTokens";
 import { buildCustomInstructionsBlock } from "../prompts";
 import { buildPlanPrompt, buildEditPrompt, buildDesignPrompt } from "./prompts";
 import { z } from "zod";
-import { orphanPlaceholderMessages, resultTargetMessage } from "./resultTarget";
+import {
+  delayedPublishFailureError,
+  orphanPlaceholderMessages,
+  resultTargetMessage,
+} from "./resultTarget";
 import { isUnclaimedOpenTurn } from "./pendingTurnRecovery";
 import type { QueryCtx, MutationCtx } from "../_generated/server";
 import type { Doc, Id } from "../_generated/dataModel";
@@ -820,10 +824,28 @@ export const saveResult = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    await clearStreamingActivity(ctx, String(args.sessionId));
-
     const session = await ctx.db.get(args.sessionId);
     if (!session) return null;
+
+    // The reply is saved before Eva pushes the branch. If that slower push
+    // later fails, a newer turn may already be running. Report the publish
+    // failure independently: running normal result finalisation again would
+    // overwrite the newer placeholder and clear its streaming state.
+    const publishError = delayedPublishFailureError(args.result, args.error);
+    if (publishError !== undefined) {
+      await ctx.db.insert("messages", {
+        parentId: args.sessionId,
+        role: "assistant",
+        content: "Failed to publish session branch",
+        timestamp: Date.now(),
+        isSystemAlert: true,
+        errorDetail: publishError,
+      });
+      await ctx.db.patch(args.sessionId, { updatedAt: Date.now() });
+      return null;
+    }
+
+    await clearStreamingActivity(ctx, String(args.sessionId));
 
     const recent = await ctx.db
       .query("messages")
@@ -832,13 +854,6 @@ export const saveResult = internalMutation({
       .take(20);
     const last = resultTargetMessage(recent);
     if (!last) return null;
-
-    const publishFailedAfterResult =
-      args.result !== null &&
-      args.error !== null &&
-      args.error.startsWith(
-        "Session completed locally, but Eva could not publish",
-      );
 
     const isDesignTurn = last.mode === "design";
     const designParsed =
@@ -860,7 +875,7 @@ export const saveResult = internalMutation({
       content:
         designParsed !== null
           ? designParsed.summary || "Here are the design variations:"
-          : args.success || publishFailedAfterResult
+          : args.success
             ? args.result || "I couldn't process your message."
             : `Error: ${args.error || "Unknown error during execution."}`,
       finishedAt: Date.now(),

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -774,6 +774,10 @@ export const docVersionDraftFields = {
 // One row per (user, surface target). `kind` names the input surface so the
 // table stays extensible. Exactly one target FK group is set, matching `kind`.
 // Content is stored TOKENIZED (@[Label](id)) so mentions survive reload.
+//
+// Drafts ≠ prompt stashes: a draft is the single live WIP for one composer
+// surface (autosaved upsert). A prompt stash is an explicit multi-entry queue
+// of frozen snapshots (see `promptStashFields`) — do not merge the tables.
 export const draftFields = {
   userId: v.id("users"),
   repoId: v.id("githubRepos"),
@@ -789,6 +793,16 @@ export const draftFields = {
   sessionId: v.optional(v.id("sessions")),
   content: v.string(),
   updatedAt: v.number(),
+};
+
+// Per-user per-repo queue of frozen composer snapshots (⌘S). Cap enforced in
+// `promptStash.ts`. Content is tokenized; "" allowed for attachment-only.
+// Ordering uses Convex `_creationTime` (no separate createdAt).
+export const promptStashFields = {
+  userId: v.id("users"),
+  repoId: v.id("githubRepos"),
+  content: v.string(),
+  attachmentStorageIds: v.optional(v.array(v.id("_storage"))),
 };
 
 export const evaluationReportFields = {

--- a/packages/backend/convex/promptStash.ts
+++ b/packages/backend/convex/promptStash.ts
@@ -1,0 +1,144 @@
+import { v } from "convex/values";
+import { authMutation, authQuery, hasRepoAccess } from "./functions";
+import { promptStashFields } from "./validators";
+
+/** Max stashed prompts per user per repo; oldest (`_creationTime`) is evicted. */
+const MAX_STASHES_PER_REPO = 20;
+
+const promptStashAttachmentValidator = v.object({
+  url: v.string(),
+  contentType: v.union(v.string(), v.null()),
+});
+
+const promptStashListItemValidator = v.object({
+  _id: v.id("promptStashes"),
+  _creationTime: v.number(),
+  ...promptStashFields,
+  attachments: v.array(promptStashAttachmentValidator),
+});
+
+/**
+ * Prompt stash (⌘S) — frozen composer snapshots, not live drafts.
+ *
+ * Drafts (`drafts` table): one autosaved WIP per chat/comment surface.
+ * Stashes (this table): many explicit queue entries per user+repo; restore
+ * appends into the current composer and consumes the entry. See
+ * `internal/docs/prompt-stash-vs-drafts.md`.
+ */
+
+/** Saves a composer snapshot; evicts the oldest row when over the per-repo cap. */
+export const add = authMutation({
+  args: {
+    repoId: v.id("githubRepos"),
+    content: v.string(),
+    attachmentStorageIds: v.optional(v.array(v.id("_storage"))),
+  },
+  returns: v.object({ evicted: v.boolean() }),
+  handler: async (ctx, args) => {
+    if (!(await hasRepoAccess(ctx.db, args.repoId, ctx.userId))) {
+      throw new Error("Not authorized");
+    }
+
+    const attachmentStorageIds = args.attachmentStorageIds ?? [];
+    const hasText = args.content.trim().length > 0;
+    if (!hasText && attachmentStorageIds.length === 0) {
+      throw new Error("Stash cannot be empty");
+    }
+
+    const existing = await ctx.db
+      .query("promptStashes")
+      .withIndex("by_user_and_repo", (q) =>
+        q.eq("userId", ctx.userId).eq("repoId", args.repoId),
+      )
+      .order("asc")
+      .collect();
+
+    let evicted = false;
+    while (existing.length >= MAX_STASHES_PER_REPO) {
+      const oldest = existing.shift();
+      if (!oldest) break;
+      await ctx.db.delete(oldest._id);
+      for (const storageId of oldest.attachmentStorageIds ?? []) {
+        await ctx.storage.delete(storageId);
+      }
+      evicted = true;
+    }
+
+    await ctx.db.insert("promptStashes", {
+      userId: ctx.userId,
+      repoId: args.repoId,
+      content: args.content,
+      attachmentStorageIds:
+        attachmentStorageIds.length > 0 ? attachmentStorageIds : undefined,
+    });
+
+    return { evicted };
+  },
+});
+
+/** Lists the current user's stashes for a repo, newest first, with attachment URLs. */
+export const listForRepo = authQuery({
+  args: { repoId: v.id("githubRepos") },
+  returns: v.array(promptStashListItemValidator),
+  handler: async (ctx, args) => {
+    if (!(await hasRepoAccess(ctx.db, args.repoId, ctx.userId))) {
+      return [];
+    }
+
+    const rows = await ctx.db
+      .query("promptStashes")
+      .withIndex("by_user_and_repo", (q) =>
+        q.eq("userId", ctx.userId).eq("repoId", args.repoId),
+      )
+      .order("desc")
+      .collect();
+
+    return Promise.all(
+      rows.map(async (row) => {
+        const attachments: Array<{
+          url: string;
+          contentType: string | null;
+        }> = [];
+        for (const storageId of row.attachmentStorageIds ?? []) {
+          const [url, meta] = await Promise.all([
+            ctx.storage.getUrl(storageId),
+            ctx.storage.getMetadata(storageId),
+          ]);
+          if (url === null) continue;
+          attachments.push({
+            url,
+            contentType: meta?.contentType ?? null,
+          });
+        }
+        return {
+          ...row,
+          attachments,
+        };
+      }),
+    );
+  },
+});
+
+/**
+ * Deletes a stash row and its blobs. Idempotent if missing. Owner-only.
+ * Used for hover-delete and restore-consume.
+ */
+export const remove = authMutation({
+  args: { id: v.id("promptStashes") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.id);
+    if (!row) {
+      return null;
+    }
+    if (row.userId !== ctx.userId) {
+      throw new Error("Not authorized");
+    }
+
+    await ctx.db.delete(args.id);
+    for (const storageId of row.attachmentStorageIds ?? []) {
+      await ctx.storage.delete(storageId);
+    }
+    return null;
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -42,6 +42,7 @@ import {
   docVersionFields,
   docVersionDraftFields,
   draftFields,
+  promptStashFields,
   evaluationReportFields,
   artifactFields,
   repoEntityCounterFields,
@@ -49,396 +50,397 @@ import {
   backgroundProcessFields,
 } from "./validators";
 
-const schema = defineSchema(
-  {
-    users: defineTable(userFields)
-      .index("by_clerk_id", ["clerkId"])
-      .index("by_email", ["email"]),
+const schema = defineSchema({
+  users: defineTable(userFields)
+    .index("by_clerk_id", ["clerkId"])
+    .index("by_email", ["email"]),
 
-    artifacts: defineTable(artifactFields)
-      .index("by_team", ["boundTeamId"])
-      .index("by_uploader", ["uploadedBy"]),
+  artifacts: defineTable(artifactFields)
+    .index("by_team", ["boundTeamId"])
+    .index("by_uploader", ["uploadedBy"]),
 
-    projects: defineTable(projectFields)
-      .index("by_repo", ["repoId"])
-      .index("by_user", ["userId"])
-      .index("by_repo_and_phase", ["repoId", "phase"])
-      .index("by_pr_url", ["prUrl"])
-      .index("by_repo_and_numId", ["repoId", "numId"])
-      .index("by_repo_and_sandbox_status", [
-        "repoId",
-        "reviewProjectSandboxStatus",
-      ]),
-
-    projectDetails: defineTable(projectDetailsFields).index("by_project", [
-      "projectId",
+  projects: defineTable(projectFields)
+    .index("by_repo", ["repoId"])
+    .index("by_user", ["userId"])
+    .index("by_repo_and_phase", ["repoId", "phase"])
+    .index("by_pr_url", ["prUrl"])
+    .index("by_repo_and_numId", ["repoId", "numId"])
+    .index("by_repo_and_sandbox_status", [
+      "repoId",
+      "reviewProjectSandboxStatus",
     ]),
 
-    agentTasks: defineTable(agentTaskFields)
-      .index("by_repo", ["repoId"])
-      .index("by_repo_and_status", ["repoId", "status"])
-      .index("by_repo_and_updatedAt", ["repoId", "updatedAt"])
-      .index("by_project", ["projectId"])
-      .index("by_project_and_status", ["projectId", "status"])
-      .index("by_repo_and_numId", ["repoId", "numId"])
-      .index("by_repo_and_sandbox_status", [
-        "repoId",
-        "reviewTaskSandboxStatus",
-      ]),
+  projectDetails: defineTable(projectDetailsFields).index("by_project", [
+    "projectId",
+  ]),
 
-    agentRuns: defineTable(agentRunFields)
-      .index("by_task", ["taskId"])
-      .index("by_task_and_status", ["taskId", "status"])
-      .index("by_status", ["status"])
-      .index("by_pr_url", ["prUrl"]),
+  agentTasks: defineTable(agentTaskFields)
+    .index("by_repo", ["repoId"])
+    .index("by_repo_and_status", ["repoId", "status"])
+    .index("by_repo_and_updatedAt", ["repoId", "updatedAt"])
+    .index("by_project", ["projectId"])
+    .index("by_project_and_status", ["projectId", "status"])
+    .index("by_repo_and_numId", ["repoId", "numId"])
+    .index("by_repo_and_sandbox_status", ["repoId", "reviewTaskSandboxStatus"]),
 
-    agentRunActivityLogs: defineTable({
-      runId: v.id("agentRuns"),
-      activityLog: v.string(),
-      type: v.optional(activityLogTypeValidator),
-      updatedAt: v.number(),
-    })
-      .index("by_run", ["runId"])
-      .index("by_run_and_type", ["runId", "type"]),
+  agentRuns: defineTable(agentRunFields)
+    .index("by_task", ["taskId"])
+    .index("by_task_and_status", ["taskId", "status"])
+    .index("by_status", ["status"])
+    .index("by_pr_url", ["prUrl"]),
 
-    githubRepos: defineTable(githubRepoFields)
-      .index("by_github_id", ["githubId"])
-      .index("by_owner_and_name", ["owner", "name"])
-      .index("by_team", ["teamId"])
-      .index("by_connected_by", ["connectedBy"]),
+  agentRunActivityLogs: defineTable({
+    runId: v.id("agentRuns"),
+    activityLog: v.string(),
+    type: v.optional(activityLogTypeValidator),
+    updatedAt: v.number(),
+  })
+    .index("by_run", ["runId"])
+    .index("by_run_and_type", ["runId", "type"]),
 
-    taskComments: defineTable(taskCommentFields).index("by_task", ["taskId"]),
+  githubRepos: defineTable(githubRepoFields)
+    .index("by_github_id", ["githubId"])
+    .index("by_owner_and_name", ["owner", "name"])
+    .index("by_team", ["teamId"])
+    .index("by_connected_by", ["connectedBy"]),
 
-    taskReactions: defineTable(taskReactionFields)
-      .index("by_task", ["taskId"])
-      .index("by_target_user_emoji", [
-        "targetType",
-        "targetId",
-        "userId",
-        "emoji",
-      ]),
+  taskComments: defineTable(taskCommentFields).index("by_task", ["taskId"]),
 
-    taskSubscribers: defineTable(taskSubscriberFields)
-      .index("by_task", ["taskId"])
-      .index("by_task_and_user", ["taskId", "userId"]),
-
-    taskProof: defineTable({
-      taskId: v.id("agentTasks"),
-      storageId: v.optional(v.id("_storage")),
-      fileName: v.optional(v.string()),
-      message: v.optional(v.string()),
-      runId: v.optional(v.id("agentRuns")),
-      createdAt: v.number(),
-    }).index("by_task", ["taskId"]),
-
-    taskDependencies: defineTable({
-      taskId: v.id("agentTasks"),
-      dependsOnId: v.id("agentTasks"),
-    })
-      .index("by_task", ["taskId"])
-      .index("by_task_and_depends_on", ["taskId", "dependsOnId"])
-      .index("by_dependency", ["dependsOnId"]),
-    taskSandboxEvents: defineTable(taskSandboxEventFields).index("by_task", [
-      "taskId",
-    ]),
-    taskActivity: defineTable(taskActivityFields).index("by_task", ["taskId"]),
-    messages: defineTable(messageFields).index("by_parent", ["parentId"]),
-    queuedMessages: defineTable(queuedMessageFields)
-      .index("by_parent_and_created", ["parentId", "createdAt"])
-      .index("by_parent_and_order", ["parentId", "order"]),
-    sessions: defineTable(sessionFields)
-      .index("by_repo", ["repoId"])
-      .index("by_user", ["userId"])
-      .index("by_repo_and_status", ["repoId", "status"])
-      .index("by_repo_and_archived", ["repoId", "archived"])
-      .index("by_pr_url", ["prUrl"])
-      .index("by_repo_and_numId", ["repoId", "numId"]),
-    backgroundProcesses: defineTable(backgroundProcessFields)
-      .index("by_session_and_status", ["sessionId", "status"])
-      .index("by_session_and_key", ["sessionId", "key"]),
-    streamingActivity: defineTable({
-      entityId: v.string(),
-      currentActivity: v.string(),
-      currentContent: v.optional(v.string()),
-      pendingQuestion: v.optional(v.string()),
-      lastUpdatedAt: v.optional(v.number()),
-    }).index("by_entity", ["entityId"]),
-    // Blocking AskUserQuestion round-trip. The paused sandbox turn posts a row
-    // here (via canUseTool), the UI reads the unanswered one and writes the
-    // answer, and the sandbox claims the answer to resume the turn. `entityId`
-    // is the generic session/project/task id (matches streamingActivity).
-    pendingQuestions: defineTable({
-      entityId: v.string(),
-      toolUseId: v.string(),
-      payload: v.string(),
-      answer: v.optional(v.string()),
-      answeredAt: v.optional(v.number()),
-      createdAt: v.number(),
-    })
-      .index("by_entity", ["entityId"])
-      .index("by_entity_tool", ["entityId", "toolUseId"]),
-    docs: defineTable(docFields)
-      .index("by_repo", ["repoId"])
-      .index("by_session", ["sessionId"])
-      .index("by_repo_and_pr_url", ["repoId", "prUrl"])
-      .index("by_repo_and_numId", ["repoId", "numId"]),
-
-    docComments: defineTable(docCommentFields).index("by_doc", ["docId"]),
-
-    docSubscribers: defineTable(docSubscriberFields)
-      .index("by_doc", ["docId"])
-      .index("by_doc_and_user", ["docId", "userId"]),
-
-    docVersions: defineTable(docVersionFields).index("by_doc", ["docId"]),
-
-    docVersionDrafts: defineTable(docVersionDraftFields).index("by_doc", [
-      "docId",
-    ]),
-    annotations: defineTable({
-      userId: v.id("users"),
-      pageUrl: v.string(),
-      pins: v.string(),
-      updatedAt: v.number(),
-    }).index("by_user_and_url", ["userId", "pageUrl"]),
-
-    evaluationReports: defineTable(evaluationReportFields)
-      .index("by_repo", ["repoId"])
-      .index("by_doc", ["docId"]),
-    designPersonas: defineTable({
-      repoId: v.id("githubRepos"),
-      userId: v.id("users"),
-      name: v.string(),
-      prompt: v.string(),
-    }).index("by_repo", ["repoId"]),
-    appTabs: defineTable(appTabFields).index("by_repo", ["repoId"]),
-    auditCategories: defineTable({
-      repoId: v.id("githubRepos"),
-      name: v.string(),
-      description: v.string(),
-      enabled: v.boolean(),
-      appId: v.optional(v.id("githubRepos")),
-      disabledForAppIds: v.optional(v.array(v.id("githubRepos"))),
-      createdAt: v.number(),
-    })
-      .index("by_repo", ["repoId"])
-      .index("by_repo_and_enabled", ["repoId", "enabled"]),
-    repoSkills: defineTable(repoSkillFields)
-      .index("by_repo", ["repoId"])
-      .index("by_repo_and_source_path", ["repoId", "sourcePath"]),
-    audits: defineTable({
-      entityId: v.union(v.id("agentTasks"), v.id("sessions"), v.id("projects")),
-      runId: v.optional(v.id("agentRuns")),
-      status: evaluationStatusValidator,
-      sections: v.optional(v.array(auditSectionValidator)),
-      summary: v.optional(v.string()),
-      error: v.optional(v.string()),
-      fixStatus: v.optional(evalFixStatusValidator),
-      createdAt: v.number(),
-      completedAt: v.optional(v.number()),
-      fixCompletedAt: v.optional(v.number()),
-    })
-      .index("by_entity", ["entityId"])
-      .index("by_entity_created", ["entityId", "createdAt"]),
-    notifications: defineTable({
-      userId: v.id("users"),
-      type: notificationTypeValidator,
-      title: v.string(),
-      message: v.optional(v.string()),
-      read: v.boolean(),
-      href: v.optional(v.string()),
-      repoId: v.optional(v.id("githubRepos")),
-      createdAt: v.number(),
-      // Human-readable task/project context shown on the notification card, e.g.
-      // a quick task's title or "Project title: issue title" for project tasks.
-      // Only set for types whose title does not already name the task (mentions,
-      // comment replies); snapshotted at creation, absent otherwise.
-      contextLabel: v.optional(v.string()),
-      // Set once this notification has been included in an email (instant send or
-      // daily digest), so neither path emails the same notification twice.
-      emailedAt: v.optional(v.number()),
-    })
-      .index("by_user", ["userId"])
-      .index("by_user_and_read", ["userId", "read"])
-      .index("by_repo", ["repoId"]),
-    repoEnvVars: defineTable({
-      repoId: v.id("githubRepos"),
-      vars: v.array(
-        v.object({
-          key: v.string(),
-          value: v.string(),
-          sandboxExclude: v.optional(v.boolean()),
-        }),
-      ),
-      updatedAt: v.number(),
-    }).index("by_repo", ["repoId"]),
-    extensionReleases: defineTable({
-      version: v.string(),
-      crxStorageId: v.id("_storage"),
-      releasedAt: v.number(),
-      notes: v.optional(v.string()),
-    }).index("by_version", ["version"]),
-    repoSnapshots: defineTable({
-      repoId: v.id("githubRepos"),
-      snapshotName: v.string(),
-      schedule: snapshotScheduleValidator,
-      enabled: v.optional(v.boolean()),
-      cronJobId: v.optional(v.string()),
-      workflowRef: v.optional(v.string()),
-      buildCommands: v.optional(v.array(v.string())),
-      // Seed-once commands run ONLY during seeded-snapshot builds, in the
-      // post-daemon phase (services like `convex dev` are up). For one-time
-      // data seeding (env set, convex import). Never re-run on sandbox boot,
-      // unlike githubRepos.startupCommands. Not part of the image fingerprint.
-      seedCommands: v.optional(v.array(v.string())),
-      // Fingerprint of the image inputs (lockfile sha on the build branch,
-      // buildCommands, config-file blobs, image definition version) stored at the
-      // last successful Image build. When unchanged, the build workflow skips the
-      // ~11-15m image rebuild — its output would be byte-identical.
-      imageFingerprint: v.optional(v.string()),
-      // Vercel base Image capture (`snap_*`) from a running sandbox — separate
-      // from `snapshotName` and per-app `seededSnapshotName`.
-      baseSnapshotId: v.optional(v.string()),
-      createdAt: v.number(),
-      updatedAt: v.number(),
-    }).index("by_repo", ["repoId"]),
-    snapshotBuilds: defineTable({
-      repoSnapshotId: v.id("repoSnapshots"),
-      status: snapshotBuildStatusValidator,
-      triggeredBy: snapshotBuildTriggerValidator,
-      // "base" (image only) vs "seeded" (boots + seeds DB before capture).
-      // Optional: legacy rows predate this field and render without a type.
-      kind: v.optional(snapshotBuildKindValidator),
-      // Sandbox provider used for this build (set at workflow start).
-      provider: v.optional(sandboxProviderKindValidator),
-      logs: v.string(),
-      error: v.optional(v.string()),
-      workflowRunId: v.optional(v.number()),
-      startedAt: v.number(),
-      completedAt: v.optional(v.number()),
-      retryCount: v.optional(v.number()),
-      // Per-app seeding outcomes captured during Step 5 of the build workflow.
-      seededApps: v.optional(v.array(seededAppResultValidator)),
-    })
-      .index("by_repo_snapshot", ["repoSnapshotId"])
-      .index("by_repo_snapshot_and_status", ["repoSnapshotId", "status"])
-      .index("by_status", ["status"]),
-    sandboxConfigFiles: defineTable({
-      repoId: v.id("githubRepos"),
-      // Legacy single-blob storage (kept for backwards compat with existing records).
-      // New uploads always use `chunks` instead.
-      storageId: v.optional(v.id("_storage")),
-      // Ordered list of storage blob IDs that, when concatenated in order, form the file.
-      // Single-blob files use a 1-element array; multi-chunk files split a large file by ~100MB.
-      chunks: v.optional(v.array(v.id("_storage"))),
-      fileName: v.string(),
-      fileSize: v.number(),
-      uploadedBy: v.id("users"),
-      createdAt: v.number(),
-    }).index("by_repo", ["repoId"]),
-    teams: defineTable(teamFields).index("by_created_by", ["createdBy"]),
-    teamMembers: defineTable({
-      teamId: v.id("teams"),
-      userId: v.id("users"),
-      role: teamMemberRoleValidator,
-      joinedAt: v.number(),
-    })
-      .index("by_team", ["teamId"])
-      .index("by_team_and_role", ["teamId", "role"])
-      .index("by_user", ["userId"])
-      .index("by_team_and_user", ["teamId", "userId"]),
-    githubWebhookEvents: defineTable({
-      event: v.string(),
-      action: v.string(),
-      prUrl: v.optional(v.string()),
-      merged: v.optional(v.boolean()),
-      taskId: v.optional(v.id("agentTasks")),
-      status: webhookEventStatusValidator,
-      createdAt: v.number(),
-    }).index("by_status", ["status"]),
-    userProviderAccounts: defineTable(userProviderAccountFields)
-      .index("by_user", ["userId"])
-      .index("by_user_and_provider", ["userId", "provider"]),
-    teamEnvVars: defineTable({
-      teamId: v.id("teams"),
-      vars: v.array(
-        v.object({
-          key: v.string(),
-          value: v.string(),
-          sandboxExclude: v.optional(v.boolean()),
-        }),
-      ),
-      updatedAt: v.number(),
-    }).index("by_team", ["teamId"]),
-    automations: defineTable(automationFields)
-      .index("by_repo", ["repoId"])
-      .index("by_repo_and_enabled", ["repoId", "enabled"])
-      .index("by_repo_and_numId", ["repoId", "numId"]),
-
-    automationRuns: defineTable(automationRunFields)
-      .index("by_automation", ["automationId"])
-      .index("by_automation_and_status", ["automationId", "status"])
-      .index("by_repo", ["repoId"]),
-
-    logs: defineTable({
-      entityType: v.string(),
-      entityId: v.string(),
-      entityTitle: v.string(),
-      rawResultEvent: v.optional(v.string()),
-      repoId: v.id("githubRepos"),
-      projectId: v.optional(v.id("projects")),
-      createdAt: v.number(),
-    })
-      .index("by_repo", ["repoId"])
-      .index("by_repo_and_created", ["repoId", "createdAt"])
-      .index("by_entity_type", ["entityType"])
-      .index("by_repo_and_entity", ["repoId", "entityId"])
-      .index("by_project", ["projectId"]),
-
-    syncSettings: defineTable(syncSettingFields).index("by_owner_and_name", [
-      "owner",
-      "name",
+  taskReactions: defineTable(taskReactionFields)
+    .index("by_task", ["taskId"])
+    .index("by_target_user_emoji", [
+      "targetType",
+      "targetId",
+      "userId",
+      "emoji",
     ]),
 
-    repoEntityCounters: defineTable(repoEntityCounterFields).index(
-      "by_repo_and_type",
-      ["repoId", "entityType"],
+  taskSubscribers: defineTable(taskSubscriberFields)
+    .index("by_task", ["taskId"])
+    .index("by_task_and_user", ["taskId", "userId"]),
+
+  taskProof: defineTable({
+    taskId: v.id("agentTasks"),
+    storageId: v.optional(v.id("_storage")),
+    fileName: v.optional(v.string()),
+    message: v.optional(v.string()),
+    runId: v.optional(v.id("agentRuns")),
+    createdAt: v.number(),
+  }).index("by_task", ["taskId"]),
+
+  taskDependencies: defineTable({
+    taskId: v.id("agentTasks"),
+    dependsOnId: v.id("agentTasks"),
+  })
+    .index("by_task", ["taskId"])
+    .index("by_task_and_depends_on", ["taskId", "dependsOnId"])
+    .index("by_dependency", ["dependsOnId"]),
+  taskSandboxEvents: defineTable(taskSandboxEventFields).index("by_task", [
+    "taskId",
+  ]),
+  taskActivity: defineTable(taskActivityFields).index("by_task", ["taskId"]),
+  messages: defineTable(messageFields).index("by_parent", ["parentId"]),
+  queuedMessages: defineTable(queuedMessageFields)
+    .index("by_parent_and_created", ["parentId", "createdAt"])
+    .index("by_parent_and_order", ["parentId", "order"]),
+  sessions: defineTable(sessionFields)
+    .index("by_repo", ["repoId"])
+    .index("by_user", ["userId"])
+    .index("by_repo_and_status", ["repoId", "status"])
+    .index("by_repo_and_archived", ["repoId", "archived"])
+    .index("by_pr_url", ["prUrl"])
+    .index("by_repo_and_numId", ["repoId", "numId"]),
+  backgroundProcesses: defineTable(backgroundProcessFields)
+    .index("by_session_and_status", ["sessionId", "status"])
+    .index("by_session_and_key", ["sessionId", "key"]),
+  streamingActivity: defineTable({
+    entityId: v.string(),
+    currentActivity: v.string(),
+    currentContent: v.optional(v.string()),
+    pendingQuestion: v.optional(v.string()),
+    lastUpdatedAt: v.optional(v.number()),
+  }).index("by_entity", ["entityId"]),
+  // Blocking AskUserQuestion round-trip. The paused sandbox turn posts a row
+  // here (via canUseTool), the UI reads the unanswered one and writes the
+  // answer, and the sandbox claims the answer to resume the turn. `entityId`
+  // is the generic session/project/task id (matches streamingActivity).
+  pendingQuestions: defineTable({
+    entityId: v.string(),
+    toolUseId: v.string(),
+    payload: v.string(),
+    answer: v.optional(v.string()),
+    answeredAt: v.optional(v.number()),
+    createdAt: v.number(),
+  })
+    .index("by_entity", ["entityId"])
+    .index("by_entity_tool", ["entityId", "toolUseId"]),
+  docs: defineTable(docFields)
+    .index("by_repo", ["repoId"])
+    .index("by_session", ["sessionId"])
+    .index("by_repo_and_pr_url", ["repoId", "prUrl"])
+    .index("by_repo_and_numId", ["repoId", "numId"]),
+
+  docComments: defineTable(docCommentFields).index("by_doc", ["docId"]),
+
+  docSubscribers: defineTable(docSubscriberFields)
+    .index("by_doc", ["docId"])
+    .index("by_doc_and_user", ["docId", "userId"]),
+
+  docVersions: defineTable(docVersionFields).index("by_doc", ["docId"]),
+
+  docVersionDrafts: defineTable(docVersionDraftFields).index("by_doc", [
+    "docId",
+  ]),
+  annotations: defineTable({
+    userId: v.id("users"),
+    pageUrl: v.string(),
+    pins: v.string(),
+    updatedAt: v.number(),
+  }).index("by_user_and_url", ["userId", "pageUrl"]),
+
+  evaluationReports: defineTable(evaluationReportFields)
+    .index("by_repo", ["repoId"])
+    .index("by_doc", ["docId"]),
+  designPersonas: defineTable({
+    repoId: v.id("githubRepos"),
+    userId: v.id("users"),
+    name: v.string(),
+    prompt: v.string(),
+  }).index("by_repo", ["repoId"]),
+  appTabs: defineTable(appTabFields).index("by_repo", ["repoId"]),
+  auditCategories: defineTable({
+    repoId: v.id("githubRepos"),
+    name: v.string(),
+    description: v.string(),
+    enabled: v.boolean(),
+    appId: v.optional(v.id("githubRepos")),
+    disabledForAppIds: v.optional(v.array(v.id("githubRepos"))),
+    createdAt: v.number(),
+  })
+    .index("by_repo", ["repoId"])
+    .index("by_repo_and_enabled", ["repoId", "enabled"]),
+  repoSkills: defineTable(repoSkillFields)
+    .index("by_repo", ["repoId"])
+    .index("by_repo_and_source_path", ["repoId", "sourcePath"]),
+  audits: defineTable({
+    entityId: v.union(v.id("agentTasks"), v.id("sessions"), v.id("projects")),
+    runId: v.optional(v.id("agentRuns")),
+    status: evaluationStatusValidator,
+    sections: v.optional(v.array(auditSectionValidator)),
+    summary: v.optional(v.string()),
+    error: v.optional(v.string()),
+    fixStatus: v.optional(evalFixStatusValidator),
+    createdAt: v.number(),
+    completedAt: v.optional(v.number()),
+    fixCompletedAt: v.optional(v.number()),
+  })
+    .index("by_entity", ["entityId"])
+    .index("by_entity_created", ["entityId", "createdAt"]),
+  notifications: defineTable({
+    userId: v.id("users"),
+    type: notificationTypeValidator,
+    title: v.string(),
+    message: v.optional(v.string()),
+    read: v.boolean(),
+    href: v.optional(v.string()),
+    repoId: v.optional(v.id("githubRepos")),
+    createdAt: v.number(),
+    // Human-readable task/project context shown on the notification card, e.g.
+    // a quick task's title or "Project title: issue title" for project tasks.
+    // Only set for types whose title does not already name the task (mentions,
+    // comment replies); snapshotted at creation, absent otherwise.
+    contextLabel: v.optional(v.string()),
+    // Set once this notification has been included in an email (instant send or
+    // daily digest), so neither path emails the same notification twice.
+    emailedAt: v.optional(v.number()),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_and_read", ["userId", "read"])
+    .index("by_repo", ["repoId"]),
+  repoEnvVars: defineTable({
+    repoId: v.id("githubRepos"),
+    vars: v.array(
+      v.object({
+        key: v.string(),
+        value: v.string(),
+        sandboxExclude: v.optional(v.boolean()),
+      }),
     ),
+    updatedAt: v.number(),
+  }).index("by_repo", ["repoId"]),
+  extensionReleases: defineTable({
+    version: v.string(),
+    crxStorageId: v.id("_storage"),
+    releasedAt: v.number(),
+    notes: v.optional(v.string()),
+  }).index("by_version", ["version"]),
+  repoSnapshots: defineTable({
+    repoId: v.id("githubRepos"),
+    snapshotName: v.string(),
+    schedule: snapshotScheduleValidator,
+    enabled: v.optional(v.boolean()),
+    cronJobId: v.optional(v.string()),
+    workflowRef: v.optional(v.string()),
+    buildCommands: v.optional(v.array(v.string())),
+    // Seed-once commands run ONLY during seeded-snapshot builds, in the
+    // post-daemon phase (services like `convex dev` are up). For one-time
+    // data seeding (env set, convex import). Never re-run on sandbox boot,
+    // unlike githubRepos.startupCommands. Not part of the image fingerprint.
+    seedCommands: v.optional(v.array(v.string())),
+    // Fingerprint of the image inputs (lockfile sha on the build branch,
+    // buildCommands, config-file blobs, image definition version) stored at the
+    // last successful Image build. When unchanged, the build workflow skips the
+    // ~11-15m image rebuild — its output would be byte-identical.
+    imageFingerprint: v.optional(v.string()),
+    // Vercel base Image capture (`snap_*`) from a running sandbox — separate
+    // from `snapshotName` and per-app `seededSnapshotName`.
+    baseSnapshotId: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }).index("by_repo", ["repoId"]),
+  snapshotBuilds: defineTable({
+    repoSnapshotId: v.id("repoSnapshots"),
+    status: snapshotBuildStatusValidator,
+    triggeredBy: snapshotBuildTriggerValidator,
+    // "base" (image only) vs "seeded" (boots + seeds DB before capture).
+    // Optional: legacy rows predate this field and render without a type.
+    kind: v.optional(snapshotBuildKindValidator),
+    // Sandbox provider used for this build (set at workflow start).
+    provider: v.optional(sandboxProviderKindValidator),
+    logs: v.string(),
+    error: v.optional(v.string()),
+    workflowRunId: v.optional(v.number()),
+    startedAt: v.number(),
+    completedAt: v.optional(v.number()),
+    retryCount: v.optional(v.number()),
+    // Per-app seeding outcomes captured during Step 5 of the build workflow.
+    seededApps: v.optional(v.array(seededAppResultValidator)),
+  })
+    .index("by_repo_snapshot", ["repoSnapshotId"])
+    .index("by_repo_snapshot_and_status", ["repoSnapshotId", "status"])
+    .index("by_status", ["status"]),
+  sandboxConfigFiles: defineTable({
+    repoId: v.id("githubRepos"),
+    // Legacy single-blob storage (kept for backwards compat with existing records).
+    // New uploads always use `chunks` instead.
+    storageId: v.optional(v.id("_storage")),
+    // Ordered list of storage blob IDs that, when concatenated in order, form the file.
+    // Single-blob files use a 1-element array; multi-chunk files split a large file by ~100MB.
+    chunks: v.optional(v.array(v.id("_storage"))),
+    fileName: v.string(),
+    fileSize: v.number(),
+    uploadedBy: v.id("users"),
+    createdAt: v.number(),
+  }).index("by_repo", ["repoId"]),
+  teams: defineTable(teamFields).index("by_created_by", ["createdBy"]),
+  teamMembers: defineTable({
+    teamId: v.id("teams"),
+    userId: v.id("users"),
+    role: teamMemberRoleValidator,
+    joinedAt: v.number(),
+  })
+    .index("by_team", ["teamId"])
+    .index("by_team_and_role", ["teamId", "role"])
+    .index("by_user", ["userId"])
+    .index("by_team_and_user", ["teamId", "userId"]),
+  githubWebhookEvents: defineTable({
+    event: v.string(),
+    action: v.string(),
+    prUrl: v.optional(v.string()),
+    merged: v.optional(v.boolean()),
+    taskId: v.optional(v.id("agentTasks")),
+    status: webhookEventStatusValidator,
+    createdAt: v.number(),
+  }).index("by_status", ["status"]),
+  userProviderAccounts: defineTable(userProviderAccountFields)
+    .index("by_user", ["userId"])
+    .index("by_user_and_provider", ["userId", "provider"]),
+  teamEnvVars: defineTable({
+    teamId: v.id("teams"),
+    vars: v.array(
+      v.object({
+        key: v.string(),
+        value: v.string(),
+        sandboxExclude: v.optional(v.boolean()),
+      }),
+    ),
+    updatedAt: v.number(),
+  }).index("by_team", ["teamId"]),
+  automations: defineTable(automationFields)
+    .index("by_repo", ["repoId"])
+    .index("by_repo_and_enabled", ["repoId", "enabled"])
+    .index("by_repo_and_numId", ["repoId", "numId"]),
 
-    mcpAuthCodes: defineTable({
-      code: v.string(),
-      clerkUserId: v.string(),
-      codeChallenge: v.string(),
-      codeChallengeMethod: v.string(),
-      redirectUri: v.string(),
-      clientId: v.string(),
-      expiresAt: v.number(),
-    }).index("by_code", ["code"]),
+  automationRuns: defineTable(automationRunFields)
+    .index("by_automation", ["automationId"])
+    .index("by_automation_and_status", ["automationId", "status"])
+    .index("by_repo", ["repoId"]),
 
-    mcpClientRegistrations: defineTable({
-      clientId: v.string(),
-      clientSecret: v.optional(v.string()),
-      redirectUris: v.array(v.string()),
-      registeredAt: v.number(),
-    }).index("by_clientId", ["clientId"]),
+  logs: defineTable({
+    entityType: v.string(),
+    entityId: v.string(),
+    entityTitle: v.string(),
+    rawResultEvent: v.optional(v.string()),
+    repoId: v.id("githubRepos"),
+    projectId: v.optional(v.id("projects")),
+    createdAt: v.number(),
+  })
+    .index("by_repo", ["repoId"])
+    .index("by_repo_and_created", ["repoId", "createdAt"])
+    .index("by_entity_type", ["entityType"])
+    .index("by_repo_and_entity", ["repoId", "entityId"])
+    .index("by_project", ["projectId"]),
 
-    sandboxGitCredentials: defineTable(sandboxGitCredentialsFields)
-      .index("by_sandbox_id", ["sandboxId"])
-      .index("by_secret", ["secret"]),
+  syncSettings: defineTable(syncSettingFields).index("by_owner_and_name", [
+    "owner",
+    "name",
+  ]),
 
-    // App-wide singleton settings (only ever one row). Read/written via the
-    // helpers in `sandboxAutoStop.ts`.
-    appSettings: defineTable(appSettingsFields),
+  repoEntityCounters: defineTable(repoEntityCounterFields).index(
+    "by_repo_and_type",
+    ["repoId", "entityType"],
+  ),
 
-    // One row per (user, surface target). Persists unsent composer text for task
-    // comments and chat prompts so drafts survive page reloads.
-    drafts: defineTable(draftFields)
-      .index("by_user_and_task", ["userId", "taskId"])
-      .index("by_user_and_project", ["userId", "projectId"])
-      .index("by_user_and_session", ["userId", "sessionId"])
-      .index("by_user_and_repo", ["userId", "repoId"]),
-  },
-  // DEMO-ONLY (not committed): tolerate pre-existing dev-deployment schema drift.
-  { schemaValidation: false },
-);
+  mcpAuthCodes: defineTable({
+    code: v.string(),
+    clerkUserId: v.string(),
+    codeChallenge: v.string(),
+    codeChallengeMethod: v.string(),
+    redirectUri: v.string(),
+    clientId: v.string(),
+    expiresAt: v.number(),
+  }).index("by_code", ["code"]),
+
+  mcpClientRegistrations: defineTable({
+    clientId: v.string(),
+    clientSecret: v.optional(v.string()),
+    redirectUris: v.array(v.string()),
+    registeredAt: v.number(),
+  }).index("by_clientId", ["clientId"]),
+
+  sandboxGitCredentials: defineTable(sandboxGitCredentialsFields)
+    .index("by_sandbox_id", ["sandboxId"])
+    .index("by_secret", ["secret"]),
+
+  // App-wide singleton settings (only ever one row). Read/written via the
+  // helpers in `sandboxAutoStop.ts`.
+  appSettings: defineTable(appSettingsFields),
+
+  // One row per (user, surface target). Persists unsent composer text for task
+  // comments and chat prompts so drafts survive page reloads.
+  // Not a stash queue — see `promptStashes` and internal/docs/prompt-stash-vs-drafts.md.
+  drafts: defineTable(draftFields)
+    .index("by_user_and_task", ["userId", "taskId"])
+    .index("by_user_and_project", ["userId", "projectId"])
+    .index("by_user_and_session", ["userId", "sessionId"])
+    .index("by_user_and_repo", ["userId", "repoId"]),
+
+  // Explicit ⌘S queue of frozen composer snapshots (text + attachment blobs),
+  // scoped per user per repo. Separate from `drafts` (live WIP upsert).
+  promptStashes: defineTable(promptStashFields).index("by_user_and_repo", [
+    "userId",
+    "repoId",
+  ]),
+});
 
 export default schema;

--- a/packages/backend/tests/resultTarget.test.ts
+++ b/packages/backend/tests/resultTarget.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  delayedPublishFailureError,
   orphanPlaceholderMessages,
   resultTargetMessage,
 } from "../convex/_sessions/resultTarget";
@@ -20,6 +21,26 @@ function reply(fields: {
     finishedAt: fields.finishedAt,
   };
 }
+
+describe("delayedPublishFailureError", () => {
+  test("identifies a publish failure after a result was already saved", () => {
+    const error =
+      "Session completed locally, but Eva could not publish the branch to GitHub.";
+    expect(delayedPublishFailureError("saved reply", error)).toBe(error);
+  });
+
+  test.each([
+    [
+      "no saved result",
+      null,
+      "Session completed locally, but Eva could not publish",
+    ],
+    ["no error", "saved reply", null],
+    ["an execution error", "saved reply", "Sandbox command failed"],
+  ])("ignores %s", (_label, result, error) => {
+    expect(delayedPublishFailureError(result, error)).toBeUndefined();
+  });
+});
 
 /**
  * A turn's result used to land on whatever the newest message was. A system

--- a/packages/backend/tests/sessionPublishContract.test.ts
+++ b/packages/backend/tests/sessionPublishContract.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "vitest";
 const convexDir = join(dirname(fileURLToPath(import.meta.url)), "../convex");
 
 const sessionWorkflow = readSource("_sessions/workflow.ts");
+const resultTarget = readSource("_sessions/resultTarget.ts");
 const sandboxExecution = readSource("_sandbox_runtime/execution.ts");
 
 const PUSH_ACTION = "internal.sandbox.pushSandboxBranch";
@@ -92,20 +93,52 @@ describe("the reply is saved before the push", () => {
   });
 
   /**
-   * The publish failure is then patched onto the saved reply, which only works
-   * because saveResult recognises the prefix the workflow produces. A typo in
-   * either literal silently replaces the agent's answer with "Error: …".
+   * The failure is then reported as its own alert, which only works because
+   * saveResult recognises the prefix the workflow produces. A typo in either
+   * literal makes the second saveResult run the generic finaliser again and
+   * replace the saved answer with "Error: …".
    */
   test("saveResult recognises the publish-failure message it is sent", () => {
-    const marker = sessionWorkflow.match(
-      /args\.error\.startsWith\(\s*"([^"]+)"/,
+    const marker = resultTarget.match(
+      /SESSION_PUBLISH_FAILURE_PREFIX =\s*"([^"]+)"/,
     );
-    expect(marker, "the publish-failure guard moved").not.toBeNull();
+    expect(marker, "the publish-failure prefix moved").not.toBeNull();
     const prefix = marker?.[1] ?? "";
     expect(prefix.length).toBeGreaterThan(0);
     const thrown = sessionWorkflow.match(/const publishError = `([^${]+)/);
     expect(thrown, "the publish-failure message moved").not.toBeNull();
     expect(thrown?.[1] ?? "").toContain(prefix);
+  });
+});
+
+/**
+ * Because the reply is saved before the push, a push failure arrives late —
+ * often after the next regular or queued turn has started. Re-running the
+ * generic finaliser then patched the NEWER turn's placeholder with the
+ * previous answer, cleared its live streaming row and wiped its
+ * activeWorkflowId (fix 60a9b977).
+ */
+describe("a delayed publish failure cannot rewrite a newer turn", () => {
+  test("saveResult isolates the failure before touching turn state", () => {
+    const body = definitionBody(sessionWorkflow, "saveResult");
+    const guardAt = body.indexOf("delayedPublishFailureError(");
+    const clearAt = body.indexOf("clearStreamingActivity(");
+    const targetAt = body.indexOf("resultTargetMessage(");
+    expect(guardAt, "the publish-failure guard moved").toBeGreaterThan(-1);
+    expect(clearAt, "the streaming clear moved").toBeGreaterThan(-1);
+    expect(targetAt, "the result target lookup moved").toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(clearAt);
+    expect(guardAt).toBeLessThan(targetAt);
+  });
+
+  test("the failure becomes a standalone system alert", () => {
+    const body = definitionBody(sessionWorkflow, "saveResult");
+    const guard = body.slice(
+      body.indexOf("delayedPublishFailureError("),
+      body.indexOf("clearStreamingActivity("),
+    );
+    expect(guard).toContain("isSystemAlert: true");
+    expect(guard).toContain("return null;");
   });
 });
 

--- a/packages/backend/tests/staleReplyContract.test.ts
+++ b/packages/backend/tests/staleReplyContract.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const daemonSource = readSource("callback-src/providers/claudeSdkDaemon.ts");
+const oneShotSource = readSource("callback-src/index.ts");
+const bundledScript = readSource(
+  "convex/_sandbox_runtime/callbackScript.generated.ts",
+);
+const sessionExecution = readSource("convex/_sessions/execution.ts");
+const queueHelpers = readSource("convex/_queues/helpers.ts");
+
+/**
+ * The Working bubble renders `streamingActivity.currentContent` verbatim, and
+ * the server clears that row when a turn completes — queued dequeues start the
+ * NEXT turn inside the completion mutation itself. A daemon streaming write
+ * that runs after delivering completion therefore lands after the next turn's
+ * clear and resurrects the finished turn's full reply under the new
+ * placeholder: users saw the previous answer as the response to their new
+ * message until the real reply arrived (fix 60a9b977).
+ */
+describe("no streaming write after completion is delivered", () => {
+  test.each([
+    ["daemon source", daemonSource],
+    ["deployed bundle", bundledScript],
+  ])("finalizeTurn reconciles before completing (%s)", (_label, source) => {
+    const body = functionBody(source, "async function finalizeTurn(");
+    const reconcileAt = body.indexOf("await setFinalizingState();");
+    const completionAt = body.indexOf("await deliverCompletionWithMedia(");
+    expect(reconcileAt, "the final reconcile moved").toBeGreaterThan(-1);
+    expect(completionAt, "the completion call moved").toBeGreaterThan(-1);
+    expect(reconcileAt).toBeLessThan(completionAt);
+
+    const afterCompletion = body.slice(completionAt);
+    expect(afterCompletion).not.toContain("setFinalizingState");
+    expect(afterCompletion).not.toContain("sendStreamingHeartbeatUpdate");
+    expect(afterCompletion).not.toContain("flushStreaming(");
+  });
+
+  test("the one-shot attempt reconciles before completing", () => {
+    const reconcileAt = oneShotSource.indexOf("await setFinalizingState();");
+    const completionAt = oneShotSource.indexOf(
+      "await deliverCompletionWithMedia(",
+    );
+    expect(reconcileAt, "the final reconcile moved").toBeGreaterThan(-1);
+    expect(completionAt, "the completion call moved").toBeGreaterThan(-1);
+    expect(reconcileAt).toBeLessThan(completionAt);
+  });
+});
+
+/**
+ * Warm daemons keep running the script they were spawned with, so sandboxes
+ * that predate fix 60a9b977 (and any crashed turn) can still leave a populated
+ * streaming row behind. Each turn start wipes the row before its own bubble
+ * exists to render it.
+ */
+describe("every turn start clears the streaming row first", () => {
+  test("startExecute clears before staging the placeholder", () => {
+    const body = definitionBody(sessionExecution, "startExecute");
+    const clearAt = body.indexOf("clearStreamingActivity(");
+    const placeholderAt = body.indexOf('ctx.db.insert("messages"');
+    expect(clearAt, "the streaming clear moved").toBeGreaterThan(-1);
+    expect(placeholderAt, "the placeholder insert moved").toBeGreaterThan(-1);
+    expect(clearAt).toBeLessThan(placeholderAt);
+  });
+
+  test.each([
+    "startNextQueuedSessionMessage",
+    "startNextQueuedProjectChatMessage",
+    "startNextQueuedTaskChatMessage",
+  ])("%s clears before inserting the user turn", (name) => {
+    const body = functionBody(queueHelpers, `export async function ${name}(`);
+    const clearAt = body.indexOf("clearStreamingActivity(");
+    const userInsertAt = body.indexOf('role: "user"');
+    expect(clearAt, "the streaming clear moved").toBeGreaterThan(-1);
+    expect(userInsertAt, "the user-turn insert moved").toBeGreaterThan(-1);
+    expect(clearAt).toBeLessThan(userInsertAt);
+  });
+});
+
+/** Comments name the very calls these rules rule out, so they have to go first. */
+function readSource(relativePath: string): string {
+  return stripComments(
+    readFileSync(join(backendDir, relativePath), "utf8").replaceAll(
+      "\r\n",
+      "\n",
+    ),
+  );
+}
+
+/** One top-level function, ending on the `\n}` that closes it at column 0. */
+function functionBody(source: string, header: string): string {
+  const startAt = source.indexOf(header);
+  expect(startAt, `${header} moved or was renamed`).toBeGreaterThan(-1);
+  const end = source.indexOf("\n}", startAt);
+  return source.slice(startAt, end < 0 ? undefined : end);
+}
+
+/** One Convex definition, ending on the `\n});` that closes it. */
+function definitionBody(source: string, name: string): string {
+  const startAt = source.indexOf(`export const ${name} =`);
+  expect(startAt, `${name} moved or was renamed`).toBeGreaterThan(-1);
+  const end = source.indexOf("\n});", startAt);
+  return source.slice(startAt, end < 0 ? undefined : end);
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[^\S\n]*\/\/.*$/gm, "");
+}

--- a/packages/ui/src/ui/popover.tsx
+++ b/packages/ui/src/ui/popover.tsx
@@ -7,6 +7,7 @@ import { SURFACE_RADIUS_CLASS } from "../utils/surface-radius";
 
 const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverContent = React.forwardRef<
   React.ComponentRef<typeof PopoverPrimitive.Content>,
@@ -29,4 +30,4 @@ const PopoverContent = React.forwardRef<
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent };
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };


### PR DESCRIPTION
## Summary
- Add prompt stash (Mod+S): park composer text + attachments in a per-user per-repo Convex queue; restore appends and consumes the entry without touching model/mode.
- Flush the queued-messages bar above the composer (narrower inset, square bottom) to match the under-composer branch bar.
- Fix new turns briefly showing the previous turn''s reply (result-target wiring).

## Test plan
- [ ] New-session + in-session: Mod+S with draft stashes/clears; empty Mod+S opens picker; restore appends and removes entry
- [ ] Stash with image attachment; 21st stash evicts oldest with toast
- [ ] Queue messages while agent runs — bar sits flush above composer with no gap
- [ ] Start a new turn after a completed reply — stream shows only the new turn, not the prior assistant message