### PR TITLE
feat(teams): Activity tab showing who is online and where

### DIFF
--- a/apps/web/src/lib/search-params.ts
+++ b/apps/web/src/lib/search-params.ts
@@ -372,7 +372,13 @@ export function isEnvVarScope(s: string): s is EnvVarScope {
   return envVarScopes.some((scope) => scope === s);
 }
 
-const teamDetailTabs = ["members", "codebases", "env", "artifacts"] as const;
+const teamDetailTabs = [
+  "activity",
+  "members",
+  "codebases",
+  "env",
+  "artifacts",
+] as const;
 export type TeamDetailTab = (typeof teamDetailTabs)[number];
 
 export function isTeamDetailTab(s: string): s is TeamDetailTab {

--- a/apps/web/src/routes/_global/teams/$teamId/$teamTab.tsx
+++ b/apps/web/src/routes/_global/teams/$teamId/$teamTab.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_global/teams/$teamId/$teamTab")({
         to: "/teams/$teamId/$teamTab",
         params: {
           teamId: params.teamId,
-          teamTab: "members",
+          teamTab: "activity",
         },
       });
     }

--- a/apps/web/src/routes/_global/teams/$teamId/index.tsx
+++ b/apps/web/src/routes/_global/teams/$teamId/index.tsx
@@ -6,7 +6,7 @@ export const Route = createFileRoute("/_global/teams/$teamId/")({
       to: "/teams/$teamId/$teamTab",
       params: {
         teamId: params.teamId,
-        teamTab: "members",
+        teamTab: "activity",
       },
     });
   },

--- a/apps/web/src/routes/_global/teams/TeamDetailClient.tsx
+++ b/apps/web/src/routes/_global/teams/TeamDetailClient.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@eva/backend";
-import type { TeamDetailTab } from "@/lib/search-params";
+import { isTeamDetailTab, type TeamDetailTab } from "@/lib/search-params";
 import { PageWrapper } from "@/lib/components/PageWrapper";
 import { EntityNotFound } from "@/lib/components/EntityNotFound";
 import { RepoLogo } from "@/lib/components/RepoLogo";
@@ -16,6 +16,7 @@ import {
   Button,
 } from "@eva/ui";
 import { IconUsers, IconPhoto, IconPhotoOff } from "@tabler/icons-react";
+import { TeamActivityTab } from "./_components/TeamActivityTab";
 import { TeamMembersTab } from "./_components/TeamMembersTab";
 import { TeamReposTab } from "./_components/TeamReposTab";
 import { TeamEnvVarsTab } from "./_components/TeamEnvVarsTab";
