### PR TITLE
refactor(ui): migrate remaining lucide icons to Tabler

### DIFF
--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -35,7 +35,6 @@
     "convex": "^1.40.0",
     "facehash": "^0.0.7",
     "highlight.js": "^11.11.1",
-    "lucide-react": "^0.563.0",
     "motion": "^12.33.0",
     "nanoid": "^5.1.6",
     "react": "^19.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -78,7 +78,6 @@
     "embla-carousel-react": "^8.6.0",
     "facehash": "^0.0.7",
     "frimousse": "^0.3.0",
-    "lucide-react": "^0.563.0",
     "media-chrome": "^4.14.0",
     "motion": "^12.33.0",
     "nanoid": "^5.1.6",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,6 @@
     "cmdk": "^1.1.1",
     "dayjs": ">=1.0.0",
     "embla-carousel-react": "^8.5.1",
-    "lucide-react": "^0.563.0",
     "media-chrome": "^4.14.0",
     "motion": "^12.33.0",
     "nanoid": "^5.1.6",

--- a/packages/ui/src/ai-elements/activity-shared.tsx
+++ b/packages/ui/src/ai-elements/activity-shared.tsx
@@ -2,23 +2,23 @@
 
 import { cn } from "../utils/cn";
 import {
-  FileSearchIcon,
-  PencilIcon,
-  FilePlusIcon,
-  TerminalIcon,
-  FolderSearchIcon,
-  FileTextIcon,
-  GlobeIcon,
-  SearchIcon,
-  WorkflowIcon,
-  BookOpenIcon,
-  WrenchIcon,
-  MessageSquareIcon,
-  ListTodoIcon,
-  InfoIcon,
-  AnchorIcon,
-  LoaderCircleIcon,
-} from "lucide-react";
+  IconFileSearch,
+  IconPencil,
+  IconFilePlus,
+  IconTerminal2,
+  IconFolderSearch,
+  IconFileText,
+  IconWorld,
+  IconSearch,
+  IconSitemap,
+  IconBook2,
+  IconTool,
+  IconMessage,
+  IconListCheck,
+  IconInfoCircle,
+  IconAnchor,
+  IconLoader2,
+} from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
 /** One item in a todo checklist step (type "todos"). */
