### PR TITLE
feat(ui): adopt Surface / Skeleton / ListRow at call sites

### DIFF
--- a/apps/web/src/lib/components/ChangelogDialog.tsx
+++ b/apps/web/src/lib/components/ChangelogDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogBody,
   DialogFooter,
   Button,
+  Surface,
   cn,
   STREAMDOWN_TABLE_RADIUS_CLASS,
 } from "@eva/ui";
@@ -89,7 +90,7 @@ export function ChangelogDialog() {
 
         <DialogBody>
           <div className="max-h-[60vh] overflow-y-auto">
-            <div className="rounded-surface border border-border bg-card p-4">
+            <Surface>
               <Streamdown
                 className={cn(
                   "text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
@@ -99,7 +100,7 @@ export function ChangelogDialog() {
               >
                 {changelog.content}
               </Streamdown>
-            </div>
+            </Surface>
           </div>
         </DialogBody>
 

--- a/apps/web/src/lib/components/CronScheduleCard.tsx
+++ b/apps/web/src/lib/components/CronScheduleCard.tsx
@@ -1,6 +1,6 @@
 import cronstrue from "cronstrue";
 import { CronExpressionParser } from "cron-parser";
-import { Input } from "@eva/ui";
+import { Input, Surface } from "@eva/ui";
 
 function getOffsetMinutes(): number {
   return -new Date().getTimezoneOffset();
@@ -89,7 +89,7 @@ export function CronScheduleCard({
   const schedule = allowManual ? value : value || "";
 
   return (
-    <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
+    <Surface density="none" className="p-3 space-y-4 sm:p-4">
       <h3 className="text-sm font-medium">Cron Schedule</h3>
       <div>
         <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
@@ -126,7 +126,7 @@ export function CronScheduleCard({
         </p>
         <CronGuide />
       </div>
-    </div>
+    </Surface>
   );
 }
 

--- a/apps/web/src/lib/components/SetupBanner.tsx
+++ b/apps/web/src/lib/components/SetupBanner.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogFooter,
   Button,
+  Surface,
 } from "@eva/ui";
 import { IconAlertTriangle } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
@@ -110,7 +111,7 @@ export function SetupBanner() {
             enable Codex, sign in locally with Codex once, then paste the saved
             auth JSON into `CODEX_AUTH_JSON`.
           </p>
-          <div className="rounded-surface border border-border bg-card p-4">
+          <Surface>
             <p className="mb-2 text-xs font-medium text-muted-foreground">
               Missing Variables:
             </p>
@@ -140,7 +141,7 @@ export function SetupBanner() {
                 </div>
               ))}
             </div>
-          </div>
+          </Surface>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => setDismissed(true)}>

--- a/apps/web/src/lib/components/chat/ChangedFilesCard.tsx
+++ b/apps/web/src/lib/components/chat/ChangedFilesCard.tsx
@@ -1,6 +1,6 @@
 import type { ActivityStep } from "@eva/ui";
 import { IconFileText } from "@tabler/icons-react";
-import { cn } from "@eva/ui";
+import { cn, Surface } from "@eva/ui";
 
 export interface ChangedFile {
   path: string;
@@ -94,7 +94,7 @@ export function ChangedFilesCard({
   };
 
   return (
-    <div className="mt-2 rounded-surface border border-border bg-card">
+    <Surface density="none" className="mt-2">
       <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
         <span className="text-xs font-medium text-foreground">
           Changed files ({files.length})
@@ -128,7 +128,7 @@ export function ChangedFilesCard({
           </li>
         ))}
       </ul>
-    </div>
+    </Surface>
   );
 }
 

--- a/apps/web/src/lib/components/chat/ReviewCommentMessage.tsx
+++ b/apps/web/src/lib/components/chat/ReviewCommentMessage.tsx
@@ -1,4 +1,5 @@
 import { IconMessage } from "@tabler/icons-react";
+import { Surface } from "@eva/ui";
 import {
   MarkdownMentionText,
   MARKDOWN_PROSE_CLASS,
@@ -31,7 +32,7 @@ function ReviewCommentCard({
   const { repo } = useRepo();
 
   return (
-    <div className="space-y-2 rounded-lg border border-border bg-card p-3">
+    <Surface density="tight" className="space-y-2">
       <div className="space-y-1">
         <div className="text-xs font-medium text-foreground">{filePath}</div>
         <div className="text-[11px] text-muted-foreground">{rangeLabel}</div>
@@ -45,7 +46,7 @@ function ReviewCommentCard({
           atKind="user"
         />
       ) : null}
-    </div>
+    </Surface>
   );
 }
 

--- a/apps/web/src/lib/components/docs/_components/DocPrdViewer.tsx
+++ b/apps/web/src/lib/components/docs/_components/DocPrdViewer.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   Spinner,
+  Surface,
   Tabs,
   TabsBar,
   TabsContent,
@@ -266,7 +267,7 @@ export function DocPrdViewer({
       />
       {streaming && (
         <div className="px-4 pb-3">
-          <div className="rounded-surface border border-border bg-card p-3 space-y-2">
+          <Surface density="tight" className="space-y-2">
             <div className="flex items-center gap-2 text-sm font-medium">
               <Spinner size="sm" />
               <span className="flex-1">
@@ -292,7 +293,7 @@ export function DocPrdViewer({
             {streamingSteps ? (
               <ActivityTasks steps={streamingSteps} isStreaming />
             ) : null}
-          </div>
+          </Surface>
         </div>
       )}
 

--- a/apps/web/src/lib/components/docs/_components/DocRecapViewer.tsx
+++ b/apps/web/src/lib/components/docs/_components/DocRecapViewer.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   Spinner,
+  Surface,
   Tabs,
   TabsBar,
   TabsContent,
@@ -240,7 +241,7 @@ export function DocRecapViewer({
       ) : null}
       {isRecapPending && !isRecapStalled && (
         <div className="px-4 pb-3">
-          <div className="rounded-surface border border-border bg-card p-3 space-y-2">
+          <Surface density="tight" className="space-y-2">
             <div className="flex items-center gap-2 text-sm font-medium">
               <Spinner size="sm" />
               <span className="flex-1">Generating recap...</span>
@@ -252,7 +253,7 @@ export function DocRecapViewer({
                 {streaming?.currentActivity ?? "Generating recap..."}
               </p>
             )}
-          </div>
+          </Surface>
         </div>
       )}
 

--- a/apps/web/src/lib/components/projects/ProjectCard.tsx
+++ b/apps/web/src/lib/components/projects/ProjectCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Id } from "@eva/backend";
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useMutation } from "convex/react";
 import { api } from "@eva/backend";
@@ -38,11 +38,13 @@ import {
   DialogTitle,
   DialogFooter,
   Input,
+  ListRow,
   Textarea,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@eva/ui";
+import { DynamicLink } from "@/lib/components/DynamicLink";
 import {
   phaseConfig,
   PROJECT_PHASES,
@@ -72,8 +74,13 @@ interface ProjectCardProps {
   isBuilding?: boolean;
   sandboxStatus?: SandboxStatus;
   isActive?: boolean;
+  /** Public (slash) path; rendered via router Link so rewrites own the href. */
   href?: string;
-  onClick?: () => void;
+  /**
+   * Plain-click handler. Call `event.preventDefault()` to cancel Link
+   * navigation (e.g. while a dialog is open).
+   */
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
   onDelete: () => void;
 }
 
@@ -157,103 +164,113 @@ export function ProjectCard({
   const hiddenCount = allAvatarIds.length - MAX_AVATARS;
 
   const cardContent = (
-    <div
-      className={`group relative shrink-0 overflow-hidden rounded-surface border transition-[transform,background-color] duration-200 ease-[var(--motion-ease-out)] ${
-        isActive
-          ? "border-primary/30 bg-primary/5 ring-1 ring-primary/30"
-          : "border-border bg-card shadow-sm hover:bg-muted/40"
-      }`}
+    <ListRow
+      className="shrink-0"
+      accentClassName={accentColor}
+      selected={isActive}
+      link={
+        href ? (
+          <DynamicLink to={href} search={(prev) => prev} />
+        ) : undefined
+      }
+      onClick={
+        editOpen || onClick
+          ? (event) => {
+              if (editOpen) {
+                event.preventDefault();
+                return;
+              }
+              onClick?.(event);
+            }
+          : undefined
+      }
+      aria-label={title}
+      contentClassName="flex flex-col gap-1.5 px-3 py-2.5 pl-3.5"
     >
-      <div className="pointer-events-none absolute -right-8 -top-10 h-24 w-24 rounded-full bg-primary/10 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-      <div
-        className={`absolute inset-y-2 left-0 w-1 rounded-r-full ${accentColor}`}
-      />
-      <div
-        role="button"
-        tabIndex={0}
-        className="relative z-[1] block w-full cursor-pointer p-2.5 pl-3 text-left motion-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35"
-        onClick={(event) => {
-          if (href && (event.metaKey || event.ctrlKey)) {
-            event.preventDefault();
-            event.stopPropagation();
-            window.open(href, "_blank");
-            return;
-          }
-          onClick?.();
-        }}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            onClick?.();
-          }
-        }}
-      >
-        <div className="flex min-w-0 items-start gap-1.5">
-          <MarqueeOnHover className="min-w-0 flex-1 text-sm font-semibold leading-5 text-foreground transition-colors duration-200 group-hover:text-primary">
+      <div className="flex min-w-0 items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <MarqueeOnHover className="min-w-0 text-[13px] font-medium leading-5 tracking-[-0.01em] text-foreground transition-colors duration-200 group-hover:text-primary">
             {title}
           </MarqueeOnHover>
-          {sandboxStatus ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className={cn(
-                    "mt-1.5 size-2 shrink-0 rounded-full",
-                    SANDBOX_STATUS_STYLES[sandboxStatus].dot,
-                  )}
-                />
-              </TooltipTrigger>
-              <TooltipContent>
-                {SANDBOX_STATUS_STYLES[sandboxStatus].label}
-              </TooltipContent>
-            </Tooltip>
+          {previewText ? (
+            <p
+              className={cn(
+                "mt-1 line-clamp-2 text-xs leading-relaxed text-pretty",
+                description
+                  ? "text-muted-foreground"
+                  : "italic text-muted-foreground/80",
+              )}
+            >
+              {previewText}
+            </p>
           ) : null}
         </div>
-        {previewText ? (
-          <p
-            className={`mt-1.5 line-clamp-1 text-xs leading-relaxed ${description ? "text-muted-foreground" : "italic text-muted-foreground/80"}`}
-          >
-            {previewText}
-          </p>
-        ) : null}
-        <div className="mt-2 flex flex-wrap items-center gap-1">
+        {sandboxStatus ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Badge
-                variant="secondary"
-                className="gap-0.5 px-1.5 py-0 text-[10px] font-medium leading-4"
-              >
-                {planningMode === "interview" ? (
-                  <IconSparkles size={10} className="shrink-0" />
-                ) : (
-                  <IconListCheck size={10} className="shrink-0" />
+              <span
+                className={cn(
+                  "relative mt-1.5 size-2 shrink-0 rounded-full after:absolute after:inset-[-8px]",
+                  SANDBOX_STATUS_STYLES[sandboxStatus].dot,
                 )}
-                {planningMode === "interview" ? "Interview" : "Tasks only"}
-              </Badge>
+              />
             </TooltipTrigger>
             <TooltipContent>
-              {planningMode === "interview"
-                ? "Created with AI interview and generated plan"
-                : "Created as a tasks-only container"}
+              {SANDBOX_STATUS_STYLES[sandboxStatus].label}
             </TooltipContent>
           </Tooltip>
-        </div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge
+              variant="secondary"
+              className="gap-0.5 px-1.5 py-0 text-[10px] font-medium leading-4"
+            >
+              {planningMode === "interview" ? (
+                <IconSparkles className="size-2.5 shrink-0" />
+              ) : (
+                <IconListCheck className="size-2.5 shrink-0" />
+              )}
+              {planningMode === "interview" ? "Interview" : "Tasks only"}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            {planningMode === "interview"
+              ? "Created with AI interview and generated plan"
+              : "Created as a tasks-only container"}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="mt-0.5 pt-0.5">
         <ProjectProgressBar
           projectId={projectId}
-          className="mt-4 h-1.5 bg-secondary/75"
+          className="h-1 bg-secondary/80"
         />
-        <div className="mt-3 flex items-center gap-1.5">
-          <AvatarStack size={20} className="-space-x-0.5">
-            {shownAvatarIds.map((id) => (
-              <UserInitials key={id} userId={id} hideLastSeen />
-            ))}
-          </AvatarStack>
-          {hiddenCount > 0 ? (
-            <span className="text-[11px] font-medium leading-none text-muted-foreground">
-              +{hiddenCount}
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <AvatarStack size={18} className="-space-x-0.5">
+              {shownAvatarIds.map((id) => (
+                <UserInitials key={id} userId={id} hideLastSeen />
+              ))}
+            </AvatarStack>
+            {hiddenCount > 0 ? (
+              <span className="text-[11px] font-medium tabular-nums text-muted-foreground">
+                +{hiddenCount}
+              </span>
+            ) : null}
+          </div>
+          {branchName ? (
+            <span className="max-w-[45%] truncate font-mono text-[10px] tabular-nums text-muted-foreground/65">
+              {branchName}
             </span>
           ) : null}
         </div>
       </div>
+
       <Dialog open={editOpen} onOpenChange={setEditOpen}>
         <DialogContent onClick={(event) => event.stopPropagation()}>
           <DialogHeader>
@@ -299,13 +316,11 @@ export function ProjectCard({
           </form>
         </DialogContent>
       </Dialog>
-    </div>
+    </ListRow>
   );
 
   const wrappedCard = isBuilding ? (
-    <div className="qt-in-progress-border rounded-[9px] p-px">
-      {cardContent}
-    </div>
+    <div className="qt-in-progress-border p-px">{cardContent}</div>
   ) : (
     cardContent
   );
@@ -346,7 +361,7 @@ export function ProjectCard({
         </ContextMenuSub>
         <ContextMenuSub>
           <ContextMenuSubTrigger>
-            <IconUserPlus size={16} />
+            <IconUserPlus className="size-4" />
             Project Lead
           </ContextMenuSubTrigger>
           <ContextMenuSubContent>
@@ -374,7 +389,7 @@ export function ProjectCard({
               ) : null}
               <ContextMenuRadioItem value="none">No lead</ContextMenuRadioItem>
               {(users ?? []).map((user) => (
-                <ContextMenuRadioItem key={user._id} value={user._id}>
+                <ContextMenuRadioItem data-pii key={user._id} value={user._id}>
                   {user.fullName ?? user.firstName ?? "Unknown"}
                 </ContextMenuRadioItem>
               ))}
@@ -388,7 +403,7 @@ export function ProjectCard({
               window.open(href, "_blank");
             }}
           >
-            <IconExternalLink size={16} />
+            <IconExternalLink className="size-4" />
             Open in new tab
           </ContextMenuItem>
         ) : null}
@@ -399,7 +414,7 @@ export function ProjectCard({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <IconGitBranch size={16} />
+              <IconGitBranch className="size-4" />
               View Branch
             </a>
           </ContextMenuItem>
@@ -411,7 +426,7 @@ export function ProjectCard({
             setEditOpen(true);
           }}
         >
-          <IconPencil size={16} />
+          <IconPencil className="size-4" />
           Edit Details
         </ContextMenuItem>
         <ContextMenuSeparator />
@@ -420,7 +435,7 @@ export function ProjectCard({
             void navigator.clipboard.writeText(title);
           }}
         >
-          <IconClipboard size={16} />
+          <IconClipboard className="size-4" />
           Copy title
         </ContextMenuItem>
         {branchName ? (
@@ -429,13 +444,13 @@ export function ProjectCard({
               void navigator.clipboard.writeText(branchName);
             }}
           >
-            <IconCopy size={16} />
+            <IconCopy className="size-4" />
             Copy branch name
           </ContextMenuItem>
         ) : null}
         <ContextMenuSeparator />
         <ContextMenuItem className="text-destructive" onClick={onDelete}>
-          <IconTrash size={16} />
+          <IconTrash className="size-4" />
           Delete
         </ContextMenuItem>
       </ContextMenuContent>

--- a/apps/web/src/lib/components/quick-tasks/QuickTaskCard.tsx
+++ b/apps/web/src/lib/components/quick-tasks/QuickTaskCard.tsx
@@ -2,8 +2,6 @@
 
 import {
   Badge,
-  Card,
-  CardContent,
   Checkbox,
   cn,
   ContextMenu,
@@ -12,6 +10,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
+  LIST_ROW_CONTROL_CLASS,
+  ListRow,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -35,7 +35,8 @@ import {
   type Priority,
 } from "@/lib/components/priority/priorityMeta";
 import dayjs, { compactRelativeTime } from "@eva/shared/dates";
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
+import { DynamicLink } from "@/lib/components/DynamicLink";
 import { DeleteTaskDialog } from "./_components/DeleteTaskDialog";
 import { MoveTaskDialog } from "./_components/MoveTaskDialog";
 import { TaskCardMenuItems } from "./_components/TaskCardMenuItems";
@@ -64,8 +65,13 @@ interface QuickTaskCardProps {
   deploymentStatus?: DeploymentStatus;
   sandboxStatus?: SandboxStatus;
   groupedCodebases?: GroupedCodebase[];
+  /** Public (slash) path; rendered via router Link so rewrites own the href. */
   href?: string;
-  onClick?: () => void;
+  /**
+   * Plain-click handler. Call `event.preventDefault()` to cancel Link
+   * navigation (selection mode, open dialogs).
+   */
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
   isSelecting?: boolean;
   isSelected?: boolean;
   isActive?: boolean;
@@ -161,180 +167,175 @@ export function QuickTaskCard({
     createdByUser?.firstName ?? createdByUser?.fullName?.split(/\s+/)[0];
 
   const card = (
-    <Card
-      className={`group relative overflow-hidden transition-[transform,background-color] duration-150 ${
+    <ListRow
+      accentClassName={accentClass}
+      selected={isActive}
+      link={
+        href ? (
+          <DynamicLink to={href} search={(prev) => prev} />
+        ) : undefined
+      }
+      onClick={
+        hasDialogOpen || onClick
+          ? (event) => {
+              if (hasDialogOpen) {
+                event.preventDefault();
+                return;
+              }
+              onClick?.(event);
+            }
+          : undefined
+      }
+      aria-label={title}
+      contentClassName="flex flex-col gap-1.5 px-2.5 py-2 pl-3 sm:px-3 sm:py-2.5 sm:pl-3.5"
+      className={cn(
         showError
           ? "border-destructive/30 bg-destructive/5"
           : isInProgress
             ? "bg-card"
-            : isActive
-              ? "border-primary/30 bg-primary/5"
-              : "bg-card hover:bg-muted/40"
-      } ${isSelected ? "ring-2 ring-primary/40" : ""} ${isActive ? "ring-1 ring-primary/30" : ""} ${
-        onClick
-          ? "motion-press cursor-pointer active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35"
-          : ""
-      }`}
-      onClick={(e) => {
-        if (e.detail === 0) return;
-        if (hasDialogOpen) return;
-        if (href && (e.metaKey || e.ctrlKey)) {
-          e.preventDefault();
-          e.stopPropagation();
-          window.open(href, "_blank");
-          return;
-        }
-        onClick?.();
-      }}
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      onKeyDown={(event) => {
-        if (!onClick || hasDialogOpen) return;
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          onClick();
-        }
-      }}
+            : undefined,
+        isSelected && "ring-2 ring-primary/40",
+      )}
     >
-      <div
-        className={`absolute inset-y-1.5 left-0 w-[3px] rounded-r-full ${accentClass}`}
-      />
-      <CardContent className="relative z-[1] px-2.5 py-2 pl-3 sm:px-3 sm:py-2.5 sm:pl-3.5">
-        <div className="flex min-w-0 items-start gap-1.5">
-          {isSelecting && (
-            <Checkbox
-              checked={isSelected}
-              onCheckedChange={() => onToggleSelect?.()}
-              onClick={(e) => e.stopPropagation()}
-              className="mt-0.5 flex-shrink-0"
-            />
-          )}
-          <MarqueeOnHover className="min-w-0 flex-1 text-sm font-medium leading-5 text-foreground transition-colors duration-200 group-hover:text-primary">
-            {taskNumber !== undefined && (
-              <span className="mr-1.5 font-mono text-xs tabular-nums text-muted-foreground/70">
-                #{taskNumber}
-              </span>
-            )}
-            {title}
-          </MarqueeOnHover>
-
-          <div className="flex shrink-0 items-center gap-1">
-            {priority ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="flex items-center">
-                    <PriorityIcon level={priority} size={14} />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>{PRIORITY_LABELS[priority]}</TooltipContent>
-              </Tooltip>
-            ) : null}
-            {sandboxStatus ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className={cn(
-                      "size-2 shrink-0 rounded-full",
-                      SANDBOX_STATUS_STYLES[sandboxStatus].dot,
-                    )}
-                  />
-                </TooltipTrigger>
-                <TooltipContent>
-                  {SANDBOX_STATUS_STYLES[sandboxStatus].label}
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
-            {scheduledAt ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="flex items-center text-primary">
-                    <IconClock size={14} />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {status === "todo"
-                    ? `Scheduled for ${dayjs(scheduledAt).format("MMM D, h:mm A")}`
-                    : `Was scheduled for ${dayjs(scheduledAt).format("MMM D, h:mm A")}`}
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
-          </div>
-        </div>
-
-        {hasMetadata && (
-          <div className="mt-1.5 flex flex-wrap items-center gap-1">
-            {projectName ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="default"
-                    className="max-w-full px-1.5 py-0 text-[10px] font-medium leading-4"
-                  >
-                    <div className="flex min-w-0 flex-row items-center gap-0.5">
-                      <IconFolder size={10} className="shrink-0" />
-                      <span className="truncate">{projectName}</span>
-                    </div>
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>{projectName}</TooltipContent>
-              </Tooltip>
-            ) : null}
-            {tags?.map((tag) => (
-              <Badge
-                key={tag}
-                variant="secondary"
-                className="px-1.5 py-0 text-[10px] font-medium leading-4"
-              >
-                <div className="flex flex-row gap-0.5 items-center">
-                  <IconTag size={10} />
-                  {tag}
-                </div>
-              </Badge>
-            ))}
-          </div>
-        )}
-
-        <div className="mt-2 flex items-center justify-between">
-          <div className="flex min-w-0 items-center gap-1.5">
-            {createdByUser ? (
-              <>
-                <UserInitials user={createdByUser} size="sm" />
-                {creatorFirstName ? (
-                  <MarqueeOnHover className="min-w-0 text-[10px] text-muted-foreground/70">
-                    {creatorFirstName}
-                  </MarqueeOnHover>
-                ) : null}
-              </>
-            ) : null}
-          </div>
-          <div className="flex items-center gap-1.5">
-            <span className="text-[10px] tabular-nums text-muted-foreground/70">
-              {compactRelativeTime(createdAt)}
+      <div className="flex min-w-0 items-start gap-2">
+        {isSelecting ? (
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={() => onToggleSelect?.()}
+            onClick={(e) => e.stopPropagation()}
+            className={cn("mt-0.5 flex-shrink-0", LIST_ROW_CONTROL_CLASS)}
+          />
+        ) : null}
+        <MarqueeOnHover className="min-w-0 flex-1 text-[13px] font-medium leading-5 tracking-[-0.01em] text-foreground transition-colors duration-200 group-hover:text-primary">
+          {taskNumber !== undefined ? (
+            <span className="mr-1.5 font-mono text-[11px] font-normal tabular-nums text-muted-foreground/55">
+              #{taskNumber}
             </span>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="sm:hidden flex items-center justify-center h-6 w-6 rounded-md text-muted-foreground hover:bg-muted/80 hover:text-foreground transition-colors relative after:absolute after:inset-[-8px]"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <IconDots size={14} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="end"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <TaskCardMenuItems variant="dropdown" {...menuProps} />
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          ) : null}
+          {title}
+        </MarqueeOnHover>
+
+        <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
+          {priority ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="relative flex items-center after:absolute after:inset-[-8px]">
+                  <PriorityIcon level={priority} size={14} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{PRIORITY_LABELS[priority]}</TooltipContent>
+            </Tooltip>
+          ) : null}
+          {sandboxStatus ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className={cn(
+                    "relative size-2 shrink-0 rounded-full after:absolute after:inset-[-8px]",
+                    SANDBOX_STATUS_STYLES[sandboxStatus].dot,
+                  )}
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                {SANDBOX_STATUS_STYLES[sandboxStatus].label}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+          {scheduledAt ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="relative flex items-center text-primary after:absolute after:inset-[-8px]">
+                  <IconClock className="size-3.5" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {status === "todo"
+                  ? `Scheduled for ${dayjs(scheduledAt).format("MMM D, h:mm A")}`
+                  : `Was scheduled for ${dayjs(scheduledAt).format("MMM D, h:mm A")}`}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
         </div>
-      </CardContent>
-    </Card>
+      </div>
+
+      {hasMetadata ? (
+        <div className="flex min-w-0 flex-wrap items-center gap-1">
+          {projectName ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge
+                  variant="default"
+                  className="max-w-full px-1.5 py-0 text-[10px] font-medium leading-4"
+                >
+                  <span className="flex min-w-0 items-center gap-0.5">
+                    <IconFolder className="size-2.5 shrink-0" />
+                    <span className="truncate">{projectName}</span>
+                  </span>
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>{projectName}</TooltipContent>
+            </Tooltip>
+          ) : null}
+          {tags?.map((tag) => (
+            <Badge
+              key={tag}
+              variant="secondary"
+              className="max-w-[7rem] px-1.5 py-0 text-[10px] font-medium leading-4"
+            >
+              <span className="flex min-w-0 items-center gap-0.5">
+                <IconTag className="size-2.5 shrink-0" />
+                <span className="truncate">{tag}</span>
+              </span>
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-0.5 flex items-center justify-between gap-2 pt-0.5">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {createdByUser ? (
+            <>
+              <UserInitials user={createdByUser} size="sm" />
+              {creatorFirstName ? (
+                <MarqueeOnHover className="min-w-0 text-[11px] text-muted-foreground/75">
+                  <span data-pii>{creatorFirstName}</span>
+                </MarqueeOnHover>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="text-[11px] tabular-nums text-muted-foreground/70">
+            {compactRelativeTime(createdAt)}
+          </span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className={cn(
+                  "relative flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-[background-color,color,transform] duration-150 ease-[var(--motion-ease-out)] after:absolute after:inset-[-8px] hover:bg-muted/80 hover:text-foreground active:scale-[0.96] sm:hidden",
+                  LIST_ROW_CONTROL_CLASS,
+                )}
+                onClick={(e) => e.stopPropagation()}
+                aria-label="Task actions"
+              >
+                <IconDots className="size-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <TaskCardMenuItems variant="dropdown" {...menuProps} />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </ListRow>
   );
 
   const wrappedCard = isInProgress ? (
-    <div className="qt-in-progress-border rounded-[9px] p-px">{card}</div>
+    <div className="qt-in-progress-border p-px">{card}</div>
   ) : (
     card
   );

--- a/apps/web/src/lib/components/sandbox/PrRecapPanel.tsx
+++ b/apps/web/src/lib/components/sandbox/PrRecapPanel.tsx
@@ -10,6 +10,7 @@ import {
   ActivityTasks,
   Button,
   Spinner,
+  Surface,
   Tabs,
   TabsBar,
   TabsList,
@@ -211,7 +212,7 @@ export function PrRecapPanel({ prUrl, repoId, recapDoc }: PrRecapPanelProps) {
 
       {isPending && !isStalled && (
         <div className="shrink-0 px-3 py-2">
-          <div className="space-y-2 rounded-lg border border-border bg-card p-3">
+          <Surface density="tight" className="space-y-2">
             <div className="flex items-center gap-2 text-sm font-medium">
               <Spinner size="sm" />
               <span className="flex-1">Generating recap...</span>
@@ -223,7 +224,7 @@ export function PrRecapPanel({ prUrl, repoId, recapDoc }: PrRecapPanelProps) {
                 {streaming?.currentActivity ?? "Generating recap..."}
               </p>
             )}
-          </div>
+          </Surface>
         </div>
       )}
 
@@ -241,11 +242,11 @@ export function PrRecapPanel({ prUrl, repoId, recapDoc }: PrRecapPanelProps) {
             </p>
           )
         ) : (
-          <div className="rounded-lg border border-border bg-card p-4">
+          <Surface>
             <Streamdown className="prose prose-sm dark:prose-invert max-w-none text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
               {recapDoc.content}
             </Streamdown>
-          </div>
+          </Surface>
         )}
       </div>
     </Tabs>

--- a/apps/web/src/lib/components/sidebar/DocsSidebar.tsx
+++ b/apps/web/src/lib/components/sidebar/DocsSidebar.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle,
   Input,
   Spinner,
+  Surface,
   Textarea,
 } from "@eva/ui";
 import { IconFile, IconPlus, IconTrash, IconUpload } from "@tabler/icons-react";
@@ -235,7 +236,10 @@ export function DocsSidebar({
       await removeDoc({ id: docToDelete.id });
       setDocToDelete(null);
       if (isViewing) {
-        navigate({ to: `${basePath}/docs`, search: (prev) => prev });
+        navigate({
+          to: `${basePath}/docs`,
+          search: (prev) => prev,
+        });
         if (onNavigate) onNavigate();
       }
     } catch (error) {
@@ -267,12 +271,15 @@ export function DocsSidebar({
             <Spinner size="sm" />
           </div>
         ) : filteredDocs.length === 0 ? (
-          <div className="p-4 text-center">
+          <div className="px-4 py-8 text-center">
             <IconFile
-              size={28}
-              className="mx-auto mb-2 text-muted-foreground"
+              size={20}
+              className="mx-auto mb-2 text-muted-foreground opacity-50"
             />
-            <p className="text-sm text-muted-foreground">No documents yet</p>
+            <p className="text-sm font-medium text-foreground">No documents yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Create one to get started.
+            </p>
           </div>
         ) : (
           <SharedLayoutNav layoutId="docs-nav" className="space-y-1">
@@ -348,7 +355,7 @@ export function DocsSidebar({
           </DialogHeader>
           {showUploadSection ? (
             <div className="space-y-4">
-              <div className="rounded-surface border border-border bg-card p-3">
+              <Surface density="tight">
                 <p className="text-sm font-medium">Upload a file</p>
                 <p className="mb-3 text-sm text-muted-foreground">
                   Supported formats: .md, .txt
@@ -365,7 +372,7 @@ export function DocsSidebar({
                   )}
                   Click to upload
                 </Button>
-              </div>
+              </Surface>
               <div className="space-y-1.5">
                 <label className="text-sm font-medium">Paste PRD content</label>
                 <Textarea

--- a/apps/web/src/lib/components/sidebar/GlobalSessionsSidebar.tsx
+++ b/apps/web/src/lib/components/sidebar/GlobalSessionsSidebar.tsx
@@ -14,6 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  Skeleton,
 } from "@eva/ui";
 import { GlobalSessionGroup } from "@/lib/components/sidebar/_components/GlobalSessionGroup";
 import { SessionsListModeTabs } from "@/lib/components/sidebar/_components/SessionsListModeTabs";
@@ -116,10 +117,7 @@ export function GlobalSessionsSidebar({
             aria-label="Loading sessions"
           >
             {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-9 animate-pulse rounded-md bg-muted/60"
-              />
+              <Skeleton key={i} className="h-9" />
             ))}
           </div>
         ) : orderedRepos.length === 0 ? (

--- a/apps/web/src/lib/components/sidebar/RepoStatsSummary.tsx
+++ b/apps/web/src/lib/components/sidebar/RepoStatsSummary.tsx
@@ -9,7 +9,7 @@ import {
   IconPercentage,
   type Icon as TablerIcon,
 } from "@tabler/icons-react";
-import { Tooltip, TooltipContent, TooltipTrigger, cn } from "@eva/ui";
+import { Skeleton, Tooltip, TooltipContent, TooltipTrigger } from "@eva/ui";
 import { OnlineTeamAvatars } from "@/lib/components/sidebar/TeamMembers";
 
 type RepoDoc = FunctionReturnType<typeof api.githubRepos.getByOwnerAndName>;
@@ -45,23 +45,20 @@ export function RepoStatsSummary({
         aria-busy="true"
         aria-label="Loading stats"
       >
-        <div className="h-8 w-8 animate-pulse rounded-surface bg-muted/60" />
-        <div className="h-8 w-8 animate-pulse rounded-surface bg-muted/60" />
+        <Skeleton className="h-8 w-8" />
+        <Skeleton className="h-8 w-8" />
       </div>
     ) : (
       <div className="flex flex-col gap-2">
+        <Skeleton className="h-8" />
         <div
-          className="h-8 animate-pulse rounded-surface bg-muted/60"
-          aria-hidden
-        />
-        <div
-          className="ui-surface min-h-[4.5rem] animate-pulse p-2.5"
+          className="min-h-[4.5rem] py-1"
           aria-busy="true"
           aria-label="Loading stats"
         >
           <div className="grid grid-cols-2 gap-2">
-            <div className="h-8 rounded bg-muted/60" />
-            <div className="h-8 rounded bg-muted/60" />
+            <Skeleton className="h-8" />
+            <Skeleton className="h-8" />
           </div>
         </div>
       </div>
@@ -110,31 +107,26 @@ export function RepoStatsSummary({
   return (
     <div className="flex flex-col gap-2">
       <OnlineTeamAvatars collapsed={false} />
-      <div className={cn("ui-surface p-2.5")}>
-        <Link
-          to={statsHref}
-          className="block rounded-md transition-colors hover:bg-muted/40 -m-1 p-1"
-        >
-          <div className="grid grid-cols-2 gap-2">
-            {items.map((item) => (
-              <div key={item.label} className="flex items-center gap-1.5">
-                <item.icon
-                  size={15}
-                  className="shrink-0 text-muted-foreground"
-                />
-                <div className="min-w-0">
-                  <p className="text-sm font-semibold leading-none tabular-nums text-sidebar-foreground">
-                    {item.value}
-                  </p>
-                  <p className="mt-0.5 truncate text-[10px] text-muted-foreground">
-                    {item.label}
-                  </p>
-                </div>
+      <Link
+        to={statsHref}
+        className="block rounded-md py-1 transition-colors hover:bg-muted/40"
+      >
+        <div className="grid grid-cols-2 gap-2">
+          {items.map((item) => (
+            <div key={item.label} className="flex items-center gap-1.5">
+              <item.icon size={15} className="shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <p className="text-sm font-semibold leading-none tabular-nums text-sidebar-foreground">
+                  {item.value}
+                </p>
+                <p className="mt-0.5 truncate text-[10px] text-muted-foreground">
+                  {item.label}
+                </p>
               </div>
-            ))}
-          </div>
-        </Link>
-      </div>
+            </div>
+          ))}
+        </div>
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/lib/components/sidebar/session-tabs/SessionChromeTabsBar.tsx
+++ b/apps/web/src/lib/components/sidebar/session-tabs/SessionChromeTabsBar.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@eva/backend";
 import type { FunctionReturnType } from "convex/server";
 import { useMemo, useState } from "react";
+import { Skeleton } from "@eva/ui";
 import { repoMatchesPath } from "@/lib/components/sidebar/_utils/repoSessionPaths";
 import {
   sessionActivityAt,
@@ -158,10 +159,7 @@ export function SessionChromeTabsBar({ pathname }: SessionChromeTabsBarProps) {
               aria-label="Loading session tabs"
             >
               {Array.from({ length: 3 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="h-9 w-52 animate-pulse rounded-t-[0.625rem] bg-muted"
-                />
+                <Skeleton key={i} className="h-9 w-52 rounded-t-[0.625rem]" />
               ))}
             </div>
           ) : orderedRepos.length === 0 ? (

--- a/apps/web/src/lib/components/tasks/_components/CommentThread.tsx
+++ b/apps/web/src/lib/components/tasks/_components/CommentThread.tsx
@@ -2,7 +2,7 @@
 
 import type { Id, api } from "@eva/backend";
 import type { FunctionReturnType } from "convex/server";
-import { Separator, cn } from "@eva/ui";
+import { Separator, Surface, cn } from "@eva/ui";
 import { CommentActivityItem } from "./CommentActivityItem";
 import { CommentReplyComposer } from "./CommentReplyComposer";
 import type { TaskComment } from "../_utils/commentThread";
@@ -69,7 +69,7 @@ export function CommentThread({
 
   if (depth === 0) {
     return (
-      <div className="space-y-3 rounded-surface border border-border bg-card p-3">
+      <Surface density="tight" className="space-y-3">
         <CommentActivityItem
           comment={comment}
           taskId={taskId}
@@ -88,7 +88,7 @@ export function CommentThread({
           <Separator className={cn("mb-3", THREAD_SEPARATOR_CLASS)} />
           <CommentReplyComposer taskId={taskId} parentId={comment._id} />
         </div>
-      </div>
+      </Surface>
     );
   }
 

--- a/apps/web/src/routes/_global/artifacts/ArtifactsGlobalClient.tsx
+++ b/apps/web/src/routes/_global/artifacts/ArtifactsGlobalClient.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@eva/backend";
+import { Skeleton } from "@eva/ui";
 import { PageWrapper } from "@/lib/components/PageWrapper";
 import { ArtifactList } from "@/lib/components/artifacts/ArtifactList";
 import { ArtifactUploadDialog } from "@/lib/components/artifacts/ArtifactUploadDialog";
@@ -27,10 +28,7 @@ export function ArtifactsGlobalClient() {
           aria-label="Loading artifacts"
         >
           {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-32 animate-pulse rounded-surface border border-border bg-muted/60"
-            />
+            <Skeleton key={i} className="h-32 border border-border" />
           ))}
         </div>
       ) : (

--- a/apps/web/src/routes/_global/changelog/ChangelogClient.tsx
+++ b/apps/web/src/routes/_global/changelog/ChangelogClient.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@eva/backend";
-import { cn, STREAMDOWN_TABLE_RADIUS_CLASS } from "@eva/ui";
+import { cn, Skeleton, STREAMDOWN_TABLE_RADIUS_CLASS } from "@eva/ui";
 import { Streamdown } from "streamdown";
 import { cjk } from "@streamdown/cjk";
 import { math } from "@streamdown/math";
@@ -10,6 +10,7 @@ import { mermaid } from "@streamdown/mermaid";
 import { IconSparkles } from "@tabler/icons-react";
 import dayjs from "dayjs";
 import { PageWrapper } from "@/lib/components/PageWrapper";
+import { EmptyState } from "@/lib/components/ui/EmptyState";
 
 /** Same plugin set as `ChangelogDialog`, so both surfaces render identically. */
 const changelogPlugins = { cjk, math, mermaid };
@@ -26,19 +27,15 @@ export function ChangelogClient() {
       {entries === undefined ? (
         <div className="space-y-3">
           {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="h-32 animate-pulse rounded-surface border border-border bg-card"
-            />
+            <Skeleton key={i} className="h-32 border border-border" />
           ))}
         </div>
       ) : entries.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 rounded-surface border border-border bg-card py-16 text-center shadow-sm">
-          <IconSparkles size={20} className="text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">
-            No changelog entries yet.
-          </p>
-        </div>
+        <EmptyState
+          icon={<IconSparkles size={24} />}
+          title="No changelog entries yet"
+          description="Published weekly changelog runs will show up here."
+        />
       ) : (
         // The rail is drawn on the list, not per entry, so it runs unbroken
         // between cards instead of restarting at each one.
@@ -52,7 +49,7 @@ export function ChangelogClient() {
                 )}
                 aria-hidden
               />
-              <article className="rounded-surface border border-border bg-card shadow-sm">
+              <article className="rounded-surface border border-border bg-card">
                 <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
                   <h2 className="text-sm font-semibold">
                     Week of {dayjs(entry.publishedAt).format("MMM D, YYYY")}

--- a/apps/web/src/routes/_global/home/ReposClient.tsx
+++ b/apps/web/src/routes/_global/home/ReposClient.tsx
@@ -17,6 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  Skeleton,
 } from "@eva/ui";
 import {
   IconDots,
@@ -218,13 +219,10 @@ export function ReposClient() {
           aria-busy="true"
           aria-label="Loading repositories"
         >
-          <div className="h-8 w-40 animate-pulse rounded-md bg-muted" />
+          <Skeleton className="h-8 w-40" />
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-28 animate-pulse rounded-surface border border-border bg-muted/60"
-              />
+              <Skeleton key={i} className="h-28 border border-border" />
             ))}
           </div>
         </div>

--- a/apps/web/src/routes/_global/home/_components/HiddenReposSheet.tsx
+++ b/apps/web/src/routes/_global/home/_components/HiddenReposSheet.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
   Button,
+  Surface,
 } from "@eva/ui";
 import { IconEye, IconBrandGithub } from "@tabler/icons-react";
 
@@ -52,9 +53,10 @@ export function HiddenReposSheet({
             </p>
           ) : (
             hiddenRepos.map((repo) => (
-              <div
+              <Surface
                 key={repo._id}
-                className="flex items-center justify-between rounded-surface border border-border bg-card p-3"
+                density="tight"
+                className="flex items-center justify-between"
               >
                 <div className="flex items-center gap-3 min-w-0">
                   <IconBrandGithub
@@ -83,7 +85,7 @@ export function HiddenReposSheet({
                   <IconEye size={16} />
                   Show
                 </Button>
-              </div>
+              </Surface>
             ))
           )}
         </div>

--- a/apps/web/src/routes/_global/setup/_components/MonorepoAppsPanel.tsx
+++ b/apps/web/src/routes/_global/setup/_components/MonorepoAppsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button, Spinner } from "@eva/ui";
+import { Button, Spinner, Surface } from "@eva/ui";
 import { IconCheck, IconFolder } from "@tabler/icons-react";
 
 export interface MonorepoApp {
@@ -52,9 +52,10 @@ export function MonorepoAppsPanel({
       {apps.map((app) => {
         const key = `${repoFullName}:${app.path}`;
         return (
-          <div
+          <Surface
             key={app.path}
-            className="flex items-center justify-between p-2 rounded-surface border border-border bg-card"
+            density="none"
+            className="flex items-center justify-between p-2"
           >
             <div className="flex items-center gap-2 min-w-0">
               <IconFolder className="w-4 h-4 text-muted-foreground flex-shrink-0" />
@@ -83,7 +84,7 @@ export function MonorepoAppsPanel({
                 Add
               </Button>
             )}
-          </div>
+          </Surface>
         );
       })}
       <div className="flex items-center gap-2 pt-2">

--- a/apps/web/src/routes/_repo/$owner/$repo/automations/AutomationClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/automations/AutomationClient.tsx
@@ -16,6 +16,7 @@ import {
   cn,
   ModelSelect,
   toast,
+  Surface,
 } from "@eva/ui";
 import { IconPlayerPlay, IconTrash } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
@@ -103,7 +104,9 @@ export function AutomationClient({
             if (isAutomationTab(v)) {
               const segment = entityPathSegment(automation);
               if (!segment) return;
-              navigate({ to: `${basePath}/automations/${segment}/${v}` });
+              navigate({
+                to: `${basePath}/automations/${segment}/${v}`,
+              });
             }
           }}
         >
@@ -235,7 +238,7 @@ function SettingsForm({
         }}
       />
 
-      <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
+      <Surface density="none" className="p-3 space-y-4 sm:p-4">
         <h3 className="text-sm font-medium">Description</h3>
         <div>
           <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
@@ -268,20 +271,20 @@ function SettingsForm({
             The prompt that will be executed on each run.
           </p>
         </div>
-      </div>
+      </Surface>
 
       {isMonorepo && (
-        <div className="rounded-surface border border-border bg-card p-3 sm:p-4">
+        <Surface density="none" className="p-3 sm:p-4">
           <SettingToggle
             title="Share across apps"
             description="Show and run this automation from every app in the monorepo"
             checked={automation.shared === true}
             onChange={(next) => commit({ contextRepoId: repoId, shared: next })}
           />
-        </div>
+        </Surface>
       )}
 
-      <div className="rounded-surface border border-border bg-card p-3 sm:p-4">
+      <Surface density="none" className="p-3 sm:p-4">
         <SettingToggle
           title="Report Only"
           description="Analyze and report without making code changes, branches, or PRs"
@@ -294,29 +297,29 @@ function SettingsForm({
             )
           }
         />
-      </div>
+      </Surface>
 
       {automation.readOnly === true && (
-        <div className="rounded-surface border border-border bg-card p-3 sm:p-4">
+        <Surface density="none" className="p-3 sm:p-4">
           <SettingToggle
             title="Actions"
             description="Parse findings into actionable items you can convert to tasks"
             checked={automation.actionsEnabled === true}
             onChange={(next) => commit({ actionsEnabled: next })}
           />
-        </div>
+        </Surface>
       )}
 
-      <div className="rounded-surface border border-border bg-card p-3 sm:p-4">
+      <Surface density="none" className="p-3 sm:p-4">
         <SettingToggle
           title="Send email"
           description="Email this automation's run summary to all users when a run succeeds"
           checked={automation.sendEmail === true}
           onChange={(next) => commit({ sendEmail: next })}
         />
-      </div>
+      </Surface>
 
-      <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
+      <Surface density="none" className="p-3 space-y-4 sm:p-4">
         <h3 className="text-sm font-medium">Model</h3>
         <div>
           <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
@@ -328,9 +331,9 @@ function SettingsForm({
             onValueChange={(m) => commit({ model: m })}
           />
         </div>
-      </div>
+      </Surface>
 
-      <div className="rounded-surface border border-border bg-card p-3 space-y-4 sm:p-4">
+      <Surface density="none" className="p-3 space-y-4 sm:p-4">
         <div className="flex items-center justify-between">
           <div>
             <h3 className="text-sm font-medium text-destructive">
@@ -349,7 +352,7 @@ function SettingsForm({
             Delete
           </Button>
         </div>
-      </div>
+      </Surface>
 
       <AutomationDeleteDialog
         automation={

--- a/apps/web/src/routes/_repo/$owner/$repo/automations/_components/RunAccordion.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/automations/_components/RunAccordion.tsx
@@ -10,6 +10,7 @@ import {
   useElapsedSeconds,
   formatElapsed,
   Spinner as UISpinner,
+  Surface,
 } from "@eva/ui";
 import {
   IconAlertTriangle,
@@ -55,12 +56,12 @@ export function LatestRun({
 
   if (!run) {
     return (
-      <div className="rounded-surface border border-border bg-card p-8 text-center">
+      <Surface density="comfortable" className="text-center">
         <p className="text-sm text-muted-foreground">
           No runs yet. Enable the automation and wait for the cron schedule to
           trigger, or click &quot;Run Now&quot;.
         </p>
-      </div>
+      </Surface>
     );
   }
 
@@ -99,12 +100,12 @@ export function RunHistory({
 
   if (runs.length === 0) {
     return (
-      <div className="rounded-surface border border-border bg-card p-8 text-center">
+      <Surface density="comfortable" className="text-center">
         <p className="text-sm text-muted-foreground">
           No runs yet. Enable the automation and wait for the cron schedule to
           trigger, or click &quot;Run Now&quot;.
         </p>
-      </div>
+      </Surface>
     );
   }
 

--- a/apps/web/src/routes/_repo/$owner/$repo/drafts/DraftsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/drafts/DraftsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@eva/backend";
+import { Skeleton } from "@eva/ui";
 import { IconFileText } from "@tabler/icons-react";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { PageWrapper } from "@/lib/components/PageWrapper";
@@ -24,10 +25,7 @@ export function DraftsClient() {
           aria-label="Loading drafts"
         >
           {Array.from({ length: 6 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-28 animate-pulse rounded-surface border border-border bg-muted/60"
-            />
+            <Skeleton key={i} className="h-28 border border-border" />
           ))}
         </div>
       </PageWrapper>

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/QuickTasksClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/QuickTasksClient.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { m, AnimatePresence } from "motion/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@eva/backend";
 import type { Id } from "@eva/backend";
+import { Skeleton } from "@eva/ui";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useRepo } from "@/lib/contexts/RepoContext";
@@ -28,7 +29,6 @@ import {
 } from "./_components/QuickTasksBulkBar";
 import { QuickTasksBulkModals } from "./_components/QuickTasksBulkModals";
 import { useFilteredQuickTasks, useQuickTaskFilters } from "./_utils";
-import { entityPathSegment } from "@/lib/numId";
 import { useAgentTaskByNumId } from "@/lib/useResolveByNumId";
 import { TASK_TAGS } from "@eva/shared";
 
@@ -146,7 +146,7 @@ export function QuickTasksClient() {
   };
 
   const activeFilterLabels = (() => {
-    const labels: Array<{ key: string; label: string }> = [];
+    const labels: Array<{ key: string; label: ReactNode }> = [];
     if (project === "all") {
       labels.push({ key: "project", label: "All Projects" });
     } else if (project !== "none") {
@@ -155,9 +155,14 @@ export function QuickTasksClient() {
     }
     if (user !== "all") {
       const u = users?.find((u) => u._id === user);
+      const name = u?.fullName ?? u?.firstName ?? "User";
       labels.push({
         key: "user",
-        label: `Created by: ${u?.fullName ?? u?.firstName ?? "User"}`,
+        label: (
+          <>
+            Created by: <span data-pii>{name}</span>
+          </>
+        ),
       });
     }
     if (assignee !== "all") {
@@ -167,7 +172,17 @@ export function QuickTasksClient() {
           : (users?.find((u) => u._id === assignee)?.fullName ??
             users?.find((u) => u._id === assignee)?.firstName ??
             "Code Reviewer");
-      labels.push({ key: "assignee", label: `Code reviewer: ${name}` });
+      labels.push({
+        key: "assignee",
+        label:
+          assignee === "unassigned" ? (
+            `Code reviewer: ${name}`
+          ) : (
+            <>
+              Code reviewer: <span data-pii>{name}</span>
+            </>
+          ),
+      });
     }
     if (statuses.length !== TASK_STATUSES.length) {
       labels.push({
@@ -229,15 +244,6 @@ export function QuickTasksClient() {
     });
   };
 
-  const handleOpenTask = (task: { numId?: number }) => {
-    const segment = entityPathSegment(task);
-    if (!segment) return;
-    navigate({
-      to: `${basePath}/quick-tasks/${segment}`,
-      search: (prev) => prev,
-    });
-  };
-
   const closeBulkAction = () => setActiveBulkAction(null);
 
   useHotkey("Alt+N", (e) => {
@@ -282,10 +288,10 @@ export function QuickTasksClient() {
           aria-busy="true"
           aria-label="Loading quick tasks"
         >
-          <div className="h-10 w-full max-w-md animate-pulse rounded-md bg-muted" />
+          <Skeleton className="h-10 w-full max-w-md" />
           <div className="flex flex-1 gap-3">
-            <div className="w-72 shrink-0 animate-pulse rounded-surface border border-border bg-muted/60" />
-            <div className="min-w-0 flex-1 animate-pulse rounded-surface border border-border bg-muted/60" />
+            <Skeleton className="w-72 shrink-0 border border-border" />
+            <Skeleton className="min-w-0 flex-1 border border-border" />
           </div>
         </div>
       </PageWrapper>
@@ -307,10 +313,10 @@ export function QuickTasksClient() {
           aria-busy="true"
           aria-label="Loading task"
         >
-          <div className="h-10 w-full max-w-md animate-pulse rounded-md bg-muted" />
+          <Skeleton className="h-10 w-full max-w-md" />
           <div className="flex flex-1 gap-3">
-            <div className="w-72 shrink-0 animate-pulse rounded-surface border border-border bg-muted/60" />
-            <div className="min-w-0 flex-1 animate-pulse rounded-surface border border-border bg-muted/60" />
+            <Skeleton className="w-72 shrink-0 border border-border" />
+            <Skeleton className="min-w-0 flex-1 border border-border" />
           </div>
         </div>
       </PageWrapper>
@@ -416,10 +422,22 @@ export function QuickTasksClient() {
                       className="text-muted-foreground"
                     />
                   }
-                  title="No quick tasks"
-                  description="Quick tasks are standalone tasks not tied to a feature. Create one for small, one-off work."
-                  actionLabel="Create Quick Task"
-                  onAction={() => setIsCreating(true)}
+                  title={
+                    hasAnyTasks ? "No matching quick tasks" : "No quick tasks"
+                  }
+                  description={
+                    hasAnyTasks
+                      ? "Try clearing filters to see all tasks."
+                      : "Quick tasks are standalone tasks not tied to a feature. Create one for small, one-off work."
+                  }
+                  actionLabel={
+                    hasAnyTasks ? "Clear filters" : "Create Quick Task"
+                  }
+                  onAction={
+                    hasAnyTasks
+                      ? clearAllFilters
+                      : () => setIsCreating(true)
+                  }
                   animate={!hasAnyTasks}
                 />
               </m.div>
@@ -438,7 +456,6 @@ export function QuickTasksClient() {
                   isSelecting={isSelecting}
                   selectedIds={selectedIds}
                   onToggleSelect={toggleSelect}
-                  onOpenTask={handleOpenTask}
                 />
               </m.div>
             ) : (
@@ -456,7 +473,6 @@ export function QuickTasksClient() {
                   isSelecting={isSelecting}
                   selectedIds={selectedIds}
                   onToggleSelect={toggleSelect}
-                  onOpenTask={handleOpenTask}
                   selectedTaskId={selectedTaskId}
                   selectedTaskStatus={
                     numIdParam !== undefined ? taskResolve.status : undefined

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/PersonaSelector.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/PersonaSelector.tsx
@@ -15,6 +15,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Surface,
   Textarea,
 } from "@eva/ui";
 import { IconEdit, IconTrash, IconUsers } from "@tabler/icons-react";
@@ -149,7 +150,7 @@ export function ManagePersonasModal({
   };
 
   const formUI = (
-    <div className="space-y-2 rounded-surface border border-border bg-card p-3">
+    <Surface density="tight" className="space-y-2">
       <Input
         placeholder="Persona name"
         value={formName}
@@ -169,7 +170,7 @@ export function ManagePersonasModal({
           {editingId ? "Save" : "Create"}
         </Button>
       </div>
-    </div>
+    </Surface>
   );
 
   return (

--- a/apps/web/src/routes/_repo/$owner/$repo/stats/StatsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/stats/StatsClient.tsx
@@ -3,6 +3,7 @@ import { useQueryState } from "nuqs";
 import { timeRangeParser } from "@/lib/search-params";
 import { api } from "@eva/backend";
 import { useQuery } from "convex-helpers/react/cache/hooks";
+import { Skeleton } from "@eva/ui";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { PageWrapper } from "@/lib/components/PageWrapper";
 import { Kpi, KpiGroup } from "@/lib/components/analytics/Kpi";
@@ -78,16 +79,13 @@ export function StatsClient() {
           aria-busy="true"
           aria-label="Loading stats"
         >
-          <div className="h-40 animate-pulse rounded-surface border border-border bg-muted/60" />
+          <Skeleton className="h-40 border border-border" />
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 3 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-24 animate-pulse rounded-surface border border-border bg-muted/60"
-              />
+              <Skeleton key={i} className="h-24 border border-border" />
             ))}
           </div>
-          <div className="h-56 animate-pulse rounded-surface border border-border bg-muted/60" />
+          <Skeleton className="h-56 border border-border" />
         </div>
       ) : (
         <div className="space-y-6">
@@ -104,7 +102,7 @@ export function StatsClient() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.3, delay: 0.1 }}
           >
-            <KpiGroup>
+            <KpiGroup className="lg:grid-cols-3">
               <Kpi
                 icon={IconGitPullRequest}
                 label="PRs Shipped"


### PR DESCRIPTION
## Summary
- `#540` already shipped the `Surface` / `Skeleton` / `ListRow` primitives.
- This adopts them across loading skeletons, bordered panels, and project/quick-task cards (ListRow replaces card+`shadow-sm`).

## Notes
- Slash-URL (`toInternalRepoHref`) helpers stripped so this lands without the monorepo rewrite.
- Some `data-pii` attrs ride along on cards; blur-PID toggle ships in a follow-up.

## Test plan
- [ ] Home / teams / drafts / stats / changelog / artifacts show Skeleton loading states
- [ ] Automations / docs / PR recap panels use Surface borders (no soft card shadow)
- [ ] Project + quick-task cards use ListRow interaction chrome