### PR TITLE
feat(chat): show who queued each pending message

### DIFF
--- a/apps/web/src/lib/components/QueuedMessagesPanel.tsx
+++ b/apps/web/src/lib/components/QueuedMessagesPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { Id } from "@eva/backend";
 import { findAIModelOption, getReasoningLevelLabel } from "@eva/backend";
+import { UserInitials } from "@eva/shared";
 import {
   Button,
   Dialog,
@@ -50,6 +51,8 @@ interface QueuedMessageItem {
   content: string;
   model?: string;
   reasoningLevel?: string;
+  /** Who queued it ??? a shared chat's queue mixes several teammates' prompts. */
+  userId?: Id<"users">;
 }
 
 interface QueuedMessagesPanelProps {
@@ -164,6 +167,14 @@ function SortableQueuedItem({
       className={isDragging ? "opacity-50" : undefined}
     >
       <div className="flex items-center gap-2.5">
+        {/* Author then model, reading left to right as "who asked, on what".
+            Fixed box because `UserInitials` renders nothing until the profile
+            query resolves, which would otherwise shift the row. */}
+        {item.userId ? (
+          <span className="flex size-4 shrink-0 items-center justify-center">
+            <UserInitials userId={item.userId} hideLastSeen />
+          </span>
+        ) : null}
         <QueueRowHandle
           item={item}
           draggable={draggable}

--- a/apps/web/src/lib/components/chat/ChatComposer.tsx
+++ b/apps/web/src/lib/components/chat/ChatComposer.tsx
@@ -170,6 +170,7 @@ export function ChatComposer({
     content: message.displayContent ?? message.content,
     model: message.model,
     reasoningLevel: message.reasoningLevel,
+    userId: message.userId,
   }));
 
   return (


### PR DESCRIPTION
## Summary
- Queued message rows show the author's avatar ahead of the model mark so shared sandbox queues are readable.

## Test plan
- [ ] Two users queue messages in one session — each row shows the right avatar