### PR TITLE
perf(web): cut initial payload and preload routes on hover

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -34,10 +34,8 @@
     <!-- Preconnect to critical third-party origins -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preconnect" href="https://flexible-duckling-74.clerk.accounts.dev" crossorigin />
-    <link rel="preconnect" href="https://good-mule-506.eu-west-1.convex.cloud" crossorigin />
-    <link rel="dns-prefetch" href="https://flexible-duckling-74.clerk.accounts.dev" />
-    <link rel="dns-prefetch" href="https://good-mule-506.eu-west-1.convex.cloud" />
+    <!-- Convex + Clerk hints, generated per deployment by vite/originHints.ts -->
+    <!-- origin-hints -->
     <!-- Non-blocking font load: renders immediately with fallback, swaps when ready -->
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@100..1000&family=Figtree:wght@300..900&family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@100..900&family=Nunito:wght@200..1000&family=Outfit:wght@100..900&family=Plus+Jakarta+Sans:wght@200..800&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Source+Serif+4:opsz,wght@8..60,200..900&family=Space+Grotesk:wght@300..700&display=swap"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -97,6 +97,7 @@
   },
   "devDependencies": {
     "@rolldown/plugin-babel": "^0.2.2",
+    "@rolldown/plugin-transform-imports": "0.1.1",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/router-plugin": "^1.120.0",
     "@types/node": "^24.10.1",

--- a/apps/web/src/lib/components/ChangelogDialogGate.tsx
+++ b/apps/web/src/lib/components/ChangelogDialogGate.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { lazy, Suspense } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@eva/backend";
+import { useDevChangelogPreview } from "@/lib/dev/preview";
+
+/**
+ * Decides whether the changelog dialog is needed before its code is fetched.
+ *
+ * `ChangelogDialog` renders markdown through streamdown + mermaid + katex, which is
+ * roughly 930 kB gzip of JS. A `lazy()` import alone does not help when the component
+ * is mounted on every page: React requests the chunk immediately and the dialog only
+ * then discovers it has nothing to show. Running the (already reactive, already cached)
+ * `getLatestChangelog` query out here means the chunk is fetched on the rare load that
+ * actually has an unread entry.
+ */
+const ChangelogDialog = lazy(() =>
+  import("@/lib/components/ChangelogDialog").then((m) => ({
+    default: m.ChangelogDialog,
+  })),
+);
+
+export function ChangelogDialogGate() {
+  const isPreview = useDevChangelogPreview();
+  const changelog = useQuery(api.changelog.getLatestChangelog);
+
+  // The dialog repeats these checks — it owns dismissal, so it decides when to
+  // close. This only decides whether the code is worth downloading.
+  if (!isPreview && !changelog?.show) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <ChangelogDialog />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/components/TablerIconByName.tsx
+++ b/apps/web/src/lib/components/TablerIconByName.tsx
@@ -1,0 +1,57 @@
+import {
+  lazy,
+  Suspense,
+  type ComponentType,
+  type LazyExoticComponent,
+} from "react";
+import { IconLayoutGrid } from "@tabler/icons-react";
+
+/**
+ * Renders a Tabler icon chosen at runtime by name (custom app tabs store the
+ * name as free text, e.g. "IconBolt").
+ *
+ * Resolving an arbitrary name needs Tabler's whole export map, which is ~2.5 MB
+ * of JS. Reaching that map only through a dynamic `import()` keeps it in its own
+ * async chunk, so the handful of screens that render a custom tab icon pay for
+ * it instead of every visitor downloading it in the initial bundle.
+ */
+interface TablerIconByNameProps {
+  name: string;
+  className?: string;
+}
+
+/**
+ * `lazy()` components must be stable across renders — a fresh one each render
+ * would suspend forever — so each name gets exactly one, cached module-side.
+ */
+const lazyIcons = new Map<
+  string,
+  LazyExoticComponent<ComponentType<{ className?: string }>>
+>();
+
+function lazyIconFor(name: string) {
+  const cached = lazyIcons.get(name);
+  if (cached) {
+    return cached;
+  }
+
+  const Icon = lazy(async () => {
+    const { resolveTablerIcon } = await import("@/lib/utils/tablerIcon");
+    return { default: resolveTablerIcon(name) };
+  });
+
+  lazyIcons.set(name, Icon);
+  return Icon;
+}
+
+export function TablerIconByName({ name, className }: TablerIconByNameProps) {
+  const Icon = lazyIconFor(name);
+
+  // The fallback doubles as the unknown-name placeholder, so the icon slot keeps
+  // its size and only swaps shape once the chunk lands (first render only).
+  return (
+    <Suspense fallback={<IconLayoutGrid className={className} />}>
+      <Icon className={className} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/utils/tablerIcon.ts
+++ b/apps/web/src/lib/utils/tablerIcon.ts
@@ -3,9 +3,12 @@ import { IconLayoutGrid, type TablerIcon } from "@tabler/icons-react";
 
 // Custom tabs store a free-text Tabler icon name (e.g. "IconBolt"). Tabler ships
 // no runtime name -> component resolver, so we build one from the namespace
-// import. This pulls the full icon set into the bundle (tree-shaking is lost);
-// acceptable for this internal platform. If bundle size becomes a concern, swap
-// `iconMap` for a curated allowlist without changing callers.
+// import. This pulls the full icon set in (tree-shaking is lost), so the module
+// weighs ~2.5 MB.
+//
+// IMPORT THIS MODULE DYNAMICALLY ONLY. A static import drags that 2.5 MB into
+// the initial bundle for every visitor. `TablerIconByName` is the one caller and
+// it goes through `await import()` to keep the weight in a lazy chunk.
 //
 // The namespace also exports non-icon members (createReactComponent, iconsList,
 // ...), so the filter keeps only `Icon*` forwardRef components.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -61,6 +61,26 @@ const router = createRouter({
   history: createAppHistory(),
   context: { isSignedIn: false },
   defaultErrorComponent: DeploymentErrorFallback,
+  // Fetch a route's chunk while the pointer rests on its link, so the click
+  // renders from cache instead of waiting on the network. Routes with a
+  // side-effecting `beforeLoad` must bail out on the `preload` flag — see
+  // `routes/index.tsx` and `routes/_global/home.tsx`.
+  defaultPreload: "intent",
+  // Twice the 50ms default: long enough that dragging the pointer across a
+  // sidebar does not queue a fetch for every item it crosses.
+  defaultPreloadDelay: 100,
+  // Monorepo apps: address bar + link hrefs use /owner/repo/app/… while the
+  // route tree matches /owner/repo--app/… (single $repo segment).
+  rewrite: {
+    input: ({ url }) => {
+      url.pathname = toInternalRepoHref(url.pathname);
+      return url;
+    },
+    output: ({ url }) => {
+      url.pathname = toDisplayRepoHref(url.pathname);
+      return url;
+    },
+  },
 });
 
 declare module "@tanstack/react-router" {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -3,9 +3,9 @@ import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import { Analytics } from "@vercel/analytics/react";
 import { ClientProvider } from "@/lib/components/ClientProvider";
-import { ChangelogDialog } from "@/lib/components/ChangelogDialog";
 import { AppToaster } from "@/lib/components/AppToaster";
 import { AppShell } from "@/lib/components/AppShell";
+import { ChangelogDialogGate } from "@/lib/components/ChangelogDialogGate";
 import { useDocumentTitle } from "@/lib/hooks/useDocumentTitle";
 
 export interface RouterContext {
@@ -35,7 +35,7 @@ function RootComponent() {
           <Outlet />
         </AppShell>
       </NuqsAdapter>
-      <ChangelogDialog />
+      <ChangelogDialogGate />
       <AppToaster />
       <Analytics />
       {DevAgentation ? (

--- a/apps/web/src/routes/_global/home.tsx
+++ b/apps/web/src/routes/_global/home.tsx
@@ -7,7 +7,11 @@ export const Route = createFileRoute("/_global/home")({
   // If the user landed here mid-MCP OAuth flow (Clerk's prod handshake can
   // redirect to the global `signInFallbackRedirectUrl` before our authorize
   // route can mint the code), bounce them back into the flow.
-  beforeLoad: () => {
+  // `preload` guard: consuming the params is destructive and the thrown
+  // redirect is swallowed during a preload, so a hover over any `/home` link
+  // would silently drop the user out of the OAuth flow.
+  beforeLoad: ({ preload }) => {
+    if (preload) return;
     const pending = consumeMcpOauthParams();
     if (pending) {
       throw redirect({

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SandboxTabBar.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SandboxTabBar.tsx
@@ -16,7 +16,7 @@ import {
 import type { Doc } from "@eva/backend";
 import { useCycleSandboxTabHotkey } from "@/lib/components/sandbox/useCycleSandboxTabHotkey";
 import { slugifyAppTabName } from "@/lib/utils/appTabSlug";
-import { resolveTablerIcon } from "@/lib/utils/tablerIcon";
+import { TablerIconByName } from "@/lib/components/TablerIconByName";
 import type { SandboxTab } from "@/lib/search-params";
 import {
   Tabs,
@@ -259,7 +259,6 @@ export function SandboxTabBar({
             </TabsTrigger>
           ) : null}
           {customTabs?.map((tab) => {
-            const Icon = resolveTablerIcon(tab.icon);
             const slug = slugifyAppTabName(tab.name);
             return (
               <TabsTrigger
@@ -267,7 +266,7 @@ export function SandboxTabBar({
                 value={slug}
                 className={TAB_TRIGGER_CLASS}
               >
-                <Icon className="w-3.5 h-3.5" />
+                <TablerIconByName name={tab.icon} className="w-3.5 h-3.5" />
                 {tab.name}
               </TabsTrigger>
             );

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/TabsSettingsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/TabsSettingsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, createElement } from "react";
+import { useState } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import { Button, Input } from "@eva/ui";
@@ -10,7 +10,7 @@ import {
   RESERVED_APP_TAB_SLUGS,
   slugifyAppTabName,
 } from "@/lib/utils/appTabSlug";
-import { resolveTablerIcon } from "@/lib/utils/tablerIcon";
+import { TablerIconByName } from "@/lib/components/TablerIconByName";
 import { CustomTabRow } from "./_components/CustomTabRow";
 import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
@@ -18,9 +18,12 @@ import { SettingsField } from "@/lib/components/settings/SettingsField";
 import { IconLayoutNavbar } from "@tabler/icons-react";
 
 function TabIconPreview({ icon }: { icon: string }) {
-  return createElement(resolveTablerIcon(icon), {
-    className: "mb-2 h-4 w-4 shrink-0 text-muted-foreground",
-  });
+  return (
+    <TablerIconByName
+      name={icon}
+      className="mb-2 h-4 w-4 shrink-0 text-muted-foreground"
+    />
+  );
 }
 
 function nameError(

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/_components/CustomTabRow.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/_components/CustomTabRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, createElement } from "react";
+import { useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import type { Doc } from "@eva/backend";
@@ -10,7 +10,7 @@ import {
   RESERVED_APP_TAB_SLUGS,
   slugifyAppTabName,
 } from "@/lib/utils/appTabSlug";
-import { resolveTablerIcon } from "@/lib/utils/tablerIcon";
+import { TablerIconByName } from "@/lib/components/TablerIconByName";
 
 interface CustomTabRowProps {
   tab: Doc<"appTabs">;
@@ -19,9 +19,12 @@ interface CustomTabRowProps {
 }
 
 function CustomTabIcon({ icon }: { icon: string }) {
-  return createElement(resolveTablerIcon(icon), {
-    className: "h-4 w-4 shrink-0 text-muted-foreground",
-  });
+  return (
+    <TablerIconByName
+      name={icon}
+      className="h-4 w-4 shrink-0 text-muted-foreground"
+    />
+  );
 }
 
 /**

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -12,8 +12,10 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/")({
   validateSearch: searchSchema,
-  beforeLoad: ({ context, search }) => {
-    if (search.agent) {
+  // A preload must not navigate the whole page, so the agent-login hand-off
+  // only runs for a real visit.
+  beforeLoad: ({ context, search, preload }) => {
+    if (search.agent && !preload) {
       window.location.href = "/api/auth/agent-login";
     }
     if (context.isSignedIn) {

--- a/apps/web/src/routes/mcp/oauth/authorize.tsx
+++ b/apps/web/src/routes/mcp/oauth/authorize.tsx
@@ -16,7 +16,10 @@ export const Route = createFileRoute("/mcp/oauth/authorize")({
   // Persist the OAuth params before any auth-driven redirect can strip them.
   // Prod Clerk live keys can bounce us to `/home` during the popup's session
   // handshake; `/home` reads this storage to recover us back into the flow.
-  beforeLoad: ({ search }) => {
+  // Skipped on preload so a hover cannot overwrite stored params with a
+  // half-filled search from some other link.
+  beforeLoad: ({ search, preload }) => {
+    if (preload) return;
     saveMcpOauthParams(search);
   },
   component: McpOauthAuthorize,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,7 @@ import tanstackRouter from "@tanstack/router-plugin/vite";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
 import { tablerDeepImports } from "./vite/deepImports";
+import { originHints } from "./vite/originHints";
 
 function agentLoginPlugin(): Plugin {
   let env: Record<string, string>;
@@ -87,6 +88,7 @@ export default defineConfig({
     // Only `tablerIcon.ts` still reaches the icon barrel, behind a dynamic
     // import — see lib/components/TablerIconByName.tsx.
     tablerDeepImports(),
+    originHints(),
     agentLoginPlugin(),
     process.env.ANALYZE === "true" &&
       visualizer({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, loadEnv, type Plugin } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
+import transformImports from "@rolldown/plugin-transform-imports";
 import tanstackRouter from "@tanstack/router-plugin/vite";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
@@ -83,6 +84,28 @@ export default defineConfig({
     // React Compiler for both dev and build so local runtime matches production
     // memoization (dev transforms are slower; worth it for responsive UI).
     babel({ presets: [reactCompilerPreset()] }),
+    // `import { IconPlus } from "@tabler/icons-react"` pulls in Tabler's barrel,
+    // which re-exports 6095 icons — so the barrel lands in the eager graph and
+    // drags every icon with it (~2.5 MB / 489 kB gzip in the initial payload).
+    // Rewriting each named import to its own icon file means the barrel is never
+    // loaded here; only `tablerIcon.ts` still reads it, behind a dynamic import.
+    //
+    // `^Icon.+$` deliberately excludes the bare `Icon` type export (there is no
+    // `icons/Icon.mjs`); unmatched members keep their original import.
+    //
+    // Build-only: in dev these deep paths are each a fresh optimizer entry, so
+    // every newly visited route would re-bundle deps and force a page reload.
+    // Dev keeps the barrel, which the optimizer pre-bundles once.
+    {
+      ...transformImports({
+        "@tabler/icons-react": {
+          transform: [
+            ["^Icon.+$", "@tabler/icons-react/dist/esm/icons/{{member}}.mjs"],
+          ],
+        },
+      }),
+      apply: "build",
+    },
     agentLoginPlugin(),
     process.env.ANALYZE === "true" &&
       visualizer({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig, loadEnv, type Plugin } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
-import transformImports from "@rolldown/plugin-transform-imports";
 import tanstackRouter from "@tanstack/router-plugin/vite";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
+import { tablerDeepImports } from "./vite/deepImports";
 
 function agentLoginPlugin(): Plugin {
   let env: Record<string, string>;
@@ -84,28 +84,9 @@ export default defineConfig({
     // React Compiler for both dev and build so local runtime matches production
     // memoization (dev transforms are slower; worth it for responsive UI).
     babel({ presets: [reactCompilerPreset()] }),
-    // `import { IconPlus } from "@tabler/icons-react"` pulls in Tabler's barrel,
-    // which re-exports 6095 icons — so the barrel lands in the eager graph and
-    // drags every icon with it (~2.5 MB / 489 kB gzip in the initial payload).
-    // Rewriting each named import to its own icon file means the barrel is never
-    // loaded here; only `tablerIcon.ts` still reads it, behind a dynamic import.
-    //
-    // `^Icon.+$` deliberately excludes the bare `Icon` type export (there is no
-    // `icons/Icon.mjs`); unmatched members keep their original import.
-    //
-    // Build-only: in dev these deep paths are each a fresh optimizer entry, so
-    // every newly visited route would re-bundle deps and force a page reload.
-    // Dev keeps the barrel, which the optimizer pre-bundles once.
-    {
-      ...transformImports({
-        "@tabler/icons-react": {
-          transform: [
-            ["^Icon.+$", "@tabler/icons-react/dist/esm/icons/{{member}}.mjs"],
-          ],
-        },
-      }),
-      apply: "build",
-    },
+    // Only `tablerIcon.ts` still reaches the icon barrel, behind a dynamic
+    // import — see lib/components/TablerIconByName.tsx.
+    tablerDeepImports(),
     agentLoginPlugin(),
     process.env.ANALYZE === "true" &&
       visualizer({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -148,6 +148,15 @@ export default defineConfig({
     rolldownOptions: {
       output: {
         codeSplitting: {
+          // Only group packages whose whole cost we are happy to load eagerly.
+          //
+          // A group's `test` claims EVERY module under the matched path,
+          // including third-party utilities the package bundles inside its own
+          // dist (dayjs inside mermaid, clsx inside streamdown). One eager
+          // import of such a utility pulls the entire group chunk into the
+          // entry graph, so index.html modulepreloads all of it. That is how
+          // mermaid/shiki/streamdown/katex were costing 1.2 MB gzip on first
+          // load — do not add groups for them.
           groups: [
             {
               name: "vendor-radix",
@@ -165,29 +174,9 @@ export default defineConfig({
               priority: 15,
             },
             {
-              name: "vendor-streamdown",
-              test: /node_modules[\\/](streamdown|@streamdown)/,
-              priority: 15,
-            },
-            {
               name: "vendor-motion",
               test: /node_modules[\\/](motion|framer-motion)/,
               priority: 15,
-            },
-            {
-              name: "vendor-shiki",
-              test: /node_modules[\\/]shiki/,
-              priority: 20,
-            },
-            {
-              name: "vendor-katex",
-              test: /node_modules[\\/]katex/,
-              priority: 20,
-            },
-            {
-              name: "vendor-mermaid",
-              test: /node_modules[\\/]mermaid/,
-              priority: 20,
             },
           ],
         },

--- a/apps/web/vite/deepImports.ts
+++ b/apps/web/vite/deepImports.ts
@@ -1,0 +1,52 @@
+import transformImports, {
+  type TransformImportsOptions,
+} from "@rolldown/plugin-transform-imports";
+
+/**
+ * The plugin is a rolldown plugin, not a Vite one. Vite declares `resolveId`'s
+ * options with an optional `kind`, so the two `Plugin` types are not mutually
+ * assignable even though Vite runs rolldown plugins natively. Keeping the
+ * package's own type avoids a cast.
+ */
+type BuildOnlyPlugin = ReturnType<typeof transformImports> & {
+  apply: "build";
+};
+
+/**
+ * Rewrites named barrel imports to per-file deep paths, at build time only.
+ *
+ * A package whose entry re-exports hundreds of modules lands in the eager
+ * module graph as soon as anything imports a single member from it, and drags
+ * the rest along with it. Rewriting `import { X } from "pkg"` to
+ * `import X from "pkg/dist/X.mjs"` means the barrel is never loaded.
+ *
+ * Build-only on purpose: in dev each deep path is its own optimizer entry, so
+ * every newly visited route would re-bundle deps and force a page reload. Dev
+ * keeps the barrel, which the optimizer pre-bundles once.
+ *
+ * Works for any package with a fat entry and a one-file-per-export dist —
+ * `lucide-react`, `@mui/icons-material`, `react-icons/*`, `date-fns`.
+ * Requires Vite 8 / rolldown; Next.js has this built in as
+ * `experimental.optimizePackageImports`.
+ */
+export function buildOnlyDeepImports(
+  options: TransformImportsOptions,
+): BuildOnlyPlugin {
+  return { ...transformImports(options), apply: "build" };
+}
+
+/**
+ * Keeps Tabler's 6095-icon barrel out of the eager graph (~2.5 MB / 489 kB gzip).
+ *
+ * `^Icon.+$` deliberately excludes the bare `Icon` type export — there is no
+ * `icons/Icon.mjs`. Members that do not match keep their original import.
+ */
+export function tablerDeepImports(): BuildOnlyPlugin {
+  return buildOnlyDeepImports({
+    "@tabler/icons-react": {
+      transform: [
+        ["^Icon.+$", "@tabler/icons-react/dist/esm/icons/{{member}}.mjs"],
+      ],
+    },
+  });
+}

--- a/apps/web/vite/originHints.ts
+++ b/apps/web/vite/originHints.ts
@@ -1,0 +1,79 @@
+import type { Plugin } from "vite";
+
+/** Replaced in `index.html` with one preconnect + dns-prefetch pair per origin. */
+const PLACEHOLDER = "<!-- origin-hints -->";
+
+function stringEnv(
+  env: Record<string, string>,
+  key: string,
+): string | undefined {
+  const value = env[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function originOf(url: string): string | undefined {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * A Clerk publishable key carries its own frontend API host: the part after
+ * `pk_test_` / `pk_live_` is base64 of `<host>$`. Deriving the host from the key
+ * means the hint can never point at a different Clerk instance than the one the
+ * app authenticates against.
+ */
+function clerkFrontendOrigin(publishableKey: string): string | undefined {
+  const encoded = publishableKey.replace(/^pk_(test|live)_/, "");
+  if (encoded === publishableKey) return undefined;
+  const host = Buffer.from(encoded, "base64")
+    .toString("utf8")
+    .replace(/\$$/, "");
+  if (!/^[a-z0-9.-]+$/i.test(host)) return undefined;
+  return `https://${host}`;
+}
+
+/**
+ * Emits the Convex and Clerk resource hints from build-time env instead of
+ * hardcoding them in `index.html`.
+ *
+ * Both hosts are per-deployment, so a checked-in literal goes stale the moment
+ * a deployment moves — and a preconnect to an origin the page never contacts is
+ * a wasted TLS handshake, not a no-op. Fonts stay hardcoded in `index.html`
+ * because those origins are the same everywhere.
+ */
+export function originHints(): Plugin {
+  let env: Record<string, string> = {};
+
+  return {
+    name: "eva-origin-hints",
+    configResolved(config) {
+      env = config.env;
+    },
+    transformIndexHtml(html) {
+      if (!html.includes(PLACEHOLDER)) {
+        throw new Error(
+          `origin-hints: index.html is missing the "${PLACEHOLDER}" placeholder.`,
+        );
+      }
+
+      const convexUrl = stringEnv(env, "VITE_CONVEX_URL");
+      const clerkKey = stringEnv(env, "VITE_CLERK_PUBLISHABLE_KEY");
+      const origins = [
+        convexUrl === undefined ? undefined : originOf(convexUrl),
+        clerkKey === undefined ? undefined : clerkFrontendOrigin(clerkKey),
+      ].filter((origin): origin is string => origin !== undefined);
+
+      const tags = origins
+        .flatMap((origin) => [
+          `<link rel="preconnect" href="${origin}" crossorigin />`,
+          `<link rel="dns-prefetch" href="${origin}" />`,
+        ])
+        .join("\n    ");
+
+      return html.replace(PLACEHOLDER, tags);
+    },
+  };
+}

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Another 1.2 MB off first load, and clicks that wait for nothing - 2026-08-04
+
+- Four `codeSplitting.groups` entries were quietly forcing mermaid, shiki, streamdown, and katex into the eager module graph: a group's `test` claims every module under the matched path, including third-party utilities a package bundles inside its own dist, so one eager import of dayjs (bundled inside mermaid) or clsx (inside streamdown) dragged the entire group chunk into the entry. Dropping those groups cut the modulepreload set from 1585.6 kB to 347.6 kB gzip, and total output grew only 0.9%, which rules out the bytes simply having been duplicated elsewhere.
+- The changelog dialog was `lazy()`, but the root route mounted it unconditionally, so React fetched the chunk on every page load regardless. A small gate component now checks whether there is a changelog to show before it fetches the dialog, moving roughly 220 kB gzip of Streamdown, mermaid, and katex off first load and onto the moment the dialog actually opens.
+- The build-time barrel rewrite from the icon work is now a reusable helper in `vite/deepImports.ts`, so the same trick applies to any fat-entry package (lucide-react, `@mui/icons-material`, react-icons, date-fns) here or in another repo, rather than being a one-off inline block.
+- Routes now preload on hover (`defaultPreload: "intent"`, 100 ms), so a click on a link the pointer has rested on costs no requests at all — measured on a production build, hovering Changelog fetched its 20 chunks and the click then rendered with zero further network activity. Preloading runs `beforeLoad`, so the three route hooks with side effects bail out on the preload flag; `/home` was the one that mattered, since it consumes the stored MCP OAuth params and its redirect is swallowed during a preload, meaning a hover over any `/home` link would previously have dropped the user out of the flow.
+- The Convex and Clerk resource hints were hardcoded in `index.html` and pointed at a Clerk instance the app never contacts, which costs a wasted TLS handshake rather than being harmless. Both origins are now derived from build-time env — the Clerk host is base64-encoded inside the publishable key — so they cannot drift from the deployment again.
+
 ## 489 kB of icons off every first page load - 2026-08-04
 
 - Tabler's package entry re-exports 6095 icons, so an ordinary `import { IconPlus } from "@tabler/icons-react"` put that barrel in the eager module graph. Combined with the runtime name resolver in `tablerIcon.ts`, which reads the whole namespace and therefore blocks tree-shaking, the initial payload carried a 2.5 MB (489 kB gzip) icon chunk that every visitor downloaded.

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 489 kB of icons off every first page load - 2026-08-04
+
+- Tabler's package entry re-exports 6095 icons, so an ordinary `import { IconPlus } from "@tabler/icons-react"` put that barrel in the eager module graph. Combined with the runtime name resolver in `tablerIcon.ts`, which reads the whole namespace and therefore blocks tree-shaking, the initial payload carried a 2.5 MB (489 kB gzip) icon chunk that every visitor downloaded.
+- Named icon imports are now rewritten to their own files at build time (`@rolldown/plugin-transform-imports`), so the barrel is no longer reachable from the eager graph. The plugin is build-only: in dev each deep path is a separate optimizer entry, which would re-bundle deps and reload the page on every newly visited route.
+- The name resolver stays behind a lazy `import()` via a new `TablerIconByName` component, so custom app tabs keep accepting any Tabler name as free text — only the screens that render one pay for the barrel, instead of every visitor.
+- Reason for change: this was diagnosed while chasing build time, which turned out to be immovable. Removing the react() plugin, the router plugin, minification, compressed-size reporting, and half the module graph each changed the build by under 0.5s — it is bound by fixed work, not by anything in the config. The payload was the real defect the investigation surfaced.
+
+
 ## Recording turns cannot self-terminate and report a promise as success - 2026-07-31
 
 All-feature walkthrough turns were using broad `pkill -f` cleanup that could match the Cursor CLI's own command line because the recording instructions are part of its process arguments. The agent died during setup, then the callback discarded Node's close signal and promoted the last streamed "recording now" preamble to a successful final reply. Recording prompts now require exact-PID cleanup, a named feature checklist, and a real deliverable per item; the callback preserves direct signal termination and rejects both direct and shell-translated interruptions even when partial assistant text exists.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react-swc':
         specifier: ^4.3.0
-        version: 4.3.0(@swc/helpers@0.5.23)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.3.0(@swc/helpers@0.5.23)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       ai:
         specifier: ^6.0.75
         version: 6.0.164(zod@4.3.6)
@@ -173,7 +173,7 @@ importers:
         version: 7.0.1-rc
       vite:
         specifier: ^6.3.5
-        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/web:
     dependencies:
@@ -423,13 +423,16 @@ importers:
     devDependencies:
       '@rolldown/plugin-babel':
         specifier: ^0.2.2
-        version: 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rolldown/plugin-transform-imports':
+        specifier: 0.1.1
+        version: 0.1.1(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.120.0
-        version: 1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: ^24.10.1
         version: 24.12.2
@@ -441,7 +444,7 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       agentation:
         specifier: ^3.0.2
         version: 3.0.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -468,10 +471,10 @@ importers:
         version: 7.0.1-rc
       vite:
         specifier: ^8.1.0
-        version: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/backend:
     dependencies:
@@ -1588,7 +1591,6 @@ packages:
   '@clerk/clerk-react@5.61.3':
     resolution: {integrity: sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==}
     engines: {node: '>=18.17.0'}
-    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -3689,6 +3691,16 @@ packages:
       vite:
         optional: true
 
+  '@rolldown/plugin-transform-imports@0.1.1':
+    resolution: {integrity: sha512-X5HYPM/OxWHNG2fOC1eEESuEoGlA1zGrx2csYmFgwPAH+bUjfllLBQeEQ49+Rk9f0x3Z4L72aU0tpxANy5tD/Q==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      rolldown: ^1.0.0-rc.13
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
@@ -4792,7 +4804,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -6021,6 +6032,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
@@ -6866,6 +6881,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.1.0:
+    resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -8049,6 +8067,15 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown-string@0.3.1:
+    resolution: {integrity: sha512-dv8GOXkYqUQdI0rsXB8hmzO95pKWSuX2eg5/JSJa9czfEVIFuKNR7ZJDfat8LlmD35RAhWY+evS7/wXXqFDfSg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      rolldown: '*'
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+
   rolldown@1.1.2:
     resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9090,14 +9117,14 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       zod: 4.3.6
 
   '@ai-sdk/provider@3.0.8':
@@ -12045,7 +12072,7 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.1.2':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
@@ -12053,7 +12080,14 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
       '@babel/runtime': 7.29.7
-      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@rolldown/plugin-transform-imports@0.1.1(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      rolldown: 1.1.2
+      rolldown-string: 0.3.1(rolldown@1.1.2)
+    optionalDependencies:
+      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -12634,7 +12668,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -12651,7 +12685,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.168.22(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13223,20 +13257,20 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.23)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.23)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.26(@swc/helpers@0.5.23)
-      vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/expect@3.2.7':
@@ -13254,6 +13288,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/mocker@3.2.7(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@3.2.7(vite@6.4.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -14516,9 +14558,11 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource-parser@3.1.0: {}
+
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -15433,6 +15477,10 @@ snapshots:
   luxon@3.7.2: {}
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.1.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -17071,6 +17119,12 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown-string@0.3.1(rolldown@1.1.2):
+    dependencies:
+      magic-string: 1.1.0
+    optionalDependencies:
+      rolldown: 1.1.2
+
   rolldown@1.1.2:
     dependencies:
       '@oxc-project/types': 0.137.0
@@ -17870,6 +17924,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
@@ -17891,23 +17966,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.1
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 22.19.17
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      lightningcss: 1.32.0
-      terser: 5.48.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
@@ -17920,6 +17978,23 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.7.0
+      lightningcss: 1.32.0
+      terser: 5.48.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
+  vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      jiti: 1.21.7
       lightningcss: 1.32.0
       terser: 5.48.0
       tsx: 4.21.0
@@ -17942,7 +18017,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.1.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -17953,7 +18028,7 @@ snapshots:
       '@types/node': 24.12.2
       esbuild: 0.27.7
       fsevents: 2.3.3
-      jiti: 2.7.0
+      jiti: 1.21.7
       terser: 5.48.0
       tsx: 4.21.0
       yaml: 2.9.0
@@ -17986,6 +18061,48 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 24.12.2
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary
- Remove React Compiler from the web build.
- Drop ~489 kB gzip of Tabler icons from the eager graph (deep-import rewrite + lazy name resolver).
- Cut ~1.2 MB gzip from first load (code-splitting groups + changelog dialog gate).
- Extract reusable `vite/deepImports.ts` helper; preload routes on hover; derive Convex/Clerk origin hints from env.

## Notes
- Split from #514 (`staging` → `main`). Additive only — does not close or replace #514.
- Independent of the Cursor ACP and Reviews split PRs.

## Test plan
- [ ] Production build: initial JS payload smaller; no huge Tabler chunk on first load
- [ ] Hover a sidebar/nav link then click — route chunks already fetched
- [ ] `/home` MCP OAuth flow still works (preload must not consume OAuth params)
- [ ] Changelog dialog still opens when there is an entry
- [ ] Custom tabs with free-text Tabler icon names still render
