### PR TITLE
refactor(cards): move team and draft delete into the right-click menu

### DIFF
--- a/apps/web/src/routes/_global/teams/_components/TeamCard.tsx
+++ b/apps/web/src/routes/_global/teams/_components/TeamCard.tsx
@@ -6,11 +6,11 @@ import {
   Card,
   CardHeader,
   CardTitle,
-  Button,
   ContextMenu,
   ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
 } from "@eva/ui";
 import {
   IconUsers,
@@ -23,7 +23,7 @@ import { useTeamLogoUpload } from "@/lib/hooks/useTeamLogoUpload";
 
 type Team = FunctionReturnType<typeof api.teams.list>[number];
 
-/** Team list card with logo display and context-menu set/change/remove. */
+/** Team list card with logo display and a right-click menu for logo and delete. */
 export function TeamCard({
   team,
   onDelete,
@@ -67,25 +67,9 @@ export function TeamCard({
                       />
                       <CardTitle className="text-base">{displayName}</CardTitle>
                     </div>
-                    <div className="flex items-center gap-1.5">
-                      {canDelete && onDelete ? (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            onDelete({ id: team._id, name: displayName });
-                          }}
-                        >
-                          <IconTrash size={14} />
-                        </Button>
-                      ) : null}
-                      <span className="rounded-full bg-secondary px-2 py-0.5 text-xs font-medium">
-                        {team.userRole}
-                      </span>
-                    </div>
+                    <span className="rounded-full bg-secondary px-2 py-0.5 text-xs font-medium">
+                      {team.userRole}
+                    </span>
                   </div>
                 </CardHeader>
               </Card>
@@ -102,6 +86,18 @@ export function TeamCard({
               <IconPhotoOff size={16} />
               Remove logo
             </ContextMenuItem>
+          ) : null}
+          {canDelete && onDelete ? (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                className="text-destructive"
+                onClick={() => onDelete({ id: team._id, name: displayName })}
+              >
+                <IconTrash size={16} />
+                Delete team
+              </ContextMenuItem>
+            </>
           ) : null}
         </ContextMenuContent>
       </ContextMenu>

--- a/apps/web/src/routes/_repo/$owner/$repo/drafts/_components/DraftCard.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/drafts/_components/DraftCard.tsx
@@ -5,7 +5,14 @@ import type { ConvexReactClient } from "convex/react";
 import { useNavigate } from "@tanstack/react-router";
 import { api } from "@eva/backend";
 import type { Id } from "@eva/backend";
-import { Badge, Button, cn } from "@eva/ui";
+import {
+  Badge,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+  cn,
+} from "@eva/ui";
 import { IconTrash } from "@tabler/icons-react";
 import { tokenizedToDisplayText } from "@/lib/components/mentions";
 import { RelativeDateTime } from "@/lib/components/RelativeDateTime";
@@ -91,8 +98,7 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
   const removeCommentDraft = useMutation(api.drafts.remove);
   const removeTaskDraft = useMutation(api.agentTasks.remove);
 
-  const handleDelete = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleDelete = () => {
     if (model.source === "comment") {
       void removeCommentDraft({ id: model.row._id });
     } else {
@@ -174,47 +180,55 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
   const ts = model.row.updatedAt;
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") handleClick();
-      }}
-      className={cn(
-        "group relative flex h-full cursor-pointer flex-col gap-2 rounded-surface border border-border bg-card p-4 shadow-sm",
-        "hover:bg-muted/40 transition-colors duration-100",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-      )}
-    >
-      <div className="flex items-center gap-2">
-        <Badge
-          variant="secondary"
-          className="border-none bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground"
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={handleClick}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") handleClick();
+          }}
+          className={cn(
+            "flex h-full cursor-pointer flex-col gap-2 rounded-surface border border-border bg-card p-4 shadow-sm",
+            "hover:bg-muted/40 transition-colors duration-100",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
         >
-          {label}
-        </Badge>
-        <RelativeDateTime at={ts} className="min-w-0 flex-1 truncate text-xs" />
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          className="h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 text-muted-foreground hover:text-destructive"
-          onClick={handleDelete}
-          title="Delete draft"
-        >
-          <IconTrash size={13} />
-        </Button>
-      </div>
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="secondary"
+              className="border-none bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground"
+            >
+              {label}
+            </Badge>
+            <RelativeDateTime
+              at={ts}
+              className="min-w-0 flex-1 truncate text-xs"
+            />
+          </div>
 
-      <p className="line-clamp-2 text-sm font-medium text-foreground">
-        {title}
-      </p>
+          <p className="line-clamp-2 text-sm font-medium text-foreground">
+            {title}
+          </p>
 
-      {snippet ? (
-        <p className="line-clamp-3 text-sm text-muted-foreground">{snippet}</p>
-      ) : (
-        <p className="text-sm text-muted-foreground/50 italic">No content</p>
-      )}
-    </div>
+          {snippet ? (
+            <p className="line-clamp-3 text-sm text-muted-foreground">
+              {snippet}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground/50 italic">
+              No content
+            </p>
+          )}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem className="text-destructive" onClick={handleDelete}>
+          <IconTrash size={16} />
+          Delete draft
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }


### PR DESCRIPTION
## Summary
- Team and draft card delete moves into the context menu (same pattern as project cards), removing always-visible/hover trash targets.

## Test plan
- [ ] Right-click a team card → Delete team
- [ ] Right-click a draft card → Delete draft
- [ ] No hover trash button on drafts