### PR TITLE
fix(ui): strip remaining card/surface shadow-sm

### DIFF
--- a/apps/web/src/lib/components/Widget.tsx
+++ b/apps/web/src/lib/components/Widget.tsx
@@ -38,7 +38,7 @@ export function Widget({
   return (
     <div
       className={cn(
-        "flex h-full flex-col rounded-surface border border-border bg-muted/50 p-1.5 shadow-sm",
+        "flex h-full flex-col rounded-surface border border-border bg-muted/50 p-1.5",
         className,
       )}
     >
@@ -59,7 +59,7 @@ export function Widget({
       )}
       <div
         className={cn(
-          "min-h-0 flex-1 rounded-surface border border-border bg-card p-4 shadow-sm",
+          "min-h-0 flex-1 rounded-surface border border-border bg-card p-4",
           contentClassName,
         )}
       >

--- a/apps/web/src/lib/components/artifacts/ArtifactCard.tsx
+++ b/apps/web/src/lib/components/artifacts/ArtifactCard.tsx
@@ -48,7 +48,7 @@ export function ArtifactCard({ artifact }: { artifact: ArtifactRow }) {
           <Link
             to="/artifacts/$artifactId"
             params={{ artifactId: artifact._id }}
-            className="flex flex-col gap-2 rounded-surface border border-border bg-card p-4 shadow-sm transition-colors hover:bg-muted"
+            className="flex flex-col gap-2 rounded-surface border border-border bg-card p-4 transition-colors hover:bg-muted"
           >
             <div className="flex items-center gap-2">
               <IconLayoutDashboard

--- a/apps/web/src/lib/components/artifacts/ArtifactViewer.tsx
+++ b/apps/web/src/lib/components/artifacts/ArtifactViewer.tsx
@@ -92,7 +92,7 @@ export function ArtifactViewer({ artifactId }: { artifactId: string }) {
           Open in new tab
         </button>
       </div>
-      <div className="min-h-0 w-full flex-1 overflow-hidden rounded-surface border border-border bg-white shadow-sm">
+      <div className="min-h-0 w-full flex-1 overflow-hidden rounded-surface border border-border bg-white">
         {url ? (
           <Suspense
             fallback={

--- a/apps/web/src/lib/components/attachments/AttachmentCard.tsx
+++ b/apps/web/src/lib/components/attachments/AttachmentCard.tsx
@@ -71,7 +71,7 @@ export function AttachmentCard({
             event.stopPropagation();
             onRemove();
           }}
-          className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground opacity-0 shadow-sm transition-opacity hover:bg-background focus:opacity-100 group-hover:opacity-100"
+          className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground opacity-0 transition-opacity hover:bg-background focus:opacity-100 group-hover:opacity-100"
         >
           <IconX className="size-3" />
         </button>

--- a/apps/web/src/lib/components/chat/BackgroundAgentsChip.tsx
+++ b/apps/web/src/lib/components/chat/BackgroundAgentsChip.tsx
@@ -68,7 +68,7 @@ export function BackgroundAgentsChip({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-border bg-secondary px-2.5 py-1 text-xs text-foreground shadow-sm hover:bg-muted"
+          className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-border bg-secondary px-2.5 py-1 text-xs text-foreground hover:bg-muted"
         >
           <IconRobot className="size-3.5 shrink-0 text-muted-foreground" />
           <span>{label}</span>

--- a/apps/web/src/lib/components/chat/imageAttachments.tsx
+++ b/apps/web/src/lib/components/chat/imageAttachments.tsx
@@ -100,7 +100,7 @@ export function ChatAttachmentPreview() {
                     type="button"
                     aria-label="Remove attachment"
                     onClick={() => attachments.remove(file.id)}
-                    className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground shadow-sm opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 hover:bg-background"
+                    className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 hover:bg-background"
                   >
                     <IconX className="size-3" />
                   </button>
@@ -147,7 +147,7 @@ export function ChatAttachmentPreview() {
                   type="button"
                   aria-label="Remove attachment"
                   onClick={() => attachments.remove(file.id)}
-                  className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground shadow-sm opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 hover:bg-background"
+                  className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 hover:bg-background"
                 >
                   <IconX className="size-3" />
                 </button>

--- a/apps/web/src/lib/components/inbox/InboxClient.tsx
+++ b/apps/web/src/lib/components/inbox/InboxClient.tsx
@@ -147,7 +147,7 @@ export function InboxClient() {
     >
       {filtered === undefined ? (
         <div
-          className="min-h-[20rem] space-y-2 rounded-surface border border-border bg-card p-4 shadow-sm"
+          className="min-h-[20rem] space-y-2 rounded-surface border border-border bg-card p-4"
           aria-busy="true"
           aria-label="Loading inbox"
         >
@@ -173,7 +173,7 @@ export function InboxClient() {
           />
         </div>
       ) : (
-        <div className="overflow-hidden rounded-surface border border-border bg-card shadow-sm">
+        <div className="overflow-hidden rounded-surface border border-border bg-card">
           <AnimatePresence initial={false}>
             {groups.map((group) => (
               <m.div

--- a/apps/web/src/lib/components/inbox/InboxFilterTabs.tsx
+++ b/apps/web/src/lib/components/inbox/InboxFilterTabs.tsx
@@ -37,7 +37,7 @@ export function InboxFilterTabs({
               // Inactive keeps a transparent border so selecting does not shift layout.
               "flex items-center gap-1.5 rounded-control border px-2.5 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35",
               isActive
-                ? "border-border bg-card font-medium text-foreground shadow-sm"
+                ? "border-border bg-card font-medium text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",
             )}
           >

--- a/apps/web/src/lib/components/inbox/NotificationRow.tsx
+++ b/apps/web/src/lib/components/inbox/NotificationRow.tsx
@@ -42,7 +42,7 @@ function NotificationSourceAvatar({
         }
       />
       <span
-        className="absolute -bottom-1 -right-1 flex size-4 items-center justify-center rounded-md border border-border bg-card shadow-sm"
+        className="absolute -bottom-1 -right-1 flex size-4 items-center justify-center rounded-md border border-border bg-card"
         aria-hidden
       >
         <TypeIcon size={11} className={appearance.iconColor} />

--- a/apps/web/src/lib/components/projects/ProjectCard.tsx
+++ b/apps/web/src/lib/components/projects/ProjectCard.tsx
@@ -161,7 +161,7 @@ export function ProjectCard({
       className={`group relative shrink-0 overflow-hidden rounded-surface border transition-[transform,background-color] duration-200 ease-[var(--motion-ease-out)] ${
         isActive
           ? "border-primary/30 bg-primary/5 ring-1 ring-primary/30"
-          : "border-border bg-card shadow-sm hover:bg-muted/40"
+          : "border-border bg-card hover:bg-muted/40"
       }`}
     >
       <div className="pointer-events-none absolute -right-8 -top-10 h-24 w-24 rounded-full bg-primary/10 blur-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100" />

--- a/apps/web/src/lib/components/projects/_components/UnscheduledProjectsSection.tsx
+++ b/apps/web/src/lib/components/projects/_components/UnscheduledProjectsSection.tsx
@@ -29,7 +29,7 @@ export function UnscheduledProjectsSection({
   if (projects.length === 0) return null;
 
   return (
-    <details className="group shrink-0 rounded-surface border border-border bg-card shadow-sm">
+    <details className="group shrink-0 rounded-surface border border-border bg-card">
       <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs font-medium text-muted-foreground">
         <IconChevronRight
           size={14}

--- a/apps/web/src/lib/components/sandbox/DiffCommentBox.tsx
+++ b/apps/web/src/lib/components/sandbox/DiffCommentBox.tsx
@@ -19,7 +19,7 @@ export function DiffCommentDraftBox({
 
   return (
     <div
-      className="mx-2 my-2 rounded-lg border border-border bg-card p-3 shadow-sm"
+      className="mx-2 my-2 rounded-lg border border-border bg-card p-3"
       contentEditable={false}
       onPointerDown={(event) => event.stopPropagation()}
     >
@@ -81,7 +81,7 @@ export function DiffCommentPendingCard({
 }: DiffCommentPendingCardProps) {
   return (
     <div
-      className="mx-2 my-2 rounded-lg border border-border bg-card p-3 shadow-sm"
+      className="mx-2 my-2 rounded-lg border border-border bg-card p-3"
       contentEditable={false}
       onPointerDown={(event) => event.stopPropagation()}
     >

--- a/apps/web/src/lib/components/sandbox/DiffFileAccordionItem.tsx
+++ b/apps/web/src/lib/components/sandbox/DiffFileAccordionItem.tsx
@@ -133,7 +133,7 @@ export function DiffFileAccordionItem({
     // final card still has a full hairline outline.
     <AccordionItem
       value={path}
-      className="rounded-md border border-border bg-card shadow-sm last:border-b"
+      className="rounded-md border border-border bg-card last:border-b"
     >
       <div className="sticky top-0 z-10 flex items-center gap-2 rounded-t-md border-b border-border bg-muted/95 px-2 backdrop-blur">
         <AccordionTrigger className="min-w-0 flex-1 py-2 hover:no-underline">

--- a/apps/web/src/lib/components/sidebar/RepoRail.tsx
+++ b/apps/web/src/lib/components/sidebar/RepoRail.tsx
@@ -169,7 +169,7 @@ function RepoRailView({
                   : "border-transparent opacity-75 hover:bg-sidebar-accent/50 hover:opacity-100",
               )}
             >
-              <span className="flex size-8 items-center justify-center rounded-full bg-white shadow-sm">
+              <span className="flex size-8 items-center justify-center rounded-full bg-white">
                 <LogoMark size={20} className="shrink-0" />
               </span>
             </Link>

--- a/apps/web/src/lib/components/tasks/_components/task-detail-constants.ts
+++ b/apps/web/src/lib/components/tasks/_components/task-detail-constants.ts
@@ -61,4 +61,4 @@ export const TASK_DETAIL_TAB_LIST_CLASS =
   "sticky top-0 z-10 h-auto w-fit gap-0.5 border border-border p-1 shadow-none tabs-segmented";
 
 export const TASK_DETAIL_TAB_TRIGGER_CLASS =
-  "gap-1 px-3 py-1.5 text-xs font-medium sm:gap-1.5 sm:text-sm transition-[color,background-color] data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=inactive]:bg-transparent data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:bg-muted data-[state=inactive]:hover:text-foreground";
+  "gap-1 px-3 py-1.5 text-xs font-medium sm:gap-1.5 sm:text-sm transition-[color,background-color] data-[state=active]:text-foreground data-[state=inactive]:bg-transparent data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:bg-muted data-[state=inactive]:hover:text-foreground";

--- a/apps/web/src/routes/_components/landing/LandingHero.tsx
+++ b/apps/web/src/routes/_components/landing/LandingHero.tsx
@@ -60,7 +60,7 @@ export function LandingHero() {
             href={EVA_GITHUB_URL}
             target="_blank"
             rel="noreferrer"
-            className="motion-base inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-xs text-muted-foreground shadow-sm hover:bg-muted/60 hover:text-foreground"
+            className="motion-base inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
           >
             <span className="landing-pulse-dot size-1.5 rounded-full bg-primary" />
             Open source and MIT licensed

--- a/apps/web/src/routes/_components/landing/LandingMcp.tsx
+++ b/apps/web/src/routes/_components/landing/LandingMcp.tsx
@@ -72,7 +72,7 @@ export function LandingMcp() {
           })}
         </LandingLattice>
 
-        <div className="mt-4 flex items-start gap-4 rounded-surface border border-border bg-card p-6 shadow-sm">
+        <div className="mt-4 flex items-start gap-4 rounded-surface border border-border bg-card p-6">
           <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-background">
             <IconBrowser size={17} className="text-primary" aria-hidden />
           </div>
@@ -97,7 +97,7 @@ function McpCallPanel() {
   const prefersReducedMotion = useReducedMotion();
 
   return (
-    <div className="overflow-hidden rounded-surface border border-border bg-card shadow-sm">
+    <div className="overflow-hidden rounded-surface border border-border bg-card">
       <div className="flex items-center gap-2 border-b border-border bg-muted/40 px-4 py-2.5">
         <p className="font-mono text-[11px] text-muted-foreground">
           Claude Desktop

--- a/apps/web/src/routes/_components/landing/LandingSandbox.tsx
+++ b/apps/web/src/routes/_components/landing/LandingSandbox.tsx
@@ -93,7 +93,7 @@ function SandboxTerminal() {
   const prefersReducedMotion = useReducedMotion();
 
   return (
-    <div className="overflow-hidden rounded-surface border border-border bg-card shadow-sm">
+    <div className="overflow-hidden rounded-surface border border-border bg-card">
       <div className="flex items-center gap-2.5 border-b border-border px-4 py-2.5">
         <span className="flex gap-1.5" aria-hidden>
           <span className="size-2 rounded-full bg-border" />

--- a/apps/web/src/routes/_components/landing/previews/MockParts.tsx
+++ b/apps/web/src/routes/_components/landing/previews/MockParts.tsx
@@ -23,7 +23,7 @@ export function MockWindow({
   bodyClassName?: string;
 }) {
   return (
-    <div className="overflow-hidden rounded-surface border border-border bg-card shadow-sm">
+    <div className="overflow-hidden rounded-surface border border-border bg-card">
       <div className="flex items-center gap-2.5 border-b border-border bg-muted/40 px-3.5 py-2.5">
         <span className="flex gap-1.5" aria-hidden>
           <span className="size-2 rounded-full bg-border" />

--- a/apps/web/src/routes/_components/landing/previews/PlanPreviews.tsx
+++ b/apps/web/src/routes/_components/landing/previews/PlanPreviews.tsx
@@ -109,7 +109,7 @@ export function ProjectsPreview() {
             {column.cards.map((card) => (
               <div
                 key={card.title}
-                className="space-y-2 rounded-md border border-border bg-card p-2 shadow-sm"
+                className="space-y-2 rounded-md border border-border bg-card p-2"
               >
                 <p className="text-[11px] font-medium leading-tight text-foreground">
                   {card.title}

--- a/apps/web/src/routes/_components/landing/previews/VerifyPreviews.tsx
+++ b/apps/web/src/routes/_components/landing/previews/VerifyPreviews.tsx
@@ -266,7 +266,7 @@ export function ProofPreview() {
         </div>
 
         <span className="absolute inset-0 flex items-center justify-center">
-          <span className="flex size-9 items-center justify-center rounded-full border border-border bg-card/90 shadow-sm backdrop-blur-sm">
+          <span className="flex size-9 items-center justify-center rounded-full border border-border bg-card/90 backdrop-blur-sm">
             <IconPlayerPlayFilled
               size={13}
               className="translate-x-px text-foreground"

--- a/apps/web/src/routes/_global/changelog/ChangelogClient.tsx
+++ b/apps/web/src/routes/_global/changelog/ChangelogClient.tsx
@@ -33,7 +33,7 @@ export function ChangelogClient() {
           ))}
         </div>
       ) : entries.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 rounded-surface border border-border bg-card py-16 text-center shadow-sm">
+        <div className="flex flex-col items-center gap-2 rounded-surface border border-border bg-card py-16 text-center">
           <IconSparkles size={20} className="text-muted-foreground" />
           <p className="text-sm text-muted-foreground">
             No changelog entries yet.
@@ -52,7 +52,7 @@ export function ChangelogClient() {
                 )}
                 aria-hidden
               />
-              <article className="rounded-surface border border-border bg-card shadow-sm">
+              <article className="rounded-surface border border-border bg-card">
                 <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
                   <h2 className="text-sm font-semibold">
                     Week of {dayjs(entry.publishedAt).format("MMM D, YYYY")}

--- a/apps/web/src/routes/_global/teams/TeamDetailClient.tsx
+++ b/apps/web/src/routes/_global/teams/TeamDetailClient.tsx
@@ -129,7 +129,7 @@ export function TeamDetailClient({
         </div>
       }
     >
-      <div className="mb-4 overflow-hidden rounded-lg border border-border bg-card shadow-sm">
+      <div className="mb-4 overflow-hidden rounded-lg border border-border bg-card">
         <div className="relative h-28 w-full bg-muted">
           {team.backgroundUrl ? (
             <img

--- a/apps/web/src/routes/_repo/$owner/$repo/drafts/_components/DraftCard.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/drafts/_components/DraftCard.tsx
@@ -190,7 +190,7 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
             if (e.key === "Enter" || e.key === " ") handleClick();
           }}
           className={cn(
-            "flex h-full cursor-pointer flex-col gap-2 rounded-surface border border-border bg-card p-4 shadow-sm",
+            "flex h-full cursor-pointer flex-col gap-2 rounded-surface border border-border bg-card p-4",
             "hover:bg-muted/40 transition-colors duration-100",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           )}

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/DesktopPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/DesktopPanel.tsx
@@ -156,7 +156,7 @@ export function DesktopPanel({
           onClick={handleTakeControl}
           className="absolute inset-0 z-10 flex cursor-pointer flex-col items-center justify-center gap-2 bg-background/55 px-4 text-center backdrop-blur-[1px]"
         >
-          <span className="rounded-md border border-border bg-card px-3 py-2 text-sm shadow-sm">
+          <span className="rounded-md border border-border bg-card px-3 py-2 text-sm">
             Agent is browsing — click to take control
           </span>
         </button>

--- a/packages/ui/src/ai-elements/conversation.tsx
+++ b/packages/ui/src/ai-elements/conversation.tsx
@@ -136,7 +136,7 @@ export const ConversationScrollButton = ({
     <div className="pointer-events-none absolute bottom-4 left-1/2 z-30 flex -translate-x-1/2 justify-center">
       <Button
         className={cn(
-          "pointer-events-auto h-7 gap-1.5 rounded-full border border-border/60 bg-card px-3 text-xs font-normal text-muted-foreground shadow-sm hover:border-border hover:bg-card hover:text-foreground",
+          "pointer-events-auto h-7 gap-1.5 rounded-full border border-border/60 bg-card px-3 text-xs font-normal text-muted-foreground hover:border-border hover:bg-card hover:text-foreground",
           className,
         )}
         onClick={handleScrollToEnd}

--- a/packages/ui/src/kibo/gantt-features.tsx
+++ b/packages/ui/src/kibo/gantt-features.tsx
@@ -101,7 +101,7 @@ export const GanttFeatureItemCard: FC<GanttFeatureItemCardProps> = ({
     <div
       data-gantt-no-pan
       className={cn(
-        "relative h-full w-full overflow-hidden border border-border/70 text-xs shadow-sm transition-shadow hover:shadow",
+        "relative h-full w-full overflow-hidden border border-border/70 text-xs transition-shadow",
         CONTROL_RADIUS_CLASS,
         className,
       )}
@@ -231,7 +231,7 @@ export const GanttFeatureItem: FC<GanttFeatureItemProps> = ({
     ? `${dayjs(startAt).format("MMM D")} – ${dayjs(endAt).format("MMM D")}`
     : dayjs(startAt).format("MMM D");
   const indicatorClass =
-    "absolute top-1/2 z-[4] flex -translate-y-1/2 items-center gap-1 whitespace-nowrap rounded-control border border-border bg-background/95 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground";
+    "absolute top-1/2 z-[4] flex -translate-y-1/2 items-center gap-1 whitespace-nowrap rounded-control border border-border bg-background/95 px-2 py-0.5 text-[10px] font-medium text-muted-foreground backdrop-blur transition-colors hover:text-foreground";
 
   return (
     <div

--- a/packages/ui/src/kibo/gantt-provider.tsx
+++ b/packages/ui/src/kibo/gantt-provider.tsx
@@ -574,7 +574,7 @@ export const GanttProvider: FC<GanttProviderProps> = ({
     >
       <div
         className={cn(
-          "gantt relative isolate grid h-full w-full flex-none select-none overflow-auto scrollbar-none rounded-surface border border-border bg-card shadow-sm",
+          "gantt relative isolate grid h-full w-full flex-none select-none overflow-auto scrollbar-none rounded-surface border border-border bg-card",
           range,
           className,
         )}

--- a/packages/ui/src/kibo/gantt-timeline.tsx
+++ b/packages/ui/src/kibo/gantt-timeline.tsx
@@ -126,7 +126,7 @@ export const GanttToday: FC<GanttTodayProps> = ({ className }) => {
     >
       <div
         className={cn(
-          "group pointer-events-auto sticky top-0 z-[1] flex select-auto flex-col flex-nowrap items-center justify-center whitespace-nowrap rounded-b-md bg-primary px-2 py-0.5 text-[10px] font-medium text-primary-foreground shadow-sm",
+          "group pointer-events-auto sticky top-0 z-[1] flex select-auto flex-col flex-nowrap items-center justify-center whitespace-nowrap rounded-b-md bg-primary px-2 py-0.5 text-[10px] font-medium text-primary-foreground",
           className,
         )}
       >

--- a/packages/ui/src/ui/tabs.tsx
+++ b/packages/ui/src/ui/tabs.tsx
@@ -83,7 +83,7 @@ const TabsList = React.forwardRef<
     >
       <span
         ref={pillRef}
-        className="t-tabs-pill rounded-lg bg-card shadow-sm"
+        className="t-tabs-pill rounded-lg bg-card"
         aria-hidden="true"
       />
       {children}


### PR DESCRIPTION
## Summary
- Remove leftover `shadow-sm` from cards, chips, landing mocks, gantt panels, inbox, widgets, etc.
- Overlays (dialogs/popovers/menus/`shadow-lg|xl`) unchanged.
- Switch thumb keeps `shadow-sm` (control affordance).

## Test plan
- [ ] Cards/panels use border only (artifacts, inbox, drafts, changelog, landing mocks)
- [ ] Dialogs/menus still elevate with shadow