### PR TITLE
feat(backend): oversized PR listFiles diff fallback module

### DIFF
--- a/packages/backend/convex/_github/prDiff.ts
+++ b/packages/backend/convex/_github/prDiff.ts
@@ -7,6 +7,7 @@ import { action, internalAction } from "../_generated/server";
 import { components, internal } from "../_generated/api";
 import { getInstallationOctokit } from "../githubAuth";
 import { extractPrNumber } from "./helpers";
+import { isPrDiffTooLargeError, listFileToUnifiedDiff } from "./prDiffFallback";
 
 /** Cap the diff we return to the client so huge PRs don't blow the payload. */
 const MAX_DIFF_BYTES = 500_000;
@@ -40,61 +41,6 @@ type PrDiffResult = {
 };
 
 type InstallationOctokit = Awaited<ReturnType<typeof getInstallationOctokit>>;
-
-/**
- * GitHub refuses `pulls.get` with the diff media type past ~300 files (HTTP 406,
- * `code: too_large`). Message matching survives Convex wrapping the HttpError.
- */
-function isPrDiffTooLargeError(error: Error): boolean {
-  return (
-    error.message.includes('"code":"too_large"') ||
-    error.message.includes("diff exceeded the maximum number of files") ||
-    error.message.includes("diff exceeded the maximum number of lines")
-  );
-}
-
-/**
- * Rebuild one file's unified-diff section from a `pulls.listFiles` entry so
- * `buildDiffFileEntries` / `@pierre/diffs` can parse the same shape as the
- * media-type endpoint.
- */
-function listFileToUnifiedDiff(file: {
-  filename: string;
-  previous_filename?: string;
-  status: string;
-  patch?: string;
-}): string {
-  const oldPath = file.previous_filename ?? file.filename;
-  const lines: string[] = [`diff --git a/${oldPath} b/${file.filename}`];
-
-  if (file.status === "added") {
-    lines.push("new file mode 100644");
-    lines.push("--- /dev/null");
-    lines.push(`+++ b/${file.filename}`);
-  } else if (file.status === "removed") {
-    lines.push("deleted file mode 100644");
-    lines.push(`--- a/${oldPath}`);
-    lines.push("+++ /dev/null");
-  } else if (file.status === "renamed") {
-    lines.push(`rename from ${oldPath}`);
-    lines.push(`rename to ${file.filename}`);
-    lines.push(`--- a/${oldPath}`);
-    lines.push(`+++ b/${file.filename}`);
-  } else {
-    lines.push(`--- a/${oldPath}`);
-    lines.push(`+++ b/${file.filename}`);
-  }
-
-  if (file.patch !== undefined && file.patch.length > 0) {
-    lines.push(file.patch);
-  } else {
-    // Binary blobs and individually oversized files omit `patch` — keep the
-    // path in the tree so the Diffs tab still lists them.
-    lines.push(`Binary files a/${oldPath} and b/${file.filename} differ`);
-  }
-
-  return lines.join("\n");
-}
 
 /**
  * Paginated fallback when the unified-diff media type is refused. GitHub's

--- a/packages/backend/convex/_github/prDiffFallback.ts
+++ b/packages/backend/convex/_github/prDiffFallback.ts
@@ -1,0 +1,66 @@
+/**
+ * Fallback for pull-request diffs GitHub refuses to serve as unified-diff text.
+ *
+ * Past ~300 files GitHub answers `pulls.get` (diff media type) with HTTP 406,
+ * so we rebuild the same unified-diff shape from paginated `pulls.listFiles`
+ * patches. These helpers are the pure string logic behind that fallback, split
+ * out from the `"use node"` action file so they can be unit tested directly.
+ */
+
+/** One `pulls.listFiles` entry — the fields we need to rebuild a diff section. */
+export type PrListFile = {
+  filename: string;
+  previous_filename?: string;
+  status: string;
+  patch?: string;
+};
+
+/**
+ * GitHub refuses `pulls.get` with the diff media type past ~300 files (HTTP 406,
+ * `code: too_large`). Message matching survives Convex wrapping the HttpError.
+ */
+export function isPrDiffTooLargeError(error: Error): boolean {
+  return (
+    error.message.includes('"code":"too_large"') ||
+    error.message.includes("diff exceeded the maximum number of files") ||
+    error.message.includes("diff exceeded the maximum number of lines")
+  );
+}
+
+/**
+ * Rebuild one file's unified-diff section from a `pulls.listFiles` entry so
+ * `buildDiffFileEntries` / `@pierre/diffs` can parse the same shape as the
+ * media-type endpoint.
+ */
+export function listFileToUnifiedDiff(file: PrListFile): string {
+  const oldPath = file.previous_filename ?? file.filename;
+  const lines: string[] = [`diff --git a/${oldPath} b/${file.filename}`];
+
+  if (file.status === "added") {
+    lines.push("new file mode 100644");
+    lines.push("--- /dev/null");
+    lines.push(`+++ b/${file.filename}`);
+  } else if (file.status === "removed") {
+    lines.push("deleted file mode 100644");
+    lines.push(`--- a/${oldPath}`);
+    lines.push("+++ /dev/null");
+  } else if (file.status === "renamed") {
+    lines.push(`rename from ${oldPath}`);
+    lines.push(`rename to ${file.filename}`);
+    lines.push(`--- a/${oldPath}`);
+    lines.push(`+++ b/${file.filename}`);
+  } else {
+    lines.push(`--- a/${oldPath}`);
+    lines.push(`+++ b/${file.filename}`);
+  }
+
+  if (file.patch !== undefined && file.patch.length > 0) {
+    lines.push(file.patch);
+  } else {
+    // Binary blobs and individually oversized files omit `patch` — keep the
+    // path in the tree so the Diffs tab still lists them.
+    lines.push(`Binary files a/${oldPath} and b/${file.filename} differ`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/backend/tests/prDiffFallback.test.ts
+++ b/packages/backend/tests/prDiffFallback.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "vitest";
+import {
+  isPrDiffTooLargeError,
+  listFileToUnifiedDiff,
+} from "../convex/_github/prDiffFallback";
+
+/**
+ * Regression cover for fix ca72203f: when a PR exceeds GitHub's 300-file diff
+ * media-type ceiling we rebuild the unified diff from `pulls.listFiles`. Both
+ * the too-large detection and the per-file diff shape must stay stable, or
+ * `@pierre/diffs` fails to parse and the Diffs tab breaks on large PRs.
+ */
+
+test("isPrDiffTooLargeError matches GitHub's oversized-diff wordings", () => {
+  expect(
+    isPrDiffTooLargeError(new Error('{"code":"too_large","message":"..."}')),
+  ).toBe(true);
+  expect(
+    isPrDiffTooLargeError(
+      new Error("the diff exceeded the maximum number of files"),
+    ),
+  ).toBe(true);
+  expect(
+    isPrDiffTooLargeError(
+      new Error("the diff exceeded the maximum number of lines"),
+    ),
+  ).toBe(true);
+});
+
+test("isPrDiffTooLargeError ignores unrelated failures", () => {
+  expect(isPrDiffTooLargeError(new Error("Not Found"))).toBe(false);
+  expect(isPrDiffTooLargeError(new Error("Bad credentials"))).toBe(false);
+});
+
+test("listFileToUnifiedDiff builds an added-file section", () => {
+  const diff = listFileToUnifiedDiff({
+    filename: "src/new.ts",
+    status: "added",
+    patch: "@@ -0,0 +1 @@\n+hello",
+  });
+
+  expect(diff).toBe(
+    [
+      "diff --git a/src/new.ts b/src/new.ts",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/src/new.ts",
+      "@@ -0,0 +1 @@",
+      "+hello",
+    ].join("\n"),
+  );
+});
+
+test("listFileToUnifiedDiff builds a removed-file section", () => {
+  const diff = listFileToUnifiedDiff({
+    filename: "src/gone.ts",
+    status: "removed",
+    patch: "@@ -1 +0,0 @@\n-bye",
+  });
+
+  expect(diff).toBe(
+    [
+      "diff --git a/src/gone.ts b/src/gone.ts",
+      "deleted file mode 100644",
+      "--- a/src/gone.ts",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-bye",
+    ].join("\n"),
+  );
+});
+
+test("listFileToUnifiedDiff uses previous_filename for renames", () => {
+  const diff = listFileToUnifiedDiff({
+    filename: "src/after.ts",
+    previous_filename: "src/before.ts",
+    status: "renamed",
+    patch: "@@ -1 +1 @@\n-old\n+new",
+  });
+
+  expect(diff).toBe(
+    [
+      "diff --git a/src/before.ts b/src/after.ts",
+      "rename from src/before.ts",
+      "rename to src/after.ts",
+      "--- a/src/before.ts",
+      "+++ b/src/after.ts",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+    ].join("\n"),
+  );
+});
+
+test("listFileToUnifiedDiff builds a modified-file section", () => {
+  const diff = listFileToUnifiedDiff({
+    filename: "src/edit.ts",
+    status: "modified",
+    patch: "@@ -1 +1 @@\n-a\n+b",
+  });
+
+  expect(diff).toBe(
+    [
+      "diff --git a/src/edit.ts b/src/edit.ts",
+      "--- a/src/edit.ts",
+      "+++ b/src/edit.ts",
+      "@@ -1 +1 @@",
+      "-a",
+      "+b",
+    ].join("\n"),
+  );
+});
+
+test("listFileToUnifiedDiff emits a binary marker when patch is absent", () => {
+  // GitHub omits `patch` for binary blobs and individually oversized files; the
+  // path must still appear so the Diffs tab lists the file.
+  const diff = listFileToUnifiedDiff({
+    filename: "assets/logo.png",
+    status: "modified",
+  });
+
+  expect(diff).toBe(
+    [
+      "diff --git a/assets/logo.png b/assets/logo.png",
+      "--- a/assets/logo.png",
+      "+++ b/assets/logo.png",
+      "Binary files a/assets/logo.png and b/assets/logo.png differ",
+    ].join("\n"),
+  );
+});
+
+test("listFileToUnifiedDiff treats an empty patch like a missing one", () => {
+  const diff = listFileToUnifiedDiff({
+    filename: "empty.bin",
+    status: "modified",
+    patch: "",
+  });
+
+  expect(diff).toContain(
+    "Binary files a/empty.bin and b/empty.bin differ",
+  );
+});


### PR DESCRIPTION
## Summary
- Extract `isPrDiffTooLargeError` / `listFileToUnifiedDiff` into `prDiffFallback.ts`.
- Keep `prDiff.ts` wired to the same paginated `listFiles` fallback when GitHub refuses the unified-diff media type.
- Add unit tests for the rebuild helpers.

## Notes
- Split from staging / #546. Backend-only; no UI change.

## Test plan
- [ ] Open Diffs on a normal-sized PR — still loads via media type
- [ ] (If available) oversized PR still shows a rebuilt unified diff via listFiles
- [ ] `packages/backend` prDiffFallback tests pass