@@ -191,12 +192,7 @@ export function TeamDetailClient({
       <Tabs
         value={tab}
         onValueChange={(v) => {
-          if (
-            v === "members" ||
-            v === "codebases" ||
-            v === "env" ||
-            v === "artifacts"
-          ) {
+          if (isTeamDetailTab(v)) {
             navigate({
               to: `/teams/${teamId}/${v}`,
             });
@@ -205,12 +201,17 @@ export function TeamDetailClient({
       >
         <TabsBar className="mb-4 px-0 pt-0">
           <TabsList>
+            <TabsTrigger value="activity">Activity</TabsTrigger>
             <TabsTrigger value="members">Members</TabsTrigger>
             <TabsTrigger value="codebases">Codebases</TabsTrigger>
             <TabsTrigger value="env">Environment Variables</TabsTrigger>
             <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
           </TabsList>
         </TabsBar>
+
+        <TabsContent value="activity">
+          <TeamActivityTab members={members} />
+        </TabsContent>
 
         <TabsContent value="members">
           <TeamMembersTab

--- a/apps/web/src/routes/_global/teams/_components/TeamActivityTab.tsx
+++ b/apps/web/src/routes/_global/teams/_components/TeamActivityTab.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { api } from "@eva/backend";
+import type { FunctionReturnType } from "convex/server";
+import { Button, Card, CardContent } from "@eva/ui";
+import { IconEye, IconEyeOff, IconUsers } from "@tabler/icons-react";
+import { UserInitials } from "@eva/shared";
+import { useFollow } from "@/lib/contexts/FollowContext";
+import { useQuantizedNow } from "@/lib/hooks/useQuantizedNow";
+import { describeLocation } from "../_utils";
+
+type Member = FunctionReturnType<typeof api.teamMembers.list>[number];
+
+/** Same window the sidebar's online avatars use, so the two never disagree. */
+const ONLINE_WINDOW_MS = 2 * 60 * 1000;
+
+function getDisplayName(user: Member["user"]): string {
+  if (!user) return "Unknown";
+  return (
+    `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() ||
+    user.fullName ||
+    user.email ||
+    "Unknown"
+  );
+}
+
+/**
+ * Who on this team is online right now, what page they are on, and a button to
+ * follow them. Follow goes through the same `FollowContext` as the sidebar's
+ * online avatars, so `FollowOverlay` drives the navigation either way.
+ */
+export function TeamActivityTab({ members }: { members: Array<Member> }) {
+  const currentUserId = useQuery(api.auth.me);
+  const { following, startFollowing, stopFollowing } = useFollow();
+
+  // Presence is decided here, not in the query: the server returns a raw
+  // `lastSeenAt` and only a client can re-evaluate the window as time passes.
+  const now = useQuantizedNow(30_000);
+  const onlineMembers = members.filter(
+    (member) =>
+      !!member.user?.lastSeenAt &&
+      now - member.user.lastSeenAt < ONLINE_WINDOW_MS,
+  );
+
+  if (onlineMembers.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
+          <IconUsers size={20} className="text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            Nobody from this team is online right now.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {onlineMembers.map((member) => {
+        const name = getDisplayName(member.user);
+        const location = describeLocation(member.user?.lastSeenPath);
+        const isSelf = member.userId === currentUserId;
+        const isFollowing = following?.userId === member.userId;
+        const canFollow = !isSelf && !!member.user?.lastSeenPath;
+
+        return (
+          <Card key={member._id}>
+            <CardContent className="flex items-center justify-between gap-2 p-3 sm:p-4">
+              <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+                <UserInitials userId={member.userId} hideLastSeen size="md" />
+                <div className="min-w-0">
+                  <p className="flex items-center gap-1.5 text-sm font-medium">
+                    <span data-pii className="truncate">
+                      {name}
+                    </span>
+                    {isSelf ? (
+                      <span className="shrink-0 rounded-full bg-secondary px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground">
+                        You
+                      </span>
+                    ) : null}
+                  </p>
+                  <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <span
+                      className="size-1.5 shrink-0 rounded-full bg-success"
+                      aria-hidden
+                    />
+                    <span className="truncate">{location ?? "Online"}</span>
+                  </p>
+                </div>
+              </div>
+              {isFollowing ? (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className="shrink-0"
+                  onClick={stopFollowing}
+                >
+                  <IconEyeOff size={14} className="mr-1.5" />
+                  Stop following
+                </Button>
+              ) : canFollow ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="shrink-0"
+                  onClick={() => startFollowing(member.userId, name)}
+                >
+                  <IconEye size={14} className="mr-1.5" />
+                  Follow
+                </Button>
+              ) : null}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/routes/_global/teams/_utils.ts
+++ b/apps/web/src/routes/_global/teams/_utils.ts
@@ -1,0 +1,54 @@
+/** Top-level global routes, keyed by their first path segment. */
+const GLOBAL_LABELS: Record<string, string> = {
+  home: "Home",
+  teams: "Teams",
+  artifacts: "Artifacts",
+  inbox: "Inbox",
+  sessions: "Sessions",
+  settings: "Settings",
+  setup: "Setup",
+  testing: "Testing",
+};
+
+/** Sections under `/{owner}/{repo}`, keyed by their third path segment. */
+const REPO_SECTION_LABELS: Record<string, string> = {
+  automations: "Automations",
+  docs: "Docs",
+  drafts: "Drafts",
+  inbox: "Inbox",
+  projects: "Projects",
+  "quick-tasks": "Quick tasks",
+  reviews: "Reviews",
+  sessions: "Sessions",
+  settings: "Settings",
+  stats: "Stats",
+  "testing-arena": "Testing arena",
+};
+
+/**
+ * Turns a teammate's `lastSeenPath` into a readable location, e.g.
+ * `/acme/web/sessions/12` → "acme/web · Sessions". Returns null when there is
+ * no path to describe, so callers can fall back to "Online".
+ *
+ * Deliberately segment-based rather than route-matched: presence stores a bare
+ * pathname, and a label only needs the first three segments.
+ */
+export function describeLocation(pathname?: string): string | null {
+  if (!pathname) return null;
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  const first = segments[0];
+  if (first === undefined) return "Home";
+
+  const global = GLOBAL_LABELS[first];
+  if (global !== undefined) return global;
+
+  const second = segments[1];
+  if (second === undefined) return first;
+
+  // Repo routes are `/{owner}/{repo}[/section/...]`, where the repo segment may
+  // carry a sandboxed-app suffix (`repo--app`) that is noise in a label.
+  const repo = `${first}/${second.replace(/--.*$/, "")}`;
+  const third = segments[2];
+  const section = third === undefined ? undefined : REPO_SECTION_LABELS[third];
+  return section === undefined ? repo : `${repo} · ${section}`;
+}

--- a/packages/backend/convex/teamMembers.ts
+++ b/packages/backend/convex/teamMembers.ts
@@ -47,6 +47,12 @@ export const list = authQuery({
           _id: v.id("users"),
           email: v.optional(v.string()),
           fullName: v.optional(v.string()),
+          firstName: v.optional(v.string()),
+          lastName: v.optional(v.string()),
+          // Presence, for the team page's Activity tab. Deliberately raw: only
+          // a client can re-evaluate "seen in the last two minutes" over time.
+          lastSeenAt: v.optional(v.number()),
+          lastSeenPath: v.optional(v.string()),
         }),
         v.null(),
       ),
@@ -76,6 +82,10 @@ export const list = authQuery({
               _id: user._id,
               email: user.email,
               fullName: user.fullName,
+              firstName: user.firstName,
+              lastName: user.lastName,
+              lastSeenAt: user.lastSeenAt,
+              lastSeenPath: user.lastSeenPath,
             }
           : null,
       });


### PR DESCRIPTION
## Summary
- Teams get an Activity tab listing who is online and their current path.
- Uses existing presence data already written for the platform.

## Notes
- Split from Staging #514. Additive only.

## Test plan
- [ ] Open a team → Activity tab
- [ ] Online members show with last-seen path
- [ ] Offline/away members listed appropriately