### PR TITLE
feat(mentions): people @-mentions in sandbox chats

### DIFF
--- a/apps/web/src/lib/components/chat/MarkdownMentionText.tsx
+++ b/apps/web/src/lib/components/chat/MarkdownMentionText.tsx
@@ -78,13 +78,13 @@ function childrenToText(children: ReactNode): string {
 }
 
 /**
- * Resolves an `@` token that could be either a Data mention or a User mention
- * (only possible in comments, where `CommentMentionInput` lets authors mix
- * both). Uses `mentions.getEntity` — the same lookup Data chips already use
- * for hover/navigate — as the single source of truth for what an opaque
- * mention id points to, rather than guessing from the id's shape.
+ * Resolves an `@` token that could be either a Data mention or a People
+ * mention — the case in every human-authored body (comments and chat messages),
+ * where the picker offers both. Uses `mentions.getEntity` — the same lookup Data
+ * chips already use for hover/navigate — as the single source of truth for what
+ * an opaque mention id points to, rather than guessing from the id's shape.
  */
-function AtMentionChip({
+export function AtMentionChip({
   id,
   label,
   repoId,

--- a/apps/web/src/lib/components/chat/MentionTextarea.tsx
+++ b/apps/web/src/lib/components/chat/MentionTextarea.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import { usePromptInputController, usePromptInputAttachments } from "@eva/ui";
 import type { Id } from "@eva/backend";
 import { attachPastedTextIfLarge } from "@/lib/components/attachments/attachmentMeta";
+import { UserProfileHoverCardBody } from "@eva/shared";
 import {
   MentionEditor,
   type MentionEditorHandle,
@@ -12,8 +13,10 @@ import {
   DataMentionHoverCardBody,
   SkillMentionHoverCardBody,
   isSkillTokenId,
+  mergeMentionItems,
 } from "@/lib/components/mentions";
 import { useDataMentionItems } from "@/lib/hooks/useDataMentionItems";
+import { usePeopleMentionItems } from "@/lib/hooks/usePeopleMentionItems";
 import { useDataMentionNavigate } from "@/lib/useDataMentionNavigate";
 import { useInlineSuggestion } from "@/lib/hooks/useInlineSuggestion";
 
@@ -75,7 +78,9 @@ export const MentionTextarea = forwardRef<
   const controller = usePromptInputController();
   const attachments = usePromptInputAttachments();
   const value = controller.textInput.value;
-  const items = useDataMentionItems(repoId);
+  const peopleItems = usePeopleMentionItems(repoId);
+  const dataItems = useDataMentionItems(repoId);
+  const { items, peopleIds } = mergeMentionItems(peopleItems, dataItems);
   const navigateToData = useDataMentionNavigate(repoBasePath, repoId);
   const { suggestion, dismiss } = useInlineSuggestion(value, completionContext);
 
@@ -117,7 +122,10 @@ export const MentionTextarea = forwardRef<
     return true;
   };
 
+  // People chips are not navigable — a mention names a teammate, it does not
+  // point at a page.
   const handleMentionChipClick = (id: string) => {
+    if (peopleIds.has(id)) return;
     void navigateToData(id);
   };
 
@@ -153,14 +161,18 @@ export const MentionTextarea = forwardRef<
       onDismissSuggestion={dismiss}
       items={items}
       slashItems={slashItems}
-      mentionPopupTitle="Data"
+      mentionPopupTitle="Mentions"
       onMentionChipClick={handleMentionChipClick}
       onSkillChipClick={handleSkillChipClick}
       initialMentionMap={initialMentionMap}
       initialSkillMap={initialSkillMap}
-      renderMentionChipHoverCard={(id) => (
-        <DataMentionHoverCardBody entityId={id} repoId={repoId} />
-      )}
+      renderMentionChipHoverCard={(id) =>
+        peopleIds.has(id) ? (
+          <UserProfileHoverCardBody userId={id} />
+        ) : (
+          <DataMentionHoverCardBody entityId={id} repoId={repoId} />
+        )
+      }
       renderSkillChipHoverCard={(id) =>
         isSkillTokenId(id) ? <SkillMentionHoverCardBody skillId={id} /> : null
       }

--- a/apps/web/src/lib/components/chat/MessageMentionText.tsx
+++ b/apps/web/src/lib/components/chat/MessageMentionText.tsx
@@ -2,11 +2,11 @@ import type { MouseEvent } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   MentionText,
-  DataMentionChip,
   SkillMentionChip,
   isSkillTokenId,
   SKILL_CHIP_CLASS,
 } from "@/lib/components/mentions";
+import { AtMentionChip } from "@/lib/components/chat/MarkdownMentionText";
 import { useDataMentionNavigate } from "@/lib/useDataMentionNavigate";
 import { useRepo } from "@/lib/contexts/RepoContext";
 
@@ -39,13 +39,15 @@ export function MessageMentionText({
           e.stopPropagation();
           void navigateToData(match.id);
         };
+        // This renders the author's own draft/queued text, so a token may name
+        // either a teammate or a data entity — AtMentionChip resolves which.
         return (
-          <DataMentionChip
+          <AtMentionChip
             key={key}
-            entityId={match.id}
-            repoId={repo._id}
+            id={match.id}
             label={match.label}
-            onClick={onClick}
+            repoId={repo._id}
+            onNavigateToData={onClick}
           />
         );
       }}

--- a/apps/web/src/lib/components/chat/ReviewCommentMessage.tsx
+++ b/apps/web/src/lib/components/chat/ReviewCommentMessage.tsx
@@ -13,6 +13,10 @@ interface ReviewCommentMessageProps {
 
 const BODY_CLASS = `${MARKDOWN_PROSE_CLASS} text-sm leading-relaxed break-words`;
 
+// This component only ever renders user-authored chat messages, whose composer
+// offers both teammates and data entities, so every `@` token here needs its
+// kind resolved (`atKind="user"`) rather than assumed to be data.
+
 function ReviewCommentCard({
   filePath,
   rangeLabel,
@@ -38,6 +42,7 @@ function ReviewCommentCard({
           repoBasePath={repoBasePath}
           repoId={repo._id}
           className={BODY_CLASS}
+          atKind="user"
         />
       ) : null}
     </div>
@@ -61,6 +66,7 @@ export function ReviewCommentMessage({
         repoBasePath={repoBasePath}
         repoId={repo._id}
         className={BODY_CLASS}
+        atKind="user"
       />
     );
   }
@@ -76,6 +82,7 @@ export function ReviewCommentMessage({
               repoBasePath={repoBasePath}
               repoId={repo._id}
               className={BODY_CLASS}
+              atKind="user"
             />
           ) : null
         ) : (

--- a/apps/web/src/lib/components/mentions/MentionEditor.tsx
+++ b/apps/web/src/lib/components/mentions/MentionEditor.tsx
@@ -27,7 +27,8 @@ import {
   getSelectionAnchorRect,
   type MentionPopupPlacement,
 } from "./mentionPopupPosition";
-import { UserProfileHoverCardBody } from "@eva/shared";
+import { UserInitials, UserProfileHoverCardBody } from "@eva/shared";
+import type { Id } from "@eva/backend";
 
 // The inline AI suggestion renders as an `::after` pseudo-element fed by
 // `data-suggestion`, mirroring how the placeholder uses `::before`. A pseudo-
@@ -42,6 +43,12 @@ export interface MentionItem<TId extends string = string> {
   description?: string;
   /** Type badge shown in the picker (e.g. Document, Session, Person). */
   badge?: string;
+  /**
+   * Set when this item is a teammate rather than a data entity, so the picker
+   * row shows their avatar. Same value as `id` for people items; kept separate
+   * so the renderer can tell the two kinds apart without re-deriving it.
+   */
+  personUserId?: Id<"users">;
 }
 
 export interface SlashItem<
@@ -184,6 +191,23 @@ function renderMenuItemRow(
 }
 
 function defaultRenderItem(item: MentionItem, _isSelected: boolean): ReactNode {
+  // People read better as an avatar + name than as an `@`-prefixed slug, and the
+  // name is PII so it carries `data-pii` for screenshot redaction.
+  if (item.personUserId !== undefined) {
+    return (
+      <span className="flex w-full min-w-0 items-center gap-2">
+        <UserInitials userId={item.personUserId} size="sm" hideLastSeen />
+        <span data-pii className="min-w-0 flex-1 truncate">
+          {item.label}
+        </span>
+        {item.badge ? (
+          <span className="shrink-0 rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+            {item.badge}
+          </span>
+        ) : null}
+      </span>
+    );
+  }
   const detail = item.description ? previewOneLine(item.description) : null;
   return renderMenuItemRow("@", item.label, detail, item.badge);
 }
@@ -859,6 +883,8 @@ export function MentionEditor<TItem extends MentionItem = MentionItem>({
           renderItem={renderSlashItem}
           onSelectItem={insertSlashItem}
           emptyContent={emptySlashContent}
+          query={trigger.query}
+          onRefocusEditor={() => editorRef.current?.focus()}
         />
       ) : (
         <MentionPickerPopup
@@ -868,6 +894,8 @@ export function MentionEditor<TItem extends MentionItem = MentionItem>({
           selectedIndex={selectedIndex}
           renderItem={renderItem}
           onSelectItem={insertMentionItem}
+          query={trigger.query}
+          onRefocusEditor={() => editorRef.current?.focus()}
         />
       )
     ) : null;

--- a/apps/web/src/lib/components/mentions/MentionPickerPopup.tsx
+++ b/apps/web/src/lib/components/mentions/MentionPickerPopup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, type ReactNode } from "react";
+import { IconSearch } from "@tabler/icons-react";
 import type { MentionPopupPlacement } from "./mentionPopupPosition";
 
 interface MentionPickerPopupProps<TItem extends { id: string }> {
@@ -11,6 +12,10 @@ interface MentionPickerPopupProps<TItem extends { id: string }> {
   renderItem: (item: TItem, isSelected: boolean) => ReactNode;
   onSelectItem: (item: TItem) => void;
   emptyContent?: ReactNode;
+  /** Text typed after the `@`/`/` trigger, i.e. what the list is filtered by. */
+  query: string;
+  /** Returns the caret to the editor, so clicking the search row keeps typing alive. */
+  onRefocusEditor: () => void;
 }
 
 export function MentionPickerPopup<TItem extends { id: string }>({
@@ -21,6 +26,8 @@ export function MentionPickerPopup<TItem extends { id: string }>({
   renderItem,
   onSelectItem,
   emptyContent,
+  query,
+  onRefocusEditor,
 }: MentionPickerPopupProps<TItem>) {
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -57,9 +64,27 @@ export function MentionPickerPopup<TItem extends { id: string }>({
           placement.placement === "above" ? "translateY(-100%)" : undefined,
       }}
     >
-      <p className="shrink-0 px-2.5 pt-2 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
-        {title}
-      </p>
+      {/* The caret has to stay in the editor — that is where the query is being
+          typed and where the chip will be inserted — so this is a live view of
+          the filter rather than a focusable field. Clicking it hands focus back
+          to the editor so typing continues to narrow the list. */}
+      <div
+        className="flex shrink-0 items-center gap-2 border-b border-border px-2.5 py-2"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onRefocusEditor();
+        }}
+      >
+        <IconSearch size={13} className="shrink-0 text-muted-foreground" />
+        <span
+          className={
+            "min-w-0 flex-1 truncate text-sm " +
+            (query ? "text-foreground" : "text-muted-foreground/70")
+          }
+        >
+          {query || `Search ${title.toLowerCase()}…`}
+        </span>
+      </div>
       {items.length > 0 ? (
         <div
           ref={listRef}

--- a/apps/web/src/lib/components/mentions/index.ts
+++ b/apps/web/src/lib/components/mentions/index.ts
@@ -15,3 +15,4 @@ export { DataMentionHoverCardBody } from "./DataMentionHoverCardBody";
 export { SkillMentionHoverCardBody } from "./SkillMentionHoverCardBody";
 export { tokenizedToEditable, tokenizedToDisplayText } from "./mentionToken";
 export { isSkillTokenId } from "./skillToken";
+export { mergeMentionItems } from "./mergeMentionItems";

--- a/apps/web/src/lib/components/mentions/mergeMentionItems.ts
+++ b/apps/web/src/lib/components/mentions/mergeMentionItems.ts
@@ -1,0 +1,21 @@
+import type { Id } from "@eva/backend";
+import type { MentionItem } from "./MentionEditor";
+
+/**
+ * Merges teammate and data `@` mention candidates into one alphabetical picker
+ * list, and returns the set of ids that belong to people.
+ *
+ * Callers need that set because people and data tokens are byte-identical
+ * (`@[Label](convexId)`), so on the client the id is the only way to tell them
+ * apart — a chip click should navigate for data but do nothing for a person,
+ * and each kind gets a different hover card.
+ */
+export function mergeMentionItems(
+  peopleItems: MentionItem<Id<"users">>[],
+  dataItems: MentionItem[],
+): { items: MentionItem[]; peopleIds: ReadonlySet<string> } {
+  const items: MentionItem[] = [...peopleItems, ...dataItems].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+  return { items, peopleIds: new Set(peopleItems.map((person) => person.id)) };
+}

--- a/apps/web/src/lib/components/projects/ProjectSandboxChatPanel.tsx
+++ b/apps/web/src/lib/components/projects/ProjectSandboxChatPanel.tsx
@@ -270,7 +270,7 @@ export function ProjectSandboxChatPanel({
         placeholder={
           !isSandboxActive
             ? "Sandbox must be running to chat..."
-            : "Ask Eva anything... / for skills · @ for data"
+            : "Ask Eva anything... / for skills · @ to mention"
         }
         emptyStateTitle={
           isSandboxActive

--- a/apps/web/src/lib/components/tasks/TaskSandboxChatPanel.tsx
+++ b/apps/web/src/lib/components/tasks/TaskSandboxChatPanel.tsx
@@ -237,7 +237,7 @@ export function TaskSandboxChatPanel({
         placeholder={
           !isSandboxActive
             ? "Sandbox must be running to chat..."
-            : "Ask Eva anything... / for skills · @ for data"
+            : "Ask Eva anything... / for skills · @ to mention"
         }
         emptyStateTitle={
           isSandboxActive

--- a/apps/web/src/lib/components/tasks/_components/CommentMentionInput.tsx
+++ b/apps/web/src/lib/components/tasks/_components/CommentMentionInput.tsx
@@ -1,18 +1,17 @@
 "use client";
 
 import { forwardRef } from "react";
-import { useQuery } from "convex-helpers/react/cache/hooks";
-import { api, type Id } from "@eva/backend";
 import { useRepo } from "@/lib/contexts/RepoContext";
-import { UserInitials, UserProfileHoverCardBody } from "@eva/shared";
+import { UserProfileHoverCardBody } from "@eva/shared";
 import { cn } from "@eva/ui";
 import {
   MentionEditor,
   type MentionEditorHandle,
-  type MentionItem,
   DataMentionHoverCardBody,
+  mergeMentionItems,
 } from "@/lib/components/mentions";
 import { useDataMentionItems } from "@/lib/hooks/useDataMentionItems";
+import { usePeopleMentionItems } from "@/lib/hooks/usePeopleMentionItems";
 import { useDataMentionNavigate } from "@/lib/useDataMentionNavigate";
 
 export type CommentMentionInputHandle = MentionEditorHandle;
@@ -47,30 +46,10 @@ export const CommentMentionInput = forwardRef<
   ref,
 ) {
   const { repo, basePath } = useRepo();
-  const members = useQuery(
-    api.teamMembers.list,
-    repo.teamId ? { teamId: repo.teamId } : "skip",
-  );
+  const peopleItems = usePeopleMentionItems(repo._id);
   const dataItems = useDataMentionItems(repo._id);
   const navigateToData = useDataMentionNavigate(basePath, repo._id);
-
-  const peopleItems: MentionItem<Id<"users">>[] = (members ?? []).flatMap(
-    (m) => {
-      if (!m.user) return [];
-      const label = m.user.fullName?.trim() || m.user.email?.trim();
-      if (!label) return [];
-      return [{ id: m.user._id, label, badge: "Person" }];
-    },
-  );
-
-  const peopleById = new Map<string, MentionItem<Id<"users">>>();
-  for (const item of peopleItems) {
-    peopleById.set(item.id, item);
-  }
-
-  const items: MentionItem[] = [...peopleItems, ...dataItems].sort((a, b) =>
-    a.label.localeCompare(b.label),
-  );
+  const { items, peopleIds } = mergeMentionItems(peopleItems, dataItems);
 
   return (
     <MentionEditor
@@ -81,16 +60,16 @@ export const CommentMentionInput = forwardRef<
       items={items}
       mentionPopupTitle="Mentions"
       onMentionChipClick={(id) => {
-        if (peopleById.has(id)) return;
+        if (peopleIds.has(id)) return;
         void navigateToData(id);
       }}
-      renderMentionChipHoverCard={(id) => {
-        const person = peopleById.get(id);
-        if (person) {
-          return <UserProfileHoverCardBody userId={person.id} />;
-        }
-        return <DataMentionHoverCardBody entityId={id} repoId={repo._id} />;
-      }}
+      renderMentionChipHoverCard={(id) =>
+        peopleIds.has(id) ? (
+          <UserProfileHoverCardBody userId={id} />
+        ) : (
+          <DataMentionHoverCardBody entityId={id} repoId={repo._id} />
+        )
+      }
       placeholder={placeholder}
       ariaLabel={placeholder ?? "Comment input"}
       initialMentionMap={initialMentionMap}
@@ -100,40 +79,6 @@ export const CommentMentionInput = forwardRef<
         "min-h-9 max-h-40 overflow-y-auto rounded-control border border-input bg-card px-3 py-2 pr-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35",
         className,
       )}
-      renderItem={(item) => {
-        const person = peopleById.get(item.id);
-        if (person) {
-          return (
-            <div className="flex w-full min-w-0 items-center gap-2">
-              <UserInitials userId={person.id} size="sm" hideLastSeen />
-              <span className="min-w-0 flex-1 truncate">{person.label}</span>
-              <span className="shrink-0 rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                Person
-              </span>
-            </div>
-          );
-        }
-        return (
-          <span className="flex min-w-0 w-full flex-col gap-0.5 overflow-hidden">
-            <span className="flex min-w-0 items-center gap-1.5">
-              <span className="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
-                <span className="shrink-0 text-muted-foreground">@</span>
-                <span className="truncate">{item.label}</span>
-              </span>
-              {item.badge ? (
-                <span className="shrink-0 rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                  {item.badge}
-                </span>
-              ) : null}
-            </span>
-            {item.description ? (
-              <span className="truncate text-xs text-muted-foreground">
-                {item.description}
-              </span>
-            ) : null}
-          </span>
-        );
-      }}
     />
   );
 });

--- a/apps/web/src/lib/hooks/usePeopleMentionItems.ts
+++ b/apps/web/src/lib/hooks/usePeopleMentionItems.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { api } from "@eva/backend";
+import type { Id } from "@eva/backend";
+import type { MentionItem } from "@/lib/components/mentions";
+
+/**
+ * Loads the teammates who can be `@`-mentioned in a repo. Shared by every
+ * mention surface (chat composers, comment inputs) so the picker offers the
+ * same people everywhere and notifications only ever target team members.
+ */
+export function usePeopleMentionItems(
+  repoId: Id<"githubRepos"> | undefined,
+): MentionItem<Id<"users">>[] {
+  const members = useQuery(
+    api.teamMembers.listForRepo,
+    repoId ? { repoId } : "skip",
+  );
+  if (!members) return [];
+  return members.flatMap((member) => {
+    // Nameless, email-less accounts have nothing to show in the picker.
+    const label = member.fullName?.trim() || member.email?.trim();
+    if (!label) return [];
+    return [
+      {
+        id: member._id,
+        label,
+        badge: "Person",
+        personUserId: member._id,
+      },
+    ];
+  });
+}

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/ChatPanel.tsx
@@ -340,10 +340,10 @@ export function ChatPanel({
   const placeholder = !isSandboxActive
     ? "Start the sandbox to begin chatting..."
     : mode === "plan"
-      ? "Describe what to plan... / for skills · @ for data"
+      ? "Describe what to plan... / for skills · @ to mention"
       : mode === "design"
-        ? "Describe the UI to design... / for skills · @ for data"
-        : "Ask Eva anything... / for skills · @ for data";
+        ? "Describe the UI to design... / for skills · @ to mention"
+        : "Ask Eva anything... / for skills · @ to mention";
 
   const readOnlyMessage = getSessionReadOnlyMessage({
     isArchived,

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/NewSessionComposer.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/NewSessionComposer.tsx
@@ -139,10 +139,10 @@ export function NewSessionComposer() {
           isInputDisabled={isSubmitting}
           placeholder={
             mode === "plan"
-              ? "Describe what to plan... / for skills · @ for data"
+              ? "Describe what to plan... / for skills · @ to mention"
               : mode === "design"
-                ? "Describe the UI to design... / for skills · @ for data"
-                : "Ask Eva anything... / for skills · @ for data"
+                ? "Describe the UI to design... / for skills · @ to mention"
+                : "Ask Eva anything... / for skills · @ to mention"
           }
           model={model}
           setModel={(next) => {

--- a/packages/backend/convex/_mentions/notifyChatMentions.ts
+++ b/packages/backend/convex/_mentions/notifyChatMentions.ts
@@ -1,0 +1,99 @@
+import type { MutationCtx } from "../_generated/server";
+import type { Doc, Id } from "../_generated/dataModel";
+import { createNotification } from "../notifications";
+import { formatMessagePreview } from "../_messages/preview";
+import { extractMentionedUserIds } from "./extractMentionedUserIds";
+
+/**
+ * Which chat a message was posted in. Carries the whole document because the
+ * caller has already loaded and authorised it, and every field needed to route
+ * the notification (repo, entity id) comes off it.
+ */
+export type ChatMentionSurface =
+  | { kind: "session"; session: Doc<"sessions"> }
+  | { kind: "project"; project: Doc<"projects"> }
+  | { kind: "task"; task: Doc<"agentTasks"> };
+
+/** Reads as "... mentioned you in a session chat". */
+const SURFACE_NAME: Record<ChatMentionSurface["kind"], string> = {
+  session: "session",
+  project: "project",
+  task: "task",
+};
+
+/**
+ * Entity context handed to `createNotification`, which turns it into the href
+ * and the context label shown on the notification card.
+ */
+function notificationTarget(surface: ChatMentionSurface): {
+  repoId?: Id<"githubRepos">;
+  sessionId?: Id<"sessions">;
+  projectId?: Id<"projects">;
+  taskId?: Id<"agentTasks">;
+} {
+  switch (surface.kind) {
+    case "session":
+      return { repoId: surface.session.repoId, sessionId: surface.session._id };
+    case "project":
+      return { repoId: surface.project.repoId, projectId: surface.project._id };
+    case "task":
+      return {
+        repoId: surface.task.repoId,
+        projectId: surface.task.projectId,
+        taskId: surface.task._id,
+      };
+  }
+}
+
+/**
+ * Notifies every teammate `@`-mentioned in a chat message.
+ *
+ * Called from the three chat `submitTurn` mutations, which sit upstream of both
+ * the "runs now" and the "queued behind the current turn" write paths — so a
+ * mention notifies at submit time regardless of what the agent is doing.
+ *
+ * Mentions are only honoured for members of the repo's team. The mention picker
+ * only offers teammates, so a non-member id means hand-authored or stale
+ * tokenized text, and notifying on it would leak the message body outside the
+ * team.
+ */
+export async function notifyChatMentions(
+  ctx: MutationCtx,
+  args: {
+    /** Tokenized message text, i.e. still containing `@[Name](userId)`. */
+    content: string;
+    authorUserId: Id<"users">;
+    surface: ChatMentionSurface;
+  },
+): Promise<void> {
+  const mentionedUserIds = extractMentionedUserIds(ctx, args.content);
+  if (mentionedUserIds.length === 0) return;
+
+  const target = notificationTarget(args.surface);
+  const repo = target.repoId ? await ctx.db.get(target.repoId) : null;
+  const teamId = repo?.teamId;
+  const author = await ctx.db.get(args.authorUserId);
+  const authorName = author?.fullName?.trim() || "Someone";
+  const title = `${authorName} mentioned you in a ${SURFACE_NAME[args.surface.kind]} chat`;
+  const message = formatMessagePreview(args.content);
+
+  for (const userId of mentionedUserIds) {
+    if (userId === args.authorUserId) continue;
+    if (teamId) {
+      const membership = await ctx.db
+        .query("teamMembers")
+        .withIndex("by_team_and_user", (q) =>
+          q.eq("teamId", teamId).eq("userId", userId),
+        )
+        .first();
+      if (!membership) continue;
+    }
+    await createNotification(ctx, {
+      userId,
+      type: "mention",
+      title,
+      message,
+      ...target,
+    });
+  }
+}

--- a/packages/backend/convex/_sessions/execution.ts
+++ b/packages/backend/convex/_sessions/execution.ts
@@ -20,6 +20,7 @@ import {
 } from "../_userProviderAccounts/defaults";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
+import { notifyChatMentions } from "../_mentions/notifyChatMentions";
 
 async function finalizeOpenSyntheticTurnOnCancel(
   ctx: MutationCtx,
@@ -54,6 +55,13 @@ export const startExecute = authMutation({
     if (!session) throw new Error("Session not found");
     if (!(await hasRepoAccess(ctx.db, session.repoId, ctx.userId)))
       throw new Error("Not authorized");
+
+    // Notify before the turn runs or queues so a mention fires either way.
+    await notifyChatMentions(ctx, {
+      content: args.message,
+      authorUserId: ctx.userId,
+      surface: { kind: "session", session },
+    });
 
     const normalizedMode =
       args.mode === "ask" || args.mode === "execute" ? "edit" : args.mode;
@@ -282,6 +290,12 @@ export const enqueueMessage = authMutation({
     if (!session) throw new Error("Session not found");
     if (!(await hasRepoAccess(ctx.db, session.repoId, ctx.userId)))
       throw new Error("Not authorized");
+
+    await notifyChatMentions(ctx, {
+      content: displayContent || content,
+      authorUserId: ctx.userId,
+      surface: { kind: "session", session },
+    });
 
     await ctx.db.insert("queuedMessages", {
       parentId: args.sessionId,

--- a/packages/backend/convex/_sessions/mutations.ts
+++ b/packages/backend/convex/_sessions/mutations.ts
@@ -20,6 +20,7 @@ import {
 } from "../_userProviderAccounts/defaults";
 import { schedulePrTitleSync } from "../_github/prTitleSync";
 import { DEFAULT_SESSION_TITLE } from "./helpers";
+import { notifyChatMentions } from "../_mentions/notifyChatMentions";
 import {
   assertStickyPreviewPort,
   normalizeStickyPreviewPath,
@@ -141,6 +142,16 @@ export const create = authMutation({
         personaId: args.personaId,
         numDesigns: args.numDesigns,
       });
+      // The first message queues directly rather than going through
+      // startExecute, so its mentions are notified here instead.
+      const session = await ctx.db.get(sessionId);
+      if (session) {
+        await notifyChatMentions(ctx, {
+          content,
+          authorUserId: ctx.userId,
+          surface: { kind: "session", session },
+        });
+      }
       if (title === DEFAULT_SESSION_TITLE) {
         await ctx.scheduler.runAfter(0, internal.textGen.generateSessionTitle, {
           sessionId,

--- a/packages/backend/convex/agentTaskChatWorkflow.ts
+++ b/packages/backend/convex/agentTaskChatWorkflow.ts
@@ -29,6 +29,7 @@ import {
 import { buildAgentTaskChatPrompt } from "./_agentTasks/chatPrompt";
 import { buildCustomInstructionsBlock } from "./prompts";
 import { resolveMessageTokens } from "./_mentions/resolveMessageTokens";
+import { notifyChatMentions } from "./_mentions/notifyChatMentions";
 import { resolveCredentialSourceLabel } from "./_userProviderAccounts/credentialSource";
 import type { Doc, Id } from "./_generated/dataModel";
 import { TASK_CHAT_DAEMON_MUTATIONS } from "./_sandbox_runtime/daemonPaths";
@@ -187,6 +188,12 @@ export const startExecute = authMutation({
     // picker overrides from collaborators (and from localStorage).
     void args.providerAccountId;
 
+    await notifyChatMentions(ctx, {
+      content: args.message,
+      authorUserId: ctx.userId,
+      surface: { kind: "task", task },
+    });
+
     await ctx.db.insert("messages", {
       parentId: args.taskId,
       role: "assistant",
@@ -299,6 +306,12 @@ export const enqueueMessage = authMutation({
     ) {
       throw new Error("Not authorized");
     }
+
+    await notifyChatMentions(ctx, {
+      content,
+      authorUserId: ctx.userId,
+      surface: { kind: "task", task },
+    });
 
     await ctx.db.insert("queuedMessages", {
       parentId: args.taskId,

--- a/packages/backend/convex/notifications.ts
+++ b/packages/backend/convex/notifications.ts
@@ -75,7 +75,7 @@ function getRepoHref(
   return `/${owner}/${name}/${appName}`;
 }
 
-/** Creates a notification for a user, auto-generating an href from repo/project/task/doc context. */
+/** Creates a notification for a user, auto-generating an href from repo/project/task/doc/session context. */
 export async function createNotification(
   ctx: MutationCtx,
   params: {
@@ -88,45 +88,54 @@ export async function createNotification(
     projectId?: Id<"projects">;
     taskId?: Id<"agentTasks">;
     docId?: Id<"docs">;
+    sessionId?: Id<"sessions">;
   },
 ) {
+  const type = params.type ?? "system";
+
+  // Fetched once and shared: the href and the context label below are both
+  // derived from whichever entity the notification is about.
+  const doc = params.docId ? await ctx.db.get(params.docId) : null;
+  const task = params.taskId ? await ctx.db.get(params.taskId) : null;
+  const project = params.projectId ? await ctx.db.get(params.projectId) : null;
+  const session = params.sessionId ? await ctx.db.get(params.sessionId) : null;
+
   let href = params.href;
   if (!href && params.repoId) {
     const repo = await ctx.db.get(params.repoId);
     if (repo) {
       const baseHref = getRepoHref(repo.owner, repo.name, repo.rootDirectory);
-      if (params.docId) {
-        href = `${baseHref}/docs/${params.docId}/content`;
-      } else if (params.projectId && params.taskId) {
-        href = `${baseHref}/projects/${params.projectId}/${params.taskId}/activity`;
-      } else if (params.taskId) {
-        href = `${baseHref}/quick-tasks/${params.taskId}`;
-      } else if (params.projectId) {
-        href = `${baseHref}/projects/${params.projectId}`;
+      // Detail routes are keyed by per-repo numId, not by Convex id — a Convex
+      // id in the path fails `parseRouteNumId` and renders "not found". An
+      // entity still awaiting numId backfill falls through to its section list.
+      if (doc?.numId !== undefined) {
+        href = `${baseHref}/docs/${doc.numId}/content`;
+      } else if (project?.numId !== undefined && task?.numId !== undefined) {
+        href = `${baseHref}/projects/${project.numId}/${task.numId}/activity`;
+      } else if (task?.numId !== undefined) {
+        href = `${baseHref}/quick-tasks/${task.numId}`;
+      } else if (project?.numId !== undefined) {
+        href = `${baseHref}/projects/${project.numId}`;
+      } else if (session?.numId !== undefined) {
+        href = `${baseHref}/sessions/${session.numId}`;
       } else {
         href = `${baseHref}/quick-tasks`;
       }
     }
   }
-  const type = params.type ?? "system";
 
   // Snapshot a human-readable context label for the notification card, but only
   // for types whose title does not already name the entity.
   let contextLabel: string | undefined;
-  if (params.docId && CONTEXT_LABEL_TYPES.has(type)) {
-    const doc = await ctx.db.get(params.docId);
+  if (CONTEXT_LABEL_TYPES.has(type)) {
     if (doc) {
       contextLabel = doc.title;
-    }
-  } else if (params.taskId && CONTEXT_LABEL_TYPES.has(type)) {
-    const task = await ctx.db.get(params.taskId);
-    if (task) {
-      if (params.projectId) {
-        const project = await ctx.db.get(params.projectId);
-        contextLabel = project ? `${project.title}: ${task.title}` : task.title;
-      } else {
-        contextLabel = task.title;
-      }
+    } else if (task) {
+      contextLabel = project ? `${project.title}: ${task.title}` : task.title;
+    } else if (project) {
+      contextLabel = project.title;
+    } else if (session) {
+      contextLabel = session.title;
     }
   }
   await ctx.db.insert("notifications", {

--- a/packages/backend/convex/projectChatWorkflow.ts
+++ b/packages/backend/convex/projectChatWorkflow.ts
@@ -32,6 +32,7 @@ import {
 } from "./_projects/helpers";
 import { buildCustomInstructionsBlock } from "./prompts";
 import { resolveMessageTokens } from "./_mentions/resolveMessageTokens";
+import { notifyChatMentions } from "./_mentions/notifyChatMentions";
 import { resolveCredentialSourceLabel } from "./_userProviderAccounts/credentialSource";
 import type { Doc, Id } from "./_generated/dataModel";
 import { PROJECT_CHAT_DAEMON_MUTATIONS } from "./_sandbox_runtime/daemonPaths";
@@ -187,6 +188,12 @@ export const startExecute = authMutation({
 
     void args.providerAccountId;
 
+    await notifyChatMentions(ctx, {
+      content: args.message,
+      authorUserId: ctx.userId,
+      surface: { kind: "project", project },
+    });
+
     await ctx.db.insert("messages", {
       parentId: args.projectId,
       role: "assistant",
@@ -297,6 +304,12 @@ export const enqueueMessage = authMutation({
     if (!(await hasRepoAccess(ctx.db, project.repoId, ctx.userId))) {
       throw new Error("Not authorized");
     }
+
+    await notifyChatMentions(ctx, {
+      content,
+      authorUserId: ctx.userId,
+      surface: { kind: "project", project },
+    });
 
     await ctx.db.insert("queuedMessages", {
       parentId: args.projectId,

--- a/packages/backend/convex/teamMembers.ts
+++ b/packages/backend/convex/teamMembers.ts
@@ -1,7 +1,7 @@
 import type { GenericDatabaseReader } from "convex/server";
 import { v } from "convex/values";
 import type { DataModel, Doc, Id } from "./_generated/dataModel";
-import { authQuery, authMutation } from "./functions";
+import { authQuery, authMutation, hasRepoAccess } from "./functions";
 import { teamMemberRoleValidator } from "./validators";
 
 /** Fetches a user's membership row for a team, or null if they aren't a member. */
@@ -47,12 +47,6 @@ export const list = authQuery({
           _id: v.id("users"),
           email: v.optional(v.string()),
           fullName: v.optional(v.string()),
-          firstName: v.optional(v.string()),
-          lastName: v.optional(v.string()),
-          // Presence, for the team page's Activity tab. Deliberately raw: only
-          // a client can re-evaluate "seen in the last two minutes" over time.
-          lastSeenAt: v.optional(v.number()),
-          lastSeenPath: v.optional(v.string()),
         }),
         v.null(),
       ),
@@ -82,16 +76,53 @@ export const list = authQuery({
               _id: user._id,
               email: user.email,
               fullName: user.fullName,
-              firstName: user.firstName,
-              lastName: user.lastName,
-              lastSeenAt: user.lastSeenAt,
-              lastSeenPath: user.lastSeenPath,
             }
           : null,
       });
     }
 
     return membersWithUsers;
+  },
+});
+
+/**
+ * Lists the user profiles that can be `@`-mentioned in a repo: the members of
+ * the repo's team. Takes a repoId rather than a teamId because mention pickers
+ * live on repo-scoped surfaces (chats, comments) that know the repo but not
+ * necessarily the team. Returns empty when the caller lacks repo access or the
+ * repo has no team (personal repo — nobody else to mention).
+ */
+export const listForRepo = authQuery({
+  args: { repoId: v.id("githubRepos") },
+  returns: v.array(
+    v.object({
+      _id: v.id("users"),
+      fullName: v.optional(v.string()),
+      email: v.optional(v.string()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    if (!(await hasRepoAccess(ctx.db, args.repoId, ctx.userId))) return [];
+    const repo = await ctx.db.get(args.repoId);
+    const teamId = repo?.teamId;
+    if (!teamId) return [];
+
+    const members = await ctx.db
+      .query("teamMembers")
+      .withIndex("by_team", (q) => q.eq("teamId", teamId))
+      .collect();
+
+    const users = [];
+    for (const member of members) {
+      const user = await ctx.db.get(member.userId);
+      if (!user) continue;
+      users.push({
+        _id: user._id,
+        fullName: user.fullName,
+        email: user.email,
+      });
+    }
+    return users;
   },
 });
 


### PR DESCRIPTION
## Summary
- Chat composers (sessions, projects, quick tasks) share the people+data @ picker.
- Mentions notify teammates at submit whether the turn runs now or queues.
- Notification hrefs use per-repo numIds so mention links resolve; picker shows a live search row.

## Test plan
- [ ] In a team repo session chat, @ a teammate and send — they get a mention notification
- [ ] Queued message with a mention still notifies
- [ ] Mention notification link opens the right session/project/task
- [ ] Comment input still offers people + data