### PR TITLE
feat(theme): add Host Grotesk as a theme font option

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -40,14 +40,14 @@
     <!-- origin-hints -->
     <!-- Non-blocking font load: renders immediately with fallback, swaps when ready -->
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@100..1000&family=Figtree:wght@300..900&family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@100..900&family=Nunito:wght@200..1000&family=Outfit:wght@100..900&family=Plus+Jakarta+Sans:wght@200..800&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Source+Serif+4:opsz,wght@8..60,200..900&family=Space+Grotesk:wght@300..700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@100..1000&family=Figtree:wght@300..900&family=Host+Grotesk:ital,wght@0,300..800;1,300..800&family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@100..900&family=Nunito:wght@200..1000&family=Outfit:wght@100..900&family=Plus+Jakarta+Sans:wght@200..800&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Source+Serif+4:opsz,wght@8..60,200..900&family=Space+Grotesk:wght@300..700&display=swap"
       rel="stylesheet"
       media="print"
       onload="this.media='all'"
     />
     <noscript>
       <link
-        href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@100..1000&family=Figtree:wght@300..900&family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@100..900&family=Nunito:wght@200..1000&family=Outfit:wght@100..900&family=Plus+Jakarta+Sans:wght@200..800&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Source+Serif+4:opsz,wght@8..60,200..900&family=Space+Grotesk:wght@300..700&display=swap"
+        href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@100..1000&family=Figtree:wght@300..900&family=Host+Grotesk:ital,wght@0,300..800;1,300..800&family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@100..900&family=Nunito:wght@200..1000&family=Outfit:wght@100..900&family=Plus+Jakarta+Sans:wght@200..800&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Source+Serif+4:opsz,wght@8..60,200..900&family=Space+Grotesk:wght@300..700&display=swap"
         rel="stylesheet"
       />
     </noscript>
@@ -110,6 +110,7 @@
             poppins: "Poppins, ui-sans-serif, system-ui, sans-serif",
             "dm-sans": "'DM Sans', ui-sans-serif, system-ui, sans-serif",
             "space-grotesk": "'Space Grotesk', ui-sans-serif, system-ui, sans-serif",
+            "host-grotesk": "'Host Grotesk', ui-sans-serif, system-ui, sans-serif",
             geist: "'Geist Sans', ui-sans-serif, system-ui, sans-serif",
             "source-serif": "'Source Serif 4', Georgia, 'Times New Roman', serif",
             jakarta: "'Plus Jakarta Sans', ui-sans-serif, system-ui, sans-serif",

--- a/apps/web/src/lib/contexts/ThemeContext.tsx
+++ b/apps/web/src/lib/contexts/ThemeContext.tsx
@@ -66,6 +66,7 @@ export type FontFamily =
   | "poppins"
   | "dm-sans"
   | "space-grotesk"
+  | "host-grotesk"
   | "geist"
   | "source-serif"
   | "jakarta"
@@ -142,6 +143,11 @@ export const FONT_FAMILIES: Record<
     label: "Space Grotesk",
     variable: "--font-space-grotesk",
     stack: "'Space Grotesk', ui-sans-serif, system-ui, sans-serif",
+  },
+  "host-grotesk": {
+    label: "Host Grotesk",
+    variable: "--font-host-grotesk",
+    stack: "'Host Grotesk', ui-sans-serif, system-ui, sans-serif",
   },
   geist: {
     label: "Geist",

--- a/packages/backend/convex/_validators/enums.ts
+++ b/packages/backend/convex/_validators/enums.ts
@@ -244,6 +244,7 @@ export const fontFamilyValidator = v.union(
   v.literal("poppins"),
   v.literal("dm-sans"),
   v.literal("space-grotesk"),
+  v.literal("host-grotesk"),
   v.literal("geist"),
   v.literal("source-serif"),
   v.literal("jakarta"),


### PR DESCRIPTION
## Summary
- Adds Host Grotesk (Google Fonts uniwidth UI sans) to theme settings alongside existing typefaces.

## Test plan
- [ ] Theme settings → pick Host Grotesk → UI font updates