@@ -110,25 +110,25 @@ export function EvaThinkingIcon({ className }: { className?: string }) {
 }
 
 export const stepConfig = {
-  read: { icon: FileSearchIcon, defaultLabel: "Read file" },
-  edit: { icon: PencilIcon, defaultLabel: "Edited file" },
-  write: { icon: FilePlusIcon, defaultLabel: "Created file" },
-  bash: { icon: TerminalIcon, defaultLabel: "Ran command" },
-  search_files: { icon: FolderSearchIcon, defaultLabel: "Found files" },
-  search_code: { icon: FileTextIcon, defaultLabel: "Searched code" },
-  web_fetch: { icon: GlobeIcon, defaultLabel: "Fetched URL" },
-  web_search: { icon: SearchIcon, defaultLabel: "Web search" },
-  subtask: { icon: WorkflowIcon, defaultLabel: "Ran agent" },
-  notebook: { icon: BookOpenIcon, defaultLabel: "Edited notebook" },
+  read: { icon: IconFileSearch, defaultLabel: "Read file" },
+  edit: { icon: IconPencil, defaultLabel: "Edited file" },
+  write: { icon: IconFilePlus, defaultLabel: "Created file" },
+  bash: { icon: IconTerminal2, defaultLabel: "Ran command" },
+  search_files: { icon: IconFolderSearch, defaultLabel: "Found files" },
+  search_code: { icon: IconFileText, defaultLabel: "Searched code" },
+  web_fetch: { icon: IconWorld, defaultLabel: "Fetched URL" },
+  web_search: { icon: IconSearch, defaultLabel: "Web search" },
+  subtask: { icon: IconSitemap, defaultLabel: "Ran agent" },
+  notebook: { icon: IconBook2, defaultLabel: "Edited notebook" },
   thinking: { icon: EvaThinkingIcon, defaultLabel: "Thinking..." },
   reasoning: { icon: EvaThinkingIcon, defaultLabel: "Thinking..." },
-  response: { icon: MessageSquareIcon, defaultLabel: "Response" },
-  question: { icon: MessageSquareIcon, defaultLabel: "Asked a question" },
-  todos: { icon: ListTodoIcon, defaultLabel: "Task list" },
-  tool: { icon: WrenchIcon, defaultLabel: "Used tool" },
-  notice: { icon: InfoIcon, defaultLabel: "Notice" },
-  hook: { icon: AnchorIcon, defaultLabel: "Hook" },
-  status: { icon: LoaderCircleIcon, defaultLabel: "Status" },
+  response: { icon: IconMessage, defaultLabel: "Response" },
+  question: { icon: IconMessage, defaultLabel: "Asked a question" },
+  todos: { icon: IconListCheck, defaultLabel: "Task list" },
+  tool: { icon: IconTool, defaultLabel: "Used tool" },
+  notice: { icon: IconInfoCircle, defaultLabel: "Notice" },
+  hook: { icon: IconAnchor, defaultLabel: "Hook" },
+  status: { icon: IconLoader2, defaultLabel: "Status" },
 };
 
 const SPINNER_VERBS = [

--- a/packages/ui/src/ai-elements/activity-tasks.tsx
+++ b/packages/ui/src/ai-elements/activity-tasks.tsx
@@ -10,14 +10,14 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import {
-  ChevronDownIcon,
-  CircleIcon,
-  CircleCheckBigIcon,
-  GitBranchIcon,
-  LoaderIcon,
-  SearchIcon,
-  TerminalIcon,
-} from "lucide-react";
+  IconChevronDown,
+  IconCircle,
+  IconCircleCheck,
+  IconGitBranch,
+  IconLoader,
+  IconSearch,
+  IconTerminal2,
+} from "@tabler/icons-react";
 import { cn } from "../utils/cn";
 import { Spinner } from "../ui/spinner";
 import { Shimmer } from "./shimmer";
