### PR TITLE
feat(inbox): chime when new notifications arrive

### DIFF
--- a/apps/web/src/lib/components/NotificationToastStream.tsx
+++ b/apps/web/src/lib/components/NotificationToastStream.tsx
@@ -9,6 +9,7 @@ import { Badge, Button, Card, CardContent } from "@eva/ui";
 import { IconX } from "@tabler/icons-react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { RelativeDateTime } from "@/lib/components/RelativeDateTime";
+import { playNotificationChime } from "@/lib/utils/notificationChime";
 import {
   NotificationIcon,
   getNotificationAppearance,
@@ -74,6 +75,14 @@ export function NotificationToastStream() {
 
     if (newlyArrived.length === 0) {
       return;
+    }
+
+    // One chime per batch, however many landed together, and only for unread
+    // arrivals. `list` returns the newest 100, so pruning an old notification
+    // pulls the next one into the window and it reads as newly arrived — but
+    // anything resurfacing that way is long since read.
+    if (newlyArrived.some((notification) => !notification.read)) {
+      playNotificationChime();
     }
 
     setToasts((previous) => {

--- a/apps/web/src/lib/utils/notificationChime.ts
+++ b/apps/web/src/lib/utils/notificationChime.ts
@@ -1,0 +1,88 @@
+/**
+ * A two-note notification chime, synthesised rather than loaded from a file.
+ *
+ * Two sine tones this short are a handful of oscillator nodes, so generating
+ * them beats shipping an audio asset: nothing to fetch, nothing to cache, and
+ * no first-notification delay while a request is in flight.
+ */
+
+/** A soft rising interval (A5 then D6), the second note overlapping the first. */
+const NOTES = [
+  { frequency: 880, startOffsetS: 0 },
+  { frequency: 1174.66, startOffsetS: 0.09 },
+];
+
+const NOTE_DURATION_S = 0.28;
+
+/** Deliberately quiet — a notification should register, not startle. */
+const PEAK_GAIN = 0.14;
+
+/** Long enough to avoid a click on attack, short enough to still sound struck. */
+const ATTACK_S = 0.012;
+
+/**
+ * Shared context, created on first use.
+ *
+ * Browsers cap how many AudioContexts a page may hold and start each one
+ * suspended until a user gesture, so there is nothing to gain from building it
+ * at import time.
+ */
+let sharedContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext | null {
+  if (sharedContext) {
+    return sharedContext;
+  }
+  if (typeof window === "undefined" || !window.AudioContext) {
+    return null;
+  }
+  sharedContext = new window.AudioContext();
+  return sharedContext;
+}
+
+/**
+ * Plays the chime, including while the tab is in the background.
+ *
+ * Background playback is why this uses the Web Audio clock instead of a timer:
+ * browsers throttle timers in hidden tabs but keep audio scheduling accurate,
+ * so notes queued the moment a notification arrives still play on time.
+ *
+ * Silent until the user has interacted with the page at least once — autoplay
+ * policy holds a freshly loaded context suspended, and no amount of scheduling
+ * overrides that. In practice signing in and navigating clears the requirement
+ * well before the first notification lands.
+ */
+export function playNotificationChime(): void {
+  const context = getAudioContext();
+  if (!context) {
+    return;
+  }
+
+  // Resuming is a no-op once the gesture requirement is met, and rejects while
+  // it is not. Either way the scheduling below is correct: a suspended context
+  // holds its clock, so the notes play on resume rather than being lost.
+  if (context.state === "suspended") {
+    context.resume().catch(() => undefined);
+  }
+
+  const chimeStart = context.currentTime;
+  for (const note of NOTES) {
+    const oscillator = context.createOscillator();
+    const envelope = context.createGain();
+    oscillator.type = "sine";
+    oscillator.frequency.value = note.frequency;
+
+    // Ramp both edges. Starting or stopping a tone at full amplitude puts a
+    // step change into the buffer, which is audible as a click.
+    const noteStart = chimeStart + note.startOffsetS;
+    const noteEnd = noteStart + NOTE_DURATION_S;
+    envelope.gain.setValueAtTime(0, noteStart);
+    envelope.gain.linearRampToValueAtTime(PEAK_GAIN, noteStart + ATTACK_S);
+    envelope.gain.exponentialRampToValueAtTime(0.0001, noteEnd);
+
+    oscillator.connect(envelope).connect(context.destination);
+    oscillator.start(noteStart);
+    // Nodes are single-use; stopping releases them for garbage collection.
+    oscillator.stop(noteEnd);
+  }
+}

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## New notifications chime, background tabs included - 2026-08-01
+
+A backgrounded tab gave no sign that anything had arrived beyond the favicon count, which only helps if you happen to look. New unread notifications now play a short two-note chime, hung off the arrival detection `NotificationToastStream` already runs so it costs no extra subscription and can never disagree with the toasts. The tones are synthesised through the Web Audio API rather than loaded from a file: nothing to fetch or cache, and no silent first notification while a request is in flight. Scheduling goes through the audio clock, which browsers keep accurate in hidden tabs even while they throttle timers, so a chime queued by a background tab still plays on time. One chime per batch however many land together, and only for unread arrivals, so pruning an old notification into the 100-item window stays silent. Autoplay policy keeps a context suspended until the user has interacted with the page at least once, which signing in and navigating satisfies well before the first notification.
+
 ## Voice dictation streams through AI Gateway - 2026-08-02
 
 Composer mic was a no-op (it queried a textarea that never existed), and browser Web Speech is uneven across browsers. An experimental switch now mints a short-lived Gateway STT token (`xai/grok-stt`) so chat composers and the quick-task description field can stream live transcription without exposing the server API key. Off by default; when off, chat still falls back to Web Speech where available.


### PR DESCRIPTION
## Summary
- Short two-note Web Audio chime on unread notification arrivals (including background tabs), tied to NotificationToastStream.

## Test plan
- [ ] Receive a notification with the tab focused — chime plays once per batch
- [ ] Background tab still chimes after prior user interaction