### PR TITLE
fix(stats): remove Humans Prompting KPI

### DIFF
--- a/apps/web/src/routes/_repo/$owner/$repo/stats/StatsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/stats/StatsClient.tsx
@@ -22,7 +22,6 @@ import { useQuantizedNow } from "@/lib/hooks/useQuantizedNow";
 import {
   IconGitPullRequest,
   IconPercentage,
-  IconUsers,
   IconChecklist,
 } from "@tabler/icons-react";
 
@@ -30,12 +29,10 @@ export function StatsClient() {
   const { repo } = useRepo();
   const [timeRange, setTimeRange] = useQueryState("range", timeRangeParser);
 
-  // Every window below is measured from one of these two clocks. The analytics
-  // queries take the timestamp as an argument because they cannot read it
-  // themselves — a Convex query is cached against its data, so a clock read
-  // freezes at whatever time the result was first computed.
+  // Analytics windows are measured from this clock. Queries take the timestamp
+  // as an argument because they cannot read it themselves — a Convex query is
+  // cached against its data, so a clock read freezes at first compute time.
   const today = useQuantizedNow(DAY_MS);
-  const nowByMinute = useQuantizedNow(60_000);
 
   const startTime = getStartTime(timeRange, today);
   const bucketSize = getBucketSize(timeRange);
@@ -45,10 +42,6 @@ export function StatsClient() {
     repoId: repo._id,
     startTime,
     previousStartTime: getPreviousStartTime(timeRange, today),
-  });
-  const activeUsers = useQuery(api.analytics.getActiveUsers, {
-    repoId: repo._id,
-    now: nowByMinute,
   });
   const timeline = useQuery(api.analytics.getActivityTimeline, {
     repoId: repo._id,
@@ -67,7 +60,6 @@ export function StatsClient() {
 
   const isLoading =
     impactStats === undefined ||
-    activeUsers === undefined ||
     timeline === undefined ||
     leaderboard === undefined ||
     heatmap === undefined;
@@ -87,8 +79,8 @@ export function StatsClient() {
           aria-label="Loading stats"
         >
           <div className="h-40 animate-pulse rounded-surface border border-border bg-muted/60" />
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, i) => (
               <div
                 key={i}
                 className="h-24 animate-pulse rounded-surface border border-border bg-muted/60"
@@ -135,12 +127,6 @@ export function StatsClient() {
                     ? impactStats.prevShipRate
                     : undefined
                 }
-              />
-              <Kpi
-                icon={IconUsers}
-                label="Humans Prompting"
-                value={activeUsers.count}
-                subtitle="Last 5 minutes"
               />
               <Kpi
                 icon={IconChecklist}


### PR DESCRIPTION
## Summary
- Drops the Humans Prompting KPI and its active-users query from app stats.

## Test plan
- [ ] Stats page shows three KPIs; no Humans Prompting