### PR TITLE
fix(web): show toolbar search as a full input by default

### DIFF
--- a/apps/web/src/lib/components/ui/ToggleSearch.tsx
+++ b/apps/web/src/lib/components/ui/ToggleSearch.tsx
@@ -1,26 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import { m, AnimatePresence } from "motion/react";
-import {
-  Button,
-  Input,
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-  cn,
-} from "@eva/ui";
+import { Input, cn } from "@eva/ui";
 import { IconSearch, IconX } from "@tabler/icons-react";
 
-// "compact" is the small toolbar pill; "large" is the taller, wider,
-// rounded-and-shadowed bar used on the quick-tasks page.
+// "compact" is the small toolbar field; "large" is the taller, wider
+// rounded-and-shadowed bar used on the quick-tasks / projects pages.
 type ToggleSearchVariant = "compact" | "large";
 
 interface ToggleSearchProps {
   value: string;
   onChange: (value: string | null) => void;
   placeholder?: string;
-  tooltipLabel?: string;
   visible?: boolean;
   variant?: ToggleSearchVariant;
 }
@@ -29,97 +19,51 @@ export function ToggleSearch({
   value,
   onChange,
   placeholder = "Search...",
-  tooltipLabel = "Search",
   visible = true,
   variant = "compact",
 }: ToggleSearchProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const showInput = isOpen || !!value;
   const isLarge = variant === "large";
 
   if (!visible) return null;
 
   return (
-    <AnimatePresence mode="popLayout" initial={false}>
-      {showInput ? (
-        <m.div
-          key="toggle-search-input"
-          initial={{ opacity: 0, width: 0 }}
-          animate={{ opacity: 1, width: "auto" }}
-          exit={{ opacity: 0, width: 0 }}
-          transition={{ duration: 0.2 }}
-          className="overflow-hidden"
-        >
-          <div
-            className={cn(
-              "relative",
-              isLarge ? "w-56 sm:w-64 md:w-80" : "w-28 sm:w-32 md:w-44",
-            )}
-          >
-            <IconSearch
-              size={isLarge ? 16 : 14}
-              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              autoFocus
-              placeholder={placeholder}
-              value={value}
-              onChange={(e) => onChange(e.target.value || null)}
-              onBlur={() => {
-                if (!value) setIsOpen(false);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  onChange(null);
-                  setIsOpen(false);
-                }
-              }}
-              className={cn(
-                isLarge
-                  ? "h-9 rounded-control pl-9 pr-8 text-sm shadow-sm focus-visible:border-border focus-visible:shadow-md focus-visible:ring-0"
-                  : "h-8 pl-7 pr-7 text-sm focus-visible:border-border focus-visible:shadow-lg focus-visible:ring-0",
-              )}
-            />
-            {value && (
-              <button
-                type="button"
-                onClick={() => {
-                  onChange(null);
-                  setIsOpen(false);
-                }}
-                className={cn(
-                  "absolute top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground",
-                  isLarge ? "right-3" : "right-2",
-                )}
-              >
-                <IconX size={isLarge ? 15 : 13} />
-              </button>
-            )}
-          </div>
-        </m.div>
-      ) : (
-        <m.div
-          key="toggle-search-icon"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.15 }}
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="motion-press h-8 w-8 hover:scale-[1.03] active:scale-[0.96]"
-                onClick={() => setIsOpen(true)}
-              >
-                <IconSearch size={16} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{tooltipLabel}</TooltipContent>
-          </Tooltip>
-        </m.div>
+    <div
+      className={cn(
+        "relative",
+        isLarge ? "w-56 sm:w-64 md:w-80" : "w-28 sm:w-32 md:w-44",
       )}
-    </AnimatePresence>
+    >
+      <IconSearch
+        size={isLarge ? 16 : 14}
+        className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+      />
+      <Input
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value || null)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            onChange(null);
+          }
+        }}
+        className={cn(
+          isLarge
+            ? "h-9 rounded-control pl-9 pr-8 text-sm shadow-sm focus-visible:border-border focus-visible:shadow-md focus-visible:ring-0"
+            : "h-8 pl-7 pr-7 text-sm focus-visible:border-border focus-visible:shadow-lg focus-visible:ring-0",
+        )}
+      />
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className={cn(
+            "absolute top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground",
+            isLarge ? "right-3" : "right-2",
+          )}
+        >
+          <IconX size={isLarge ? 15 : 13} />
+        </button>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/lib/components/ui/ToggleSearch.tsx
+++ b/apps/web/src/lib/components/ui/ToggleSearch.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Input, cn } from "@eva/ui";
-import { IconSearch, IconX } from "@tabler/icons-react";
+import { SearchInput, cn } from "@eva/ui";
 
