### PR TITLE
feat(ui): Tabs sm, Sonner font inherit, focus ring polish

### DIFF
--- a/packages/ui/src/ui/input.tsx
+++ b/packages/ui/src/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full border border-input bg-card px-3.5 py-2 text-sm transition-[border-color,box-shadow,background-color,transform] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/90 focus-visible:border-ring/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full border border-input bg-card px-3.5 py-2 text-sm transition-[border-color,box-shadow,background-color,transform] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/90 focus-visible:border-ring/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50",
           CONTROL_RADIUS_CLASS,
           className,
         )}

--- a/packages/ui/src/ui/select.tsx
+++ b/packages/ui/src/ui/select.tsx
@@ -20,7 +20,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between whitespace-nowrap border border-input bg-card px-3.5 py-2 text-sm ring-offset-background transition-[border-color,box-shadow,background-color,transform] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between whitespace-nowrap border border-input bg-card px-3.5 py-2 text-sm ring-offset-background transition-[border-color,box-shadow,background-color,transform] placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       CONTROL_RADIUS_CLASS,
       className,
     )}

--- a/packages/ui/src/ui/sonner.tsx
+++ b/packages/ui/src/ui/sonner.tsx
@@ -7,14 +7,20 @@ import { Toaster as SonnerToaster, type ToasterProps } from "sonner";
  * passes `theme` (and any other ToasterProps) since the theme lives in the
  * app, not this package. Toasts are styled as border-based surfaces to match
  * the HeroUI design system (card surface + hairline border + overlay shadow).
+ *
+ * Sonner's default CSS hardcodes a system font stack on `[data-sonner-toast]`,
+ * which beats inheritance from `body`. `fontFamily: inherit` wins that fight
+ * so toasts follow `--font-sans` like the rest of the app (including the
+ * sticky "Update available" refresh toast).
  */
-function Toaster(props: ToasterProps) {
+function Toaster({ style, ...props }: ToasterProps) {
   return (
     <SonnerToaster
+      style={{ fontFamily: "inherit", ...style }}
       toastOptions={{
         classNames: {
           toast:
-            "group toast rounded-surface border border-border bg-card text-foreground shadow-lg",
+            "group toast font-sans rounded-surface border border-border bg-card text-foreground shadow-lg",
           description: "text-muted-foreground",
           actionButton: "bg-primary text-primary-foreground",
           cancelButton: "bg-muted text-muted-foreground",

--- a/packages/ui/src/ui/tabs.tsx
+++ b/packages/ui/src/ui/tabs.tsx
@@ -2,16 +2,37 @@
 
 import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../utils/cn";
 import { SURFACE_RADIUS_CLASS } from "../utils/surface-radius";
 import { syncTabsPill } from "./tabsSliding";
 
 const Tabs = TabsPrimitive.Root;
 
+const tabsListVariants = cva(
+  cn(
+    "relative inline-flex items-center justify-center border border-border bg-background p-1 text-muted-foreground",
+    SURFACE_RADIUS_CLASS,
+  ),
+  {
+    variants: {
+      size: {
+        default: "h-10",
+        // Shrinks list + triggers together so callers don't size each TabsTrigger.
+        sm: "h-8 [&_.t-tab]:px-2.5 [&_.t-tab]:py-1 [&_.t-tab]:text-xs",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
 const TabsList = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, children, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> &
+    VariantProps<typeof tabsListVariants>
+>(({ className, children, size, ...props }, ref) => {
   const listRef = React.useRef<React.ComponentRef<
     typeof TabsPrimitive.List
   > | null>(null);
@@ -74,11 +95,7 @@ const TabsList = React.forwardRef<
   return (
     <TabsPrimitive.List
       ref={mergedRef}
-      className={cn(
-        "relative inline-flex h-10 items-center justify-center border border-border bg-background p-1 text-muted-foreground",
-        SURFACE_RADIUS_CLASS,
-        className,
-      )}
+      className={cn(tabsListVariants({ size }), className)}
       {...props}
     >
       <span
@@ -92,6 +109,21 @@ const TabsList = React.forwardRef<
 });
 TabsList.displayName = TabsPrimitive.List.displayName;
 
+const tabsBarVariants = cva(
+  "flex shrink-0 flex-wrap items-center gap-2 border-b border-border",
+  {
+    variants: {
+      size: {
+        default: "px-3 py-2",
+        sm: "px-2 py-1.5",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
 /**
  * Page- and panel-level tab strip: a `TabsList` sitting on the hairline that
  * divides it from the content below, with an optional trailing slot for
@@ -99,19 +131,17 @@ TabsList.displayName = TabsPrimitive.List.displayName;
  * padding stay identical across surfaces; pass `className` only to override
  * padding (twMerge lets `px-4` win over the default `px-3`).
  *
- * Not for the folder-style sandbox tabs or the small `h-8` segmented toggles —
- * those own their own chrome.
+ * Use `size="sm"` for nested panels (e.g. session Review). Not for folder-style
+ * sandbox tabs — those own their own chrome.
  */
 const TabsBar = React.forwardRef<
   HTMLDivElement,
-  React.ComponentPropsWithoutRef<"div"> & { actions?: React.ReactNode }
->(({ className, children, actions, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<"div"> &
+    VariantProps<typeof tabsBarVariants> & { actions?: React.ReactNode }
+>(({ className, children, actions, size, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      "flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2",
-      className,
-    )}
+    className={cn(tabsBarVariants({ size }), className)}
     {...props}
   >
     {children}

--- a/packages/ui/src/ui/textarea.tsx
+++ b/packages/ui/src/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[84px] w-full border border-input bg-card px-3.5 py-2.5 text-sm transition-[border-color,box-shadow,background-color,transform] placeholder:text-muted-foreground/90 focus-visible:border-ring/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[84px] w-full border border-input bg-card px-3.5 py-2.5 text-sm transition-[border-color,box-shadow,background-color,transform] placeholder:text-muted-foreground/90 focus-visible:border-ring/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35 disabled:cursor-not-allowed disabled:opacity-50",
         CONTROL_RADIUS_CLASS,
         className,
       )}


### PR DESCRIPTION
## Summary
- `TabsList` / `TabsBar` gain `size="sm"` for nested panels (e.g. session Review).
- Sonner toasts inherit app font (`fontFamily: inherit` + `font-sans`) instead of Sonner’s hardcoded system stack.
- Input / Select / Textarea focus rings: `ring-2` → `ring-1`.

## Notes
- Split from staging / #546. Primitives only — call sites can adopt `size="sm"` later.

## Test plan
- [ ] Tabs still look correct at default size
- [ ] Toast uses the app sans font (not system UI)
- [ ] Focus ring on inputs/selects/textareas is thinner but still visible