### PR TITLE
feat: blur-PID toggle + data-pii annotations

### DIFF
--- a/apps/web/src/lib/components/BlurPidEffect.tsx
+++ b/apps/web/src/lib/components/BlurPidEffect.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@eva/backend";
+
+/**
+ * Mirrors the user's blur-PID preference onto `<html data-blur-pid>`.
+ *
+ * A single global CSS rule in globals.css blurs every `[data-pii]` element under
+ * that attribute, so the preference reaches names and emails rendered inside
+ * portals (tooltips, popovers, hover cards) without threading a prop through
+ * every call site. Renders nothing.
+ */
+export function BlurPidEffect() {
+  const enabled = useQuery(api.auth.getBlurPidEnabled);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (enabled === true) {
+      root.setAttribute("data-blur-pid", "");
+    } else {
+      root.removeAttribute("data-blur-pid");
+    }
+  }, [enabled]);
+
+  return null;
+}

--- a/apps/web/src/lib/components/ClientProvider.tsx
+++ b/apps/web/src/lib/components/ClientProvider.tsx
@@ -13,6 +13,7 @@ import usePresence from "@convex-dev/presence/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { useAuth } from "@clerk/clerk-react";
 import { ConvexQueryCacheProvider } from "convex-helpers/react/cache/provider";
+import { BlurPidEffect } from "@/lib/components/BlurPidEffect";
 import { FaviconController } from "@/lib/components/FaviconController";
 import { ThemeModeProvider } from "@/lib/components/ThemeModeProvider";
 import { useEffect, useRef, useState } from "react";
@@ -146,6 +147,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
         <ThemeProvider>
           <TooltipProvider delayDuration={300}>
             {children}
+            <BlurPidEffect />
             <PresenceHeartbeat />
             <WelcomeSetupDialog />
           </TooltipProvider>