@@ -109,16 +109,16 @@ export interface ActivityTasksProps extends ComponentProps<"div"> {
 function TodoStatusIcon({ status }: { status: TodoItem["status"] }) {
   if (status === "completed") {
     return (
-      <CircleCheckBigIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+      <IconCircleCheck className="mt-0.5 size-3.5 shrink-0 text-primary" />
     );
   }
   if (status === "in_progress") {
     return (
-      <LoaderIcon className="mt-0.5 size-3.5 shrink-0 animate-spin text-primary" />
+      <IconLoader className="mt-0.5 size-3.5 shrink-0 animate-spin text-primary" />
     );
   }
   return (
-    <CircleIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+    <IconCircle className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
   );
 }
 
@@ -156,9 +156,9 @@ function TodoChecklist({
 }
 
 function bashIconForKind(kind: CommandVisualKind) {
-  if (kind === "inspect") return SearchIcon;
-  if (kind === "git") return GitBranchIcon;
-  return TerminalIcon;
+  if (kind === "inspect") return IconSearch;
+  if (kind === "git") return IconGitBranch;
+  return IconTerminal2;
 }
 
 /** One per-call activity row with Synara-style humanized label. */
@@ -288,7 +288,7 @@ function ActivityStepRow({
         <Collapsible className="group w-full">
           <CollapsibleTrigger className="flex w-full items-center gap-2 text-left transition-colors hover:text-foreground">
             {rowHeader}
-            <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+            <IconChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
           </CollapsibleTrigger>
           <CollapsibleContent className="mt-1.5 ml-6 space-y-1 border-l border-border pl-3 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
             <ActivityStepDetail step={step} onOpenFile={onOpenFile} />
@@ -431,7 +431,7 @@ export const ActivityTasks = memo(
         >
           <CollapsibleTrigger className="flex w-full items-center gap-2 border-b border-border pb-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground">
             <span>Worked for {duration}</span>
-            <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+            <IconChevronDown className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
           </CollapsibleTrigger>
           <CollapsibleContent className="mt-2 space-y-1.5 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
             <ActivityRowList

--- a/packages/ui/src/ai-elements/artifact.tsx
+++ b/packages/ui/src/ai-elements/artifact.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import type { ComponentProps, HTMLAttributes } from "react";
-import type { LucideIcon } from "lucide-react";
-import { XIcon } from "lucide-react";
+import type { Icon as TablerIconType } from "@tabler/icons-react";
+import { IconX } from "@tabler/icons-react";
 import { Button } from "../ui/button";
 import {
   Tooltip,
@@ -60,7 +60,7 @@ export const ArtifactClose = ({
     variant={variant}
     {...props}
   >
-    {children ?? <XIcon className="size-4" />}
+    {children ?? <IconX className="size-4" />}
     <span className="sr-only">Close</span>
   </Button>
 );
@@ -95,7 +95,7 @@ export const ArtifactActions = ({
 export type ArtifactActionProps = ComponentProps<typeof Button> & {
   tooltip?: string;
   label?: string;
-  icon?: LucideIcon;
+  icon?: TablerIconType;
 };
 
 export const ArtifactAction = ({

--- a/packages/ui/src/ai-elements/attachments.tsx
+++ b/packages/ui/src/ai-elements/attachments.tsx
@@ -12,14 +12,14 @@ import {
 import { cn } from "../utils/cn";
 import { SURFACE_RADIUS_CLASS } from "../utils/surface-radius";
 import {
-  FileTextIcon,
-  GlobeIcon,
-  ImageIcon,
-  Music2Icon,
-  PaperclipIcon,
-  VideoIcon,
-  XIcon,
-} from "lucide-react";
+  IconFileText,
+  IconWorld,
+  IconPhoto,
+  IconMusic,
+  IconPaperclip,
+  IconVideo,
+  IconX,
+} from "@tabler/icons-react";
 import { createContext, useCallback, useContext, useMemo } from "react";
 
 export type AttachmentData =
@@ -36,13 +36,13 @@ export type AttachmentMediaCategory =
 
 export type AttachmentVariant = "grid" | "inline" | "list";
 
-const mediaCategoryIcons: Record<AttachmentMediaCategory, typeof ImageIcon> = {
-  audio: Music2Icon,
-  document: FileTextIcon,
-  image: ImageIcon,
-  source: GlobeIcon,
-  unknown: PaperclipIcon,
-  video: VideoIcon,
+const mediaCategoryIcons: Record<AttachmentMediaCategory, typeof IconPhoto> = {
+  audio: IconMusic,
+  document: IconFileText,
+  image: IconPhoto,
+  source: IconWorld,
+  unknown: IconPaperclip,
+  video: IconVideo,
 };
 
 export const getMediaCategory = (
@@ -214,7 +214,7 @@ export const AttachmentPreview = ({
 
   const iconSize = variant === "inline" ? "size-3" : "size-4";
 
-  const renderIcon = (Icon: typeof ImageIcon) => (
+  const renderIcon = (Icon: typeof IconPhoto) => (
     <Icon className={cn(iconSize, "text-muted-foreground")} />
   );
 
@@ -325,7 +325,7 @@ export const AttachmentRemove = ({
       variant="ghost"
       {...props}
     >
-      {children ?? <XIcon />}
+      {children ?? <IconX />}
       <span className="sr-only">{label}</span>
     </Button>
   );

--- a/packages/ui/src/ai-elements/chain-of-thought.tsx
+++ b/packages/ui/src/ai-elements/chain-of-thought.tsx
@@ -9,7 +9,7 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import { cn } from "../utils/cn";
-import { ChevronDownIcon, DotIcon } from "lucide-react";
+import { IconChevronDown, IconPointFilled } from "@tabler/icons-react";
 import { createContext, memo, useContext, useMemo } from "react";
 
 interface ChainOfThoughtContextValue {
@@ -98,7 +98,7 @@ export const ChainOfThoughtHeader = memo(
           <span className="flex-1 text-left tabular-nums">
             {children ?? "Chain of Thought"}
           </span>
-          <ChevronDownIcon
+          <IconChevronDown
             className={cn(
               "size-4 transition-transform",
               isOpen ? "rotate-180" : "rotate-0",
@@ -126,7 +126,7 @@ const stepStatusStyles = {
 export const ChainOfThoughtStep = memo(
   ({
     className,
-    icon: Icon = DotIcon,
+    icon: Icon = IconPointFilled,
     label,
     description,
     status = "complete",

--- a/packages/ui/src/ai-elements/code-block.tsx
+++ b/packages/ui/src/ai-elements/code-block.tsx
@@ -2,7 +2,7 @@
 
 import type { HTMLAttributes } from "react";
 import { createContext, useContext, useState } from "react";
-import { CheckIcon, CopyIcon } from "lucide-react";
+import { IconCheck, IconCopy } from "@tabler/icons-react";
 import { Button } from "../ui/button";
 import { cn } from "../utils/cn";
 import { SURFACE_RADIUS_CLASS } from "../utils/surface-radius";
@@ -69,9 +69,9 @@ export const CodeBlockCopyButton = ({
       {...props}
     >
       {copied ? (
-        <CheckIcon className="size-3.5" />
+        <IconCheck className="size-3.5" />
       ) : (
-        <CopyIcon className="size-3.5" />
+        <IconCopy className="size-3.5" />
       )}
       <span className="sr-only">Copy code</span>
     </Button>

--- a/packages/ui/src/ai-elements/conversation.tsx
+++ b/packages/ui/src/ai-elements/conversation.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from "react";
 
 import { Button } from "../ui/button";
 import { cn } from "../utils/cn";
-import { ChevronDownIcon, DownloadIcon } from "lucide-react";
+import { IconChevronDown, IconDownload } from "@tabler/icons-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
@@ -147,7 +147,7 @@ export const ConversationScrollButton = ({
         title="Scroll to end"
         {...props}
       >
-        <ChevronDownIcon className="size-3.5" />
+        <IconChevronDown className="size-3.5" />
         Scroll to end
       </Button>
     </div>
@@ -215,7 +215,7 @@ export const ConversationDownload = ({
       variant="outline"
       {...props}
     >
-      {children ?? <DownloadIcon className="size-4" />}
+      {children ?? <IconDownload className="size-4" />}
     </Button>
   );
 };

--- a/packages/ui/src/ai-elements/message.tsx
+++ b/packages/ui/src/ai-elements/message.tsx
@@ -17,7 +17,7 @@ import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import {
   createContext,
   memo,
@@ -271,7 +271,7 @@ export const MessageBranchPrevious = ({
       variant="ghost"
       {...props}
     >
-      {children ?? <ChevronLeftIcon size={14} />}
+      {children ?? <IconChevronLeft className="size-3.5" />}
     </Button>
   );
 };
@@ -294,7 +294,7 @@ export const MessageBranchNext = ({
       variant="ghost"
       {...props}
     >
-      {children ?? <ChevronRightIcon size={14} />}
+      {children ?? <IconChevronRight className="size-3.5" />}
     </Button>
   );
 };

--- a/packages/ui/src/ai-elements/plan.tsx
+++ b/packages/ui/src/ai-elements/plan.tsx
@@ -18,7 +18,7 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import { cn } from "../utils/cn";
-import { ChevronsUpDownIcon } from "lucide-react";
+import { IconSelector } from "@tabler/icons-react";
 import { createContext, useContext } from "react";
 
 import { Shimmer } from "./shimmer";
@@ -49,7 +49,7 @@ export const Plan = ({
 }: PlanProps) => (
   <PlanContext.Provider value={{ isStreaming }}>
     <Collapsible asChild data-slot="plan" {...props}>
-      <Card className={cn("shadow-none", className)}>{children}</Card>
+      <Card className={cn("smooth-shadow-none", className)}>{children}</Card>
     </Collapsible>
   </PlanContext.Provider>
 );
@@ -140,7 +140,7 @@ export const PlanTrigger = ({ className, ...props }: PlanTriggerProps) => (
       variant="ghost"
       {...props}
     >
-      <ChevronsUpDownIcon className="size-4" />
+      <IconSelector className="size-4" />
       <span className="sr-only">Toggle plan</span>
     </Button>
   </CollapsibleTrigger>

--- a/packages/ui/src/ai-elements/prompt-input-traits.tsx
+++ b/packages/ui/src/ai-elements/prompt-input-traits.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { ChevronDownIcon } from "lucide-react";
+import { IconChevronDown } from "@tabler/icons-react";
 import { Button } from "../ui/button";
 import {
   DropdownMenu,
@@ -155,7 +155,7 @@ export function TraitsMenu({
           )}
         >
           <span>{triggerLabels.join(" · ")}</span>
-          <ChevronDownIcon aria-hidden="true" className="size-3 opacity-60" />
+          <IconChevronDown aria-hidden="true" className="size-3 opacity-60" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-44">

--- a/packages/ui/src/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/ai-elements/prompt-input.tsx
@@ -51,8 +51,13 @@ import {
 import { Spinner } from "../ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "../utils/cn";
-import { ImageIcon, PlusIcon, SquareIcon, XIcon } from "lucide-react";
-import { IconArrowUp } from "@tabler/icons-react";
+import {
+  IconArrowUp,
+  IconPhoto,
+  IconPlus,
+  IconSquare,
+  IconX,
+} from "@tabler/icons-react";
 import { nanoid } from "nanoid";
 import {
   Children,
@@ -365,7 +370,7 @@ export const PromptInputActionAddAttachments = ({
 
   return (
     <DropdownMenuItem {...props} onSelect={handleSelect}>
-      <ImageIcon className="mr-2 size-4" /> {label}
+      <IconPhoto className="mr-2 size-4" /> {label}
     </DropdownMenuItem>
   );
 };
@@ -1101,7 +1106,7 @@ export const PromptInputActionMenuTrigger = ({
 }: PromptInputActionMenuTriggerProps) => (
   <DropdownMenuTrigger asChild>
     <PromptInputButton className={className} {...props}>
-      {children ?? <PlusIcon className="size-4" />}
+      {children ?? <IconPlus className="size-4" />}
     </PromptInputButton>
   </DropdownMenuTrigger>
 );
@@ -1151,9 +1156,9 @@ export const PromptInputSubmit = ({
   if (status === "submitted") {
     Icon = <Spinner />;
   } else if (status === "streaming") {
-    Icon = <SquareIcon className="size-4" />;
+    Icon = <IconSquare className="size-4" />;
   } else if (status === "error") {
-    Icon = <XIcon className="size-4" />;
+    Icon = <IconX className="size-4" />;
   }
 
   const handleClick = useCallback(

--- a/packages/ui/src/ai-elements/queue.tsx
+++ b/packages/ui/src/ai-elements/queue.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { forwardRef, type ComponentProps, type ReactNode } from "react";
-import { ChevronDownIcon } from "lucide-react";
+import { IconChevronDown } from "@tabler/icons-react";
 import { Button } from "../ui/button";
 import {
   Collapsible,
@@ -16,7 +16,7 @@ export type QueueProps = ComponentProps<"div">;
 export const Queue = ({ className, ...props }: QueueProps) => (
   <div
     className={cn(
-      "flex flex-col rounded-xl border border-border bg-card/40 px-2.5 py-2 shadow-sm",
+      "flex flex-col rounded-xl bg-card/40 px-2.5 py-2 smooth-shadow-ring-sm",
       className,
     )}
     {...props}
@@ -68,7 +68,7 @@ export const QueueSectionLabel = ({
   ...props
 }: QueueSectionLabelProps) => (
   <span className={cn("flex items-center gap-1.5", className)} {...props}>
-    <ChevronDownIcon className="size-3.5 opacity-70 transition-transform group-data-[state=closed]:-rotate-90" />
+    <IconChevronDown className="size-3.5 opacity-70 transition-transform group-data-[state=closed]:-rotate-90" />
     {icon}
     <span>
       {count} {label}

--- a/packages/ui/src/ai-elements/reasoning.tsx
+++ b/packages/ui/src/ai-elements/reasoning.tsx
@@ -14,7 +14,7 @@ import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import { BrainIcon, ChevronDownIcon } from "lucide-react";
+import { IconBrain, IconChevronDown } from "@tabler/icons-react";
 import {
   createContext,
   memo,
@@ -189,9 +189,9 @@ export const ReasoningTrigger = memo(
       >
         {children ?? (
           <>
-            <BrainIcon className="size-4" />
+            <IconBrain className="size-4" />
             {getThinkingMessage(isStreaming, duration)}
-            <ChevronDownIcon
+            <IconChevronDown
               className={cn(
                 "size-4 transition-transform",
                 isOpen ? "rotate-180" : "rotate-0",

--- a/packages/ui/src/ai-elements/task.tsx
+++ b/packages/ui/src/ai-elements/task.tsx
@@ -8,7 +8,7 @@ import {
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import { cn } from "../utils/cn";
-import { ChevronDownIcon, FileIcon } from "lucide-react";
+import { IconChevronDown, IconFile } from "@tabler/icons-react";
 
 export type TaskProps = ComponentProps<typeof Collapsible> & {
   defaultOpen?: boolean;
@@ -40,7 +40,7 @@ export function TaskTrigger({
       {...props}
     >
       {title ?? children}
-      <ChevronDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+      <IconChevronDown className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
     </CollapsibleTrigger>
   );
 }
@@ -92,7 +92,7 @@ export function TaskItemFile({
       )}
       {...props}
     >
-      <FileIcon className="size-3 shrink-0" />
+      <IconFile className="size-3 shrink-0" />
       <span className="truncate">{children}</span>
     </span>
   );

--- a/packages/ui/src/ai-elements/test-results.tsx
+++ b/packages/ui/src/ai-elements/test-results.tsx
@@ -3,12 +3,12 @@
 import type { ComponentProps, HTMLAttributes } from "react";
 import { createContext, useContext, useMemo } from "react";
 import {
-  CheckCircle2Icon,
-  ChevronRightIcon,
-  CircleDotIcon,
-  CircleIcon,
-  XCircleIcon,
-} from "lucide-react";
+  IconCircleCheck,
+  IconChevronRight,
+  IconCircleDot,
+  IconCircle,
+  IconCircleX,
+} from "@tabler/icons-react";
 import { Badge } from "../ui/badge";
 import {
   Collapsible,
@@ -103,18 +103,18 @@ export const TestResultsSummary = ({
       {children ?? (
         <>
           <Badge className="gap-1" variant="success">
-            <CheckCircle2Icon className="size-3" />
+            <IconCircleCheck className="size-3" />
             {summary.passed} passed
           </Badge>
           {summary.failed > 0 && (
             <Badge className="gap-1" variant="destructive">
-              <XCircleIcon className="size-3" />
+              <IconCircleX className="size-3" />
               {summary.failed} failed
             </Badge>
           )}
           {summary.skipped > 0 && (
             <Badge className="gap-1" variant="warning">
-              <CircleIcon className="size-3" />
+              <IconCircle className="size-3" />
               {summary.skipped} skipped
             </Badge>
           )}
@@ -247,7 +247,7 @@ export const TestSuiteName = ({
       )}
       {...props}
     >
-      <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+      <IconChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
       <TestStatusIcon status={status} />
       <span className="font-medium text-sm">{children ?? name}</span>
     </CollapsibleTrigger>
@@ -352,10 +352,10 @@ const statusStyles: Record<TestStatus, string> = {
 };
 
 const statusIcons: Record<TestStatus, React.ReactNode> = {
-  failed: <XCircleIcon className="size-4" />,
-  passed: <CheckCircle2Icon className="size-4" />,
-  running: <CircleDotIcon className="size-4" />,
-  skipped: <CircleIcon className="size-4" />,
+  failed: <IconCircleX className="size-4" />,
+  passed: <IconCircleCheck className="size-4" />,
+  running: <IconCircleDot className="size-4" />,
+  skipped: <IconCircle className="size-4" />,
 };
 
 const TestStatusIcon = ({ status }: { status: TestStatus }) => (

--- a/packages/ui/src/kibo/theme-switcher.tsx
+++ b/packages/ui/src/kibo/theme-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import { Monitor, Moon, Sun } from "lucide-react";
+import { IconDeviceDesktop, IconMoon, IconSun } from "@tabler/icons-react";
 import { motion } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
 import { cn } from "../utils/cn";
@@ -9,17 +9,17 @@ import { cn } from "../utils/cn";
 const themes = [
   {
     key: "system",
-    icon: Monitor,
+    icon: IconDeviceDesktop,
     label: "System theme",
   },
   {
     key: "light",
-    icon: Sun,
+    icon: IconSun,
     label: "Light theme",
   },
   {
     key: "dark",
-    icon: Moon,
+    icon: IconMoon,
     label: "Dark theme",
   },
 ] as const;

--- a/packages/ui/src/ui/calendar.tsx
+++ b/packages/ui/src/ui/calendar.tsx
@@ -6,7 +6,7 @@ import {
   getDefaultClassNames,
   type DayButton,
 } from "react-day-picker";
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import { cn } from "../utils/cn";
 import { SURFACE_RADIUS_CLASS } from "../utils/surface-radius";
 import { buttonVariants } from "./button";
@@ -91,7 +91,7 @@ function Calendar({
           ...chevronProps
         }) => {
           const Icon =
-            orientation === "left" ? ChevronLeftIcon : ChevronRightIcon;
+            orientation === "left" ? IconChevronLeft : IconChevronRight;
           return (
             <Icon
               className={cn("size-4", chevronClassName)}

--- a/packages/ui/src/ui/command.tsx
+++ b/packages/ui/src/ui/command.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { type DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
-import { Search } from "lucide-react";
+import { IconSearch } from "@tabler/icons-react";
 
 import { cn } from "../utils/cn";
 import { SURFACE_RADIUS_CLASS } from "../utils/surface-radius";
@@ -45,7 +45,7 @@ const CommandInput = React.forwardRef<
     className="flex items-center gap-2 border-b border-border px-3.5"
     cmdk-input-wrapper=""
   >
-    <Search className="size-4 shrink-0 text-muted-foreground" />
+    <IconSearch className="size-4 shrink-0 text-muted-foreground" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,9 +113,6 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
-      lucide-react:
-        specifier: ^0.563.0
-        version: 0.563.0(react@19.2.1)
       motion:
         specifier: ^12.33.0
         version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -372,9 +369,6 @@ importers:
       frimousse:
         specifier: ^0.3.0
         version: 0.3.0(react@19.2.1)(typescript@7.0.1-rc)
-      lucide-react:
-        specifier: ^0.563.0
-        version: 0.563.0(react@19.2.1)
       media-chrome:
         specifier: ^4.14.0
         version: 4.19.0(react@19.2.1)
@@ -720,9 +714,6 @@ importers:
       embla-carousel-react:
         specifier: ^8.5.1
         version: 8.6.0(react@19.2.1)
-      lucide-react:
-        specifier: ^0.563.0
-        version: 0.563.0(react@19.2.1)
       media-chrome:
         specifier: ^4.14.0
         version: 4.19.0(react@19.2.1)
@@ -6914,11 +6905,6 @@ packages:
 
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
-
-  lucide-react@0.563.0:
-    resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -15541,10 +15527,6 @@ snapshots:
       yallist: 3.1.1
 
   lru_map@0.4.1: {}
-
-  lucide-react@0.563.0(react@19.2.1):
-    dependencies:
-      react: 19.2.1
 
   luxon@3.7.2: {}
 


### PR DESCRIPTION
## Summary
- Removes `lucide-react` from web, UI package, and chrome extension; remaining glyphs use Tabler for one stroke weight.

## Test plan
- [ ] Smoke AI elements, calendar, command palette, theme switcher icons
- [ ] Confirm lucide-react gone from package.json / lockfile