-// "compact" is the small toolbar field; "large" is the taller, wider
-// rounded-and-shadowed bar used on the quick-tasks / projects pages.
+// "compact" is the narrow logs/toolbar field; "large" is the wider field on
+// quick-tasks and projects.
 type ToggleSearchVariant = "compact" | "large";
 
 interface ToggleSearchProps {
@@ -15,6 +14,11 @@ interface ToggleSearchProps {
   variant?: ToggleSearchVariant;
 }
 
+/**
+ * Toolbar search built on the shared SearchInput primitive so it matches
+ * other controls (border-input, rounded-control, focus ring) instead of a
+ * one-off shadowed field.
+ */
 export function ToggleSearch({
   value,
   onChange,
@@ -22,48 +26,27 @@ export function ToggleSearch({
   visible = true,
   variant = "compact",
 }: ToggleSearchProps) {
-  const isLarge = variant === "large";
-
   if (!visible) return null;
 
+  const isLarge = variant === "large";
+
   return (
-    <div
+    <SearchInput
+      value={value}
+      onChange={(next) => onChange(next.length > 0 ? next : null)}
+      onClear={() => onChange(null)}
+      placeholder={placeholder}
       className={cn(
-        "relative",
-        isLarge ? "w-56 sm:w-64 md:w-80" : "w-28 sm:w-32 md:w-44",
+        "max-w-none shrink-0",
+        isLarge ? "w-52 sm:w-64 md:w-72" : "w-36 sm:w-44",
       )}
-    >
-      <IconSearch
-        size={isLarge ? 16 : 14}
-        className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-      />
-      <Input
-        placeholder={placeholder}
-        value={value}
-        onChange={(e) => onChange(e.target.value || null)}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            onChange(null);
-          }
-        }}
-        className={cn(
-          isLarge
-            ? "h-9 rounded-control pl-9 pr-8 text-sm shadow-sm focus-visible:border-border focus-visible:shadow-md focus-visible:ring-0"
-            : "h-8 pl-7 pr-7 text-sm focus-visible:border-border focus-visible:shadow-lg focus-visible:ring-0",
-        )}
-      />
-      {value ? (
-        <button
-          type="button"
-          onClick={() => onChange(null)}
-          className={cn(
-            "absolute top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground",
-            isLarge ? "right-3" : "right-2",
-          )}
-        >
-          <IconX size={isLarge ? 15 : 13} />
-        </button>
-      ) : null}
-    </div>
+      // Match neighboring h-8 toolbar chips (view toggle, filter buttons).
+      inputClassName="h-8"
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          onChange(null);
+        }
+      }}
+    />
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/projects/ProjectsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/projects/ProjectsClient.tsx
@@ -233,7 +233,6 @@ export function ProjectsClient() {
         value={searchQuery}
         onChange={(v) => setParams({ q: v ?? "" })}
         placeholder="Search projects..."
-        tooltipLabel="Search projects"
         visible={hasProjects}
         variant="large"
       />

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/QuickTasksToolbar.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/QuickTasksToolbar.tsx
@@ -196,7 +196,6 @@ export function QuickTasksToolbar({
         value={searchQuery}
         onChange={onSearchChange}
         placeholder="Search tasks..."
-        tooltipLabel="Search tasks"
         visible={hasQuickTasks}
         variant="large"
       />

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/logs/_components/LogsHeader.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/logs/_components/LogsHeader.tsx
@@ -51,7 +51,6 @@ export function LogsHeader({
         value={searchQuery}
         onChange={onSearchChange}
         placeholder="Search logs..."
-        tooltipLabel="Search logs"
       />
 
       <div className="flex items-center rounded-lg bg-muted/60 p-0.5">

--- a/packages/ui/src/ui/search-input.tsx
+++ b/packages/ui/src/ui/search-input.tsx
@@ -1,8 +1,11 @@
 import { IconSearch } from "@tabler/icons-react";
-import { ClearInput } from "./clear-input";
+import { ClearInput, type ClearInputProps } from "./clear-input";
 import { cn } from "../utils/cn";
 
-interface SearchInputProps {
+interface SearchInputProps extends Omit<
+  ClearInputProps,
+  "value" | "onChange" | "leading" | "wrapperClassName"
+> {
   value: string;
   onChange: (value: string) => void;
   onClear: () => void;
@@ -18,6 +21,7 @@ function SearchInput({
   placeholder = "Search...",
   className,
   inputClassName,
+  ...props
 }: SearchInputProps) {
   return (
     <ClearInput
@@ -37,6 +41,7 @@ function SearchInput({
           className="pointer-events-none absolute left-3 top-1/2 z-[3] -translate-y-1/2 text-muted-foreground"
         />
       }
+      {...props}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Toolbar search is a full input by default (not a collapsed icon toggle).
- Restyled to match design-system search inputs.

## Notes
- Split from Staging #514. Additive only.

## Test plan
- [ ] Projects / quick-tasks / logs toolbars show a full search field
- [ ] Typing filters as before; clear works