--- a/apps/web/src/lib/components/FollowOverlay.tsx
+++ b/apps/web/src/lib/components/FollowOverlay.tsx
@@ -86,7 +86,9 @@ function FollowOverlayInner({
 
       <div className="fixed top-3 left-1/2 z-[60] -translate-x-1/2">
         <div className="flex items-center gap-2 rounded-full bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground shadow-lg">
-          <span>Following {name}</span>
+          <span>
+            Following <span data-pii>{name}</span>
+          </span>
           <Button
             size="icon"
             variant="ghost"

--- a/apps/web/src/lib/components/LiveCursors.tsx
+++ b/apps/web/src/lib/components/LiveCursors.tsx
@@ -36,7 +36,7 @@ function RemoteCursorItem({ cursor }: { cursor: RemoteCursor }) {
       <Cursor style={{ color: hex }}>
         <CursorPointer />
         <CursorBody className="text-white" style={{ backgroundColor: hex }}>
-          <CursorName>{cursor.firstName}</CursorName>
+          <CursorName data-pii>{cursor.firstName}</CursorName>
         </CursorBody>
       </Cursor>
     </div>

--- a/apps/web/src/lib/components/analytics/Leaderboard.tsx
+++ b/apps/web/src/lib/components/analytics/Leaderboard.tsx
@@ -49,7 +49,7 @@ export function Leaderboard({ entries }: LeaderboardProps) {
                   </span>
                   <div className="min-w-0 flex-1">
                     <MarqueeOnHover className="text-sm font-medium text-foreground">
-                      {entry.fullName || "Unknown User"}
+                      <span data-pii>{entry.fullName || "Unknown User"}</span>
                     </MarqueeOnHover>
                     <p className="text-xs text-muted-foreground">
                       {entry.prsCreated} PRs · {entry.tasksCompleted} tasks

--- a/apps/web/src/lib/components/chat/ChatMessage.tsx
+++ b/apps/web/src/lib/components/chat/ChatMessage.tsx
@@ -183,7 +183,10 @@ export const ChatMessage = memo(function ChatMessage({
           }
         >
           {isOtherUser && senderFirstName ? (
-            <span className="px-1 text-[11px] font-medium text-muted-foreground">
+            <span
+              data-pii
+              className="px-1 text-[11px] font-medium text-muted-foreground"
+            >
               {senderFirstName}
             </span>
           ) : null}

--- a/apps/web/src/lib/components/chat/TypingIndicator.tsx
+++ b/apps/web/src/lib/components/chat/TypingIndicator.tsx
@@ -1,16 +1,32 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { cn } from "@eva/ui";
 import type { TypingUser } from "@/lib/hooks/useTypingPresence";
 
-function typingLabel(users: TypingUser[]): string {
+function typingLabel(users: TypingUser[]): ReactNode {
   const names = users.map((user) => user.firstName);
   // Defaults guard against an empty array for the type checker; in practice the
   // indicator is only rendered with at least one user.
   const [first = "Someone", second = "Someone"] = names;
-  if (names.length === 1) return `${first} is typing`;
-  if (names.length === 2) return `${first} and ${second} are typing`;
-  return `${first} and ${names.length - 1} others are typing`;
+  if (names.length === 1)
+    return (
+      <>
+        <span data-pii>{first}</span> is typing
+      </>
+    );
+  if (names.length === 2)
+    return (
+      <>
+        <span data-pii>{first}</span> and <span data-pii>{second}</span> are
+        typing
+      </>
+    );
+  return (
+    <>
+      <span data-pii>{first}</span> and {names.length - 1} others are typing
+    </>
+  );
 }
 
 function TypingAvatar({ firstName }: { firstName: string }) {

--- a/apps/web/src/lib/components/docs/_components/DocCommentThread.tsx
+++ b/apps/web/src/lib/components/docs/_components/DocCommentThread.tsx
@@ -202,7 +202,9 @@ function DocCommentItem({ comment }: { comment: DocComment }) {
         {comment.authorId ? (
           <UserInitials userId={comment.authorId} size="sm" />
         ) : null}
-        <span className="font-medium text-xs">{name}</span>
+        <span data-pii className="font-medium text-xs">
+          {name}
+        </span>
         <RelativeDateTime
           at={comment.createdAt}
           className="text-[10px] text-muted-foreground"

--- a/apps/web/src/lib/components/projects/ProjectMetadataBar.tsx
+++ b/apps/web/src/lib/components/projects/ProjectMetadataBar.tsx
@@ -209,7 +209,7 @@ export function ProjectMetadataBar({ projectId }: ProjectMetadataBarProps) {
               className={`flex items-center gap-1.5 ${!project.projectLead ? "text-muted-foreground" : ""}`}
             >
               <IconUser size={14} className="text-muted-foreground" />
-              <span>
+              <span data-pii={Boolean(project.projectLead) || undefined}>
                 {project.projectLead
                   ? (() => {
                       const lead = (users ?? []).find(
@@ -227,7 +227,7 @@ export function ProjectMetadataBar({ projectId }: ProjectMetadataBarProps) {
             <SelectLabel>Project Lead</SelectLabel>
             <SelectItem value="none">Unassigned</SelectItem>
             {(users ?? []).map((user) => (
-              <SelectItem key={user._id} value={user._id}>
+              <SelectItem data-pii key={user._id} value={user._id}>
                 {displayName(user)}
               </SelectItem>
             ))}
@@ -261,7 +261,7 @@ export function ProjectMetadataBar({ projectId }: ProjectMetadataBarProps) {
               ) : (
                 <IconUserPlus size={14} className="text-muted-foreground" />
               )}
-              <span>
+              <span data-pii={Boolean(reviewerUser) || undefined}>
                 {reviewerUser ? displayName(reviewerUser) : "Code Reviewer"}
               </span>
             </div>
@@ -279,7 +279,7 @@ export function ProjectMetadataBar({ projectId }: ProjectMetadataBarProps) {
                     name={getUserInitials(user)}
                     enableBlink
                   />
-                  <span>{displayName(user)}</span>
+                  <span data-pii>{displayName(user)}</span>
                 </div>
               </SelectItem>
             ))}
@@ -307,6 +307,7 @@ export function ProjectMetadataBar({ projectId }: ProjectMetadataBarProps) {
               const isMember = memberIds.has(user._id);
               return (
                 <DropdownMenuCheckboxItem
+                  data-pii
                   key={user._id}
                   checked={isMember}
                   onCheckedChange={() => {
@@ -399,7 +400,7 @@ export function ProjectMetadataBar({ projectId }: ProjectMetadataBarProps) {
         {creator ? (
           <>
             <UserInitials userId={creator._id} size="sm" />
-            <span>{displayName(creator)}</span>
+            <span data-pii>{displayName(creator)}</span>
             <span>·</span>
           </>
         ) : null}

--- a/apps/web/src/lib/components/quick-tasks/AssignTasksModal.tsx
+++ b/apps/web/src/lib/components/quick-tasks/AssignTasksModal.tsx
@@ -118,7 +118,7 @@ export function AssignTasksModal({
           {mode === "me" ? (
             <DialogDescription>
               {count} task{count === 1 ? "" : "s"} will be assigned to{" "}
-              {currentUserName}.
+              <span data-pii>{currentUserName}</span>.
             </DialogDescription>
           ) : (
             <DialogDescription>
@@ -134,7 +134,7 @@ export function AssignTasksModal({
             <SelectContent>
               {(users ?? []).map((user) => (
                 <SelectItem key={user._id} value={user._id}>
-                  {getUserLabel(user)}
+                  <span data-pii>{getUserLabel(user)}</span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/apps/web/src/lib/components/quick-tasks/_components/AssigneeSelector.tsx
+++ b/apps/web/src/lib/components/quick-tasks/_components/AssigneeSelector.tsx
@@ -45,7 +45,7 @@ export function AssigneeSelector({
           {assignedUser ? (
             <>
               <UserInitials user={assignedUser} size="sm" hideLastSeen />
-              <span className="text-foreground">
+              <span data-pii className="text-foreground">
                 {getUserDisplayName(assignedUser)}
               </span>
             </>
@@ -82,7 +82,7 @@ export function AssigneeSelector({
                     name={getUserInitials(user)}
                     enableBlink
                   />
-                  {getUserDisplayName(user)}
+                  <span data-pii>{getUserDisplayName(user)}</span>
                   {assignedTo === user._id && (
                     <IconCheck size={14} className="ml-auto" />
                   )}

--- a/apps/web/src/lib/components/quick-tasks/_components/TaskCardMenuItems.tsx
+++ b/apps/web/src/lib/components/quick-tasks/_components/TaskCardMenuItems.tsx
@@ -258,7 +258,9 @@ export function TaskCardMenuItems({
               user.role === "dev"
                 ? [
                     <RadioItem key={user._id} value={user._id}>
-                      {user.fullName ?? user.firstName ?? "Unknown"}
+                      <span data-pii>
+                        {user.fullName ?? user.firstName ?? "Unknown"}
+                      </span>
                     </RadioItem>,
                   ]
                 : [],

--- a/apps/web/src/lib/components/settings/ExperimentalSettingsClient.tsx
+++ b/apps/web/src/lib/components/settings/ExperimentalSettingsClient.tsx
@@ -19,6 +19,13 @@ export function ExperimentalSettingsClient() {
     );
   });
 
+  const blurPid = useQuery(api.auth.getBlurPidEnabled);
+  const setBlurPid = useMutation(
+    api.auth.setBlurPidEnabled,
+  ).withOptimisticUpdate((localStore, args) => {
+    localStore.setQuery(api.auth.getBlurPidEnabled, {}, args.enabled);
+  });
+
   const voiceDictation = useQuery(api.auth.getVoiceDictationEnabled);
   const setVoiceDictation = useMutation(
     api.auth.setVoiceDictationEnabled,
@@ -26,7 +33,11 @@ export function ExperimentalSettingsClient() {
     localStore.setQuery(api.auth.getVoiceDictationEnabled, {}, args.enabled);
   });
 
-  if (enabled === undefined || voiceDictation === undefined) {
+  if (
+    enabled === undefined ||
+    blurPid === undefined ||
+    voiceDictation === undefined
+  ) {
     return (
       <SettingsPage title="Experimental">
         <div className="flex items-center justify-center py-12">
@@ -52,6 +63,17 @@ export function ExperimentalSettingsClient() {
                 checked={enabled}
                 onCheckedChange={(checked) => setEnabled({ enabled: checked })}
                 aria-label="Chrome-style session tabs"
+              />
+            }
+          />
+          <SettingsToggleRow
+            title="Blur personal info"
+            description="Blur names and emails when screen recording. Avatars stay visible."
+            action={
+              <Switch
+                checked={blurPid}
+                onCheckedChange={(checked) => setBlurPid({ enabled: checked })}
+                aria-label="Blur personal info"
               />
             }
           />

--- a/apps/web/src/lib/components/sidebar/SidebarListHoverCard.tsx
+++ b/apps/web/src/lib/components/sidebar/SidebarListHoverCard.tsx
@@ -58,7 +58,7 @@ export function HoverCardAuthor({ userId }: { userId: Id<"users"> }) {
         hideLastSeen
         disableProfileCard
       />
-      <span className="truncate text-xs text-muted-foreground">
+      <span data-pii className="truncate text-xs text-muted-foreground">
         {authorDisplayName(user)}
       </span>
     </div>

--- a/apps/web/src/lib/components/sidebar/SidebarUserMenu.tsx
+++ b/apps/web/src/lib/components/sidebar/SidebarUserMenu.tsx
@@ -89,7 +89,10 @@ export function SidebarUserMenu({ name, showSearch }: SidebarUserMenuProps) {
               size="sm"
               disableProfileCard
             />
-            <p className="truncate text-sm font-medium text-foreground">
+            <p
+              data-pii
+              className="truncate text-sm font-medium text-foreground"
+            >
               {name}
             </p>
           </DropdownMenuLabel>

--- a/apps/web/src/lib/components/sidebar/TeamMembers.tsx
+++ b/apps/web/src/lib/components/sidebar/TeamMembers.tsx
@@ -19,7 +19,7 @@ function getDisplayName(user: {
   );
 }
 
-/** Online teammates as followable avatars (above the sidebar stats card). */
+/** Online teammates as followable avatars (above the sidebar stats). */
 export function OnlineTeamAvatars({ collapsed }: { collapsed: boolean }) {
   const teamData = useQuery(api.users.listTeamWithMembers, {});
   const { following, startFollowing, stopFollowing } = useFollow();
@@ -68,10 +68,11 @@ export function OnlineTeamAvatars({ collapsed }: { collapsed: boolean }) {
               </TooltipTrigger>
               <TooltipContent>
                 {isFollowing
-                  ? `Stop following ${name}`
+                  ? "Stop following "
                   : u.lastSeenPath
-                    ? `Follow ${name}`
-                    : name}
+                    ? "Follow "
+                    : ""}
+                <span data-pii>{name}</span>
               </TooltipContent>
             </Tooltip>
           );
@@ -123,10 +124,11 @@ export function OnlineTeamAvatars({ collapsed }: { collapsed: boolean }) {
               </TooltipTrigger>
               <TooltipContent>
                 {isFollowing
-                  ? `Stop following ${name}`
+                  ? "Stop following "
                   : u.lastSeenPath
-                    ? `Follow ${name}`
-                    : name}
+                    ? "Follow "
+                    : ""}
+                <span data-pii>{name}</span>
               </TooltipContent>
             </Tooltip>
           );

--- a/apps/web/src/lib/components/tasks/_components/CommentActivityItem.tsx
+++ b/apps/web/src/lib/components/tasks/_components/CommentActivityItem.tsx
@@ -57,7 +57,7 @@ function CommentAuthorName({
 
   if (fromList) {
     return (
-      <span className="truncate text-sm font-medium text-foreground">
+      <span data-pii className="truncate text-sm font-medium text-foreground">
         {getUserDisplayName(fromList)}
       </span>
     );
@@ -80,7 +80,7 @@ function CommentAuthorName({
   }
 
   return (
-    <span className="truncate text-sm font-medium text-foreground">
+    <span data-pii className="truncate text-sm font-medium text-foreground">
       {getUserDisplayName(profile)}
     </span>
   );

--- a/apps/web/src/lib/components/tasks/_components/CreatedTimelineItem.tsx
+++ b/apps/web/src/lib/components/tasks/_components/CreatedTimelineItem.tsx
@@ -38,7 +38,9 @@ export function CreatedTimelineItem({
         )}
       </span>
       <span className="min-w-0 flex-1 truncate">
-        <span className="font-medium text-foreground">{actorName}</span>
+        <span data-pii className="font-medium text-foreground">
+          {actorName}
+        </span>
         {` ${actionLabel}`}
         <span className="text-muted-foreground/50" aria-hidden>
           {" "}

--- a/apps/web/src/lib/components/tasks/_components/ReactionBar.tsx
+++ b/apps/web/src/lib/components/tasks/_components/ReactionBar.tsx
@@ -50,7 +50,7 @@ export function ReactionBar({ groups, toggle }: ReactionBarProps) {
                     hideLastSeen
                     disableProfileCard
                   />
-                  <span className="text-sm text-foreground">
+                  <span data-pii className="text-sm text-foreground">
                     {reactor.name}
                   </span>
                 </div>

--- a/apps/web/src/lib/components/tasks/_components/RunTimelineItem.tsx
+++ b/apps/web/src/lib/components/tasks/_components/RunTimelineItem.tsx
@@ -150,7 +150,10 @@ export function RunTimelineItem({
               <div className="mr-2 flex min-w-0 flex-1 items-center justify-between gap-3">
                 <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                   {requester ? (
-                    <span className="truncate text-xs font-medium text-foreground">
+                    <span
+                      data-pii
+                      className="truncate text-xs font-medium text-foreground"
+                    >
                       {getUserDisplayName(requester)}
                     </span>
                   ) : null}
@@ -329,7 +332,10 @@ function RunInlineComment({
             <UserInitials userId={comment.authorId} size="sm" />
           ) : null}
           {author ? (
-            <span className="truncate text-xs font-medium text-foreground">
+            <span
+              data-pii
+              className="truncate text-xs font-medium text-foreground"
+            >
               {getUserDisplayName(author)}
             </span>
           ) : null}

--- a/apps/web/src/lib/components/tasks/_components/StatusFieldsSection.tsx
+++ b/apps/web/src/lib/components/tasks/_components/StatusFieldsSection.tsx
@@ -348,7 +348,7 @@ export function StatusFieldsSection({
                 ) : (
                   <IconUserPlus size={14} className="text-muted-foreground" />
                 )}
-                <span>
+                <span data-pii={Boolean(task?.assignedTo) || undefined}>
                   {task?.assignedTo ? assignedDisplayName : "Code Reviewer"}
                 </span>
               </div>
@@ -366,7 +366,7 @@ export function StatusFieldsSection({
                       name={getUserInitials(user)}
                       enableBlink
                     />
-                    <span>{getUserDisplayName(user)}</span>
+                    <span data-pii>{getUserDisplayName(user)}</span>
                   </div>
                 </SelectItem>
               ))}

--- a/apps/web/src/lib/components/tasks/_components/TaskActivityItem.tsx
+++ b/apps/web/src/lib/components/tasks/_components/TaskActivityItem.tsx
@@ -148,17 +148,25 @@ export function TaskActivityItem({
         )}
       </span>
       <span className="min-w-0 flex-1 truncate">
-        <span className="font-medium text-foreground">{actorName}</span>
+        <span data-pii className="font-medium text-foreground">
+          {actorName}
+        </span>
         {" changed "}
         <span className="font-medium">{fieldLabel}</span>
         {showValues && (
           <>
             {" from "}
-            <span className="font-medium text-foreground/80">
+            <span
+              data-pii={event.field === "assignee" || undefined}
+              className="font-medium text-foreground/80"
+            >
               {oldFormatted}
             </span>
             <IconArrowRight size={10} className="inline mx-0.5 align-middle" />
-            <span className="font-medium text-foreground/80">
+            <span
+              data-pii={event.field === "assignee" || undefined}
+              className="font-medium text-foreground/80"
+            >
               {newFormatted}
             </span>
           </>

--- a/apps/web/src/lib/components/tasks/_components/TaskSubscribers.tsx
+++ b/apps/web/src/lib/components/tasks/_components/TaskSubscribers.tsx
@@ -100,7 +100,7 @@ export function TaskSubscribers({
             >
               <div className="flex items-center gap-1.5">
                 <Facehash size={16} name={getUserInitials(user)} enableBlink />
-                <span>{getUserDisplayName(user)}</span>
+                <span data-pii>{getUserDisplayName(user)}</span>
               </div>
             </DropdownMenuCheckboxItem>
           ))}

--- a/apps/web/src/routes/_global/teams/_components/TeamMembersTab.tsx
+++ b/apps/web/src/routes/_global/teams/_components/TeamMembersTab.tsx
@@ -173,10 +173,10 @@ export function TeamMembersTab({
               <div className="flex min-w-0 items-center gap-2 sm:gap-3">
                 <UserInitials userId={member.userId} hideLastSeen size="md" />
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium">
+                  <p data-pii className="truncate text-sm font-medium">
                     {member.user?.fullName || member.user?.email || "Unknown"}
                   </p>
-                  <p className="truncate text-xs text-muted-foreground">
+                  <p data-pii className="truncate text-xs text-muted-foreground">
                     {member.user?.email}
                   </p>
                 </div>

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/QuickTasksToolbar.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/QuickTasksToolbar.tsx
@@ -130,11 +130,15 @@ export function QuickTasksToolbar({
         : (projects?.find((p) => p._id === projectFilter)?.title ?? "Project");
 
   const userFilterLabel =
-    userFilter === "all"
-      ? "All Users"
-      : (users?.find((u) => u._id === userFilter)?.fullName ??
-        users?.find((u) => u._id === userFilter)?.firstName ??
-        "User");
+    userFilter === "all" ? (
+      "All Users"
+    ) : (
+      <span data-pii>
+        {users?.find((u) => u._id === userFilter)?.fullName ??
+          users?.find((u) => u._id === userFilter)?.firstName ??
+          "User"}
+      </span>
+    );
 
   const [
     { statuses, assignee, tags, sortField, sortDir, timeRange },
@@ -146,13 +150,17 @@ export function QuickTasksToolbar({
   const reviewers = (users ?? []).filter((u) => u.role === "dev");
 
   const assigneeLabel =
-    assignee === "all"
-      ? "All Code Reviewers"
-      : assignee === "unassigned"
-        ? "Unassigned"
-        : (users?.find((u) => u._id === assignee)?.fullName ??
+    assignee === "all" ? (
+      "All Code Reviewers"
+    ) : assignee === "unassigned" ? (
+      "Unassigned"
+    ) : (
+      <span data-pii>
+        {users?.find((u) => u._id === assignee)?.fullName ??
           users?.find((u) => u._id === assignee)?.firstName ??
-          "Code Reviewer");
+          "Code Reviewer"}
+      </span>
+    );
 
   const handleStatusToggle = (status: DisplayTaskStatus) => {
     const next = new Set(visibleStatuses);
@@ -356,7 +364,9 @@ export function QuickTasksToolbar({
                       <DropdownMenuSeparator />
                       {users.map((u) => (
                         <DropdownMenuRadioItem key={u._id} value={u._id}>
-                          {u.fullName ?? u.firstName ?? "Unknown"}
+                          <span data-pii>
+                            {u.fullName ?? u.firstName ?? "Unknown"}
+                          </span>
                         </DropdownMenuRadioItem>
                       ))}
                     </>
@@ -385,7 +395,9 @@ export function QuickTasksToolbar({
                       <DropdownMenuSeparator />
                       {reviewers.map((u) => (
                         <DropdownMenuRadioItem key={u._id} value={u._id}>
-                          {u.fullName ?? u.firstName ?? "Unknown"}
+                          <span data-pii>
+                            {u.fullName ?? u.firstName ?? "Unknown"}
+                          </span>
                         </DropdownMenuRadioItem>
                       ))}
                     </>

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/NewSessionComposer.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/NewSessionComposer.tsx
@@ -122,9 +122,13 @@ export function NewSessionComposer() {
       <div className="flex w-full max-w-2xl flex-col gap-3">
         <h1 className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
           <span>
-            {firstName
-              ? `${firstName}, what are we building for`
-              : "What are we building for"}
+            {firstName ? (
+              <>
+                <span data-pii>{firstName}</span>, what are we building for
+              </>
+            ) : (
+              "What are we building for"
+            )}
           </span>
           <ComposerAppSwitcher />
           <span>?</span>

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -59,6 +59,8 @@ export const userFields = {
   emailNotificationsEnabled: v.optional(v.boolean()),
   /** Opt-in Chrome-style horizontal session tabs (replaces sessions sidebar). */
   experimentalSessionTabsEnabled: v.optional(v.boolean()),
+  /** Blur user names and email addresses across the UI (for screen recording). */
+  blurPidEnabled: v.optional(v.boolean()),
   /** Opt-in live voice dictation via AI Gateway streaming STT. */
   voiceDictationEnabled: v.optional(v.boolean()),
 };

--- a/packages/backend/convex/auth.ts
+++ b/packages/backend/convex/auth.ts
@@ -217,6 +217,29 @@ export const setExperimentalSessionTabsEnabled = authMutation({
 });
 
 /**
+ * Returns whether personally identifiable text (user names, email addresses) is
+ * blurred across the UI. Defaults to false.
+ */
+export const getBlurPidEnabled = authQuery({
+  args: {},
+  returns: v.boolean(),
+  handler: async (ctx) => {
+    const user = await ctx.db.get(ctx.userId);
+    return user?.blurPidEnabled ?? false;
+  },
+});
+
+/** Updates the current user's blur-PID preference. */
+export const setBlurPidEnabled = authMutation({
+  args: { enabled: v.boolean() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(ctx.userId, { blurPidEnabled: args.enabled });
+    return null;
+  },
+});
+
+/**
  * Returns whether live voice dictation is enabled. Defaults to false
  * (opt-in experimental). Model is hardcoded server-side.
  */

--- a/packages/shared/src/components/user-initials.tsx
+++ b/packages/shared/src/components/user-initials.tsx
@@ -82,11 +82,19 @@ export function UserInitials({
   const initials = getUserInitials(user);
   const name = getUserName(user);
   const online = !!user.lastSeenAt && Date.now() - user.lastSeenAt < 120_000;
-  const tooltip = online
-    ? `${name} · Online`
+  // Name is a separate node rather than part of the string so the blur-PID
+  // rule can reach it without hiding the presence suffix.
+  const presenceSuffix = online
+    ? " · Online"
     : user.lastSeenAt
-      ? `${name} · Active ${compactRelativeTime(user.lastSeenAt)}`
-      : name;
+      ? ` · Active ${compactRelativeTime(user.lastSeenAt)}`
+      : "";
+  const tooltip = (
+    <>
+      <span data-pii>{name}</span>
+      {presenceSuffix}
+    </>
+  );
   const iconSizePx =
     size === "xl" ? 48 : size === "md" ? 24 : size === "lg" ? 32 : 16;
   const dotSize =
@@ -264,7 +272,10 @@ export function UserProfileHoverCardBody({ userId }: { userId: string }) {
           </div>
         ) : null}
 
-        <p className="truncate text-[15px] font-semibold leading-tight tracking-tight text-foreground">
+        <p
+          data-pii
+          className="truncate text-[15px] font-semibold leading-tight tracking-tight text-foreground"
+        >
           {name}
         </p>
         {roleLabel ? (
@@ -277,7 +288,9 @@ export function UserProfileHoverCardBody({ userId }: { userId: string }) {
           {user.email ? (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <MailIcon className="size-3.5 shrink-0 text-muted-foreground/60" />
-              <span className="truncate">{user.email}</span>
+              <span data-pii className="truncate">
+                {user.email}
+              </span>
             </div>
           ) : null}
           <div className="flex items-center gap-2 text-xs">


### PR DESCRIPTION
## Summary
- Add `blurPidEnabled` user preference + `getBlurPidEnabled` / `setBlurPidEnabled`.
- `BlurPidEffect` mirrors the flag onto `<html data-blur-pid>` (CSS rule already on main).
- Annotate names/emails with `data-pii` across chat, sidebar, tasks, teams, user-initials, etc.
- Experimental settings: **Blur personal info** toggle.

## Test plan
- [ ] Settings → Experimental → enable Blur personal info
- [ ] Names/emails blur in sidebar, chat, hover cards, team members
- [ ] Avatars remain visible
- [ ] Disable toggle → PII readable again