### PR TITLE
feat(web): monorepo slash URLs (toInternalRepoHref)

### DIFF
--- a/apps/web/src/lib/components/EntityNotFound.tsx
+++ b/apps/web/src/lib/components/EntityNotFound.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { IconAlertCircle } from "@tabler/icons-react";
 import { Button } from "@eva/ui";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface EntityNotFoundProps {
   /** Singular label used in copy, e.g. "task", "session", "document". */
@@ -33,7 +34,9 @@ export function EntityNotFound({
         action={
           backTo ? (
             <Button asChild size="sm" variant="outline" className="mt-5">
-              <Link to={backTo}>{backLabel ?? `Back to ${entityLabel}s`}</Link>
+              <Link to={toInternalRepoHref(backTo)}>
+                {backLabel ?? `Back to ${entityLabel}s`}
+              </Link>
             </Button>
           ) : undefined
         }

--- a/apps/web/src/lib/components/docs/_components/DocPrdViewer.tsx
+++ b/apps/web/src/lib/components/docs/_components/DocPrdViewer.tsx
@@ -45,6 +45,7 @@ import { DocModeSwitcher } from "./DocModeSwitcher";
 import { DocPresenceFacepile } from "./DocPresenceFacepile";
 import { DocTestGenDialog } from "./DocTestGenDialog";
 import { parseActivitySteps } from "@eva/shared/parseActivitySteps";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 type Doc = NonNullable<FunctionReturnType<typeof api.docs.get>>;
 
@@ -113,7 +114,9 @@ export function DocPrdViewer({
   const handleDocTabChange = (value: string) => {
     if (!isDocViewerTab(value)) return;
     navigate({
-      to: `${basePath}/docs/${entityPathSegment(doc) ?? ""}/${value}`,
+      to: toInternalRepoHref(
+        `${basePath}/docs/${entityPathSegment(doc) ?? ""}/${value}`,
+      ),
       search: (prev) => prev,
     });
   };

--- a/apps/web/src/lib/components/docs/_components/DocRecapViewer.tsx
+++ b/apps/web/src/lib/components/docs/_components/DocRecapViewer.tsx
@@ -41,6 +41,7 @@ import { DocContentTab } from "./DocContentTab";
 import { HtmlPreviewFrame } from "./HtmlPreviewFrame";
 import { DocPresenceFacepile } from "./DocPresenceFacepile";
 import { parseActivitySteps } from "@eva/shared/parseActivitySteps";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 type Doc = NonNullable<FunctionReturnType<typeof api.docs.get>>;
 
@@ -101,7 +102,7 @@ export function DocRecapViewer({
     const segment = entityPathSegment(doc);
     if (!segment) return;
     void navigate({
-      to: `${basePath}/docs/${segment}/${viewTab}`,
+      to: toInternalRepoHref(`${basePath}/docs/${segment}/${viewTab}`),
       search: (prev) => prev,
       replace: true,
     });
@@ -110,7 +111,9 @@ export function DocRecapViewer({
   const handleDocTabChange = (value: string) => {
     if (value !== "recap" && value !== "summary") return;
     navigate({
-      to: `${basePath}/docs/${entityPathSegment(doc) ?? ""}/${value}`,
+      to: toInternalRepoHref(
+        `${basePath}/docs/${entityPathSegment(doc) ?? ""}/${value}`,
+      ),
       search: (prev) => prev,
     });
   };

--- a/apps/web/src/lib/components/inbox/InboxClient.tsx
+++ b/apps/web/src/lib/components/inbox/InboxClient.tsx
@@ -8,33 +8,14 @@ import { useQueryState } from "nuqs";
 import { m, AnimatePresence } from "motion/react";
 import { PageWrapper } from "@/lib/components/PageWrapper";
 import { EmptyState } from "@/lib/components/ui/EmptyState";
-import { Button } from "@eva/ui";
+import { Button, Skeleton } from "@eva/ui";
 import { IconChecks, IconInbox } from "@tabler/icons-react";
 import dayjs from "@eva/shared/dates";
 import { inboxFilterParser } from "@/lib/search-params";
 import { type Notification } from "@/lib/components/notifications/notification-config";
 import { InboxFilterTabs } from "@/lib/components/inbox/InboxFilterTabs";
 import { NotificationRow } from "@/lib/components/inbox/NotificationRow";
-
-const KNOWN_SUB_PAGES = new Set([
-  "projects",
-  "docs",
-  "sessions",
-  "quick-tasks",
-  "settings",
-  "testing-arena",
-  "stats",
-  "automations",
-  "inbox",
-]);
-
-function transformNotificationHref(href: string): string {
-  const segments = href.split("/").filter(Boolean);
-  if (segments.length < 3) return href;
-  if (KNOWN_SUB_PAGES.has(segments[2])) return href;
-  const [owner, repo, appName, ...rest] = segments;
-  return `/${owner}/${repo}--${appName}/${rest.join("/")}`;
-}
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 function groupByDate(notifications: Notification[]) {
   const groups: { label: string; items: Notification[] }[] = [];
@@ -112,7 +93,7 @@ export function InboxClient() {
 
   const handleClick = (n: Notification) => {
     if (!n.read) markAsRead({ id: n._id });
-    if (n.href) navigate({ to: transformNotificationHref(n.href) });
+    if (n.href) navigate({ to: toInternalRepoHref(n.href) });
   };
 
   const isEmpty = groups !== undefined && groups.length === 0;
@@ -120,29 +101,30 @@ export function InboxClient() {
   return (
     <PageWrapper
       title="Inbox"
+      comfortable
       fillHeight={isEmpty}
       headerRight={
-        <div className="flex items-center gap-2">
-          <InboxFilterTabs
-            filter={filter}
-            unreadCount={unreadCount}
-            onChange={setFilter}
-          />
-          {unreadCount > 0 ? (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => markAllAsRead()}
-              title="Mark all as read"
-              aria-label="Mark all as read"
-              className="h-7 text-xs text-muted-foreground"
-            >
-              <IconChecks size={14} />
-              {/* The label is noise on narrow screens; the icon carries it. */}
-              <span className="hidden sm:inline">Mark all read</span>
-            </Button>
-          ) : null}
-        </div>
+        unreadCount > 0 ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => markAllAsRead()}
+            title="Mark all as read"
+            aria-label="Mark all as read"
+            className="h-7 text-xs text-muted-foreground"
+          >
+            <IconChecks size={14} />
+            {/* The label is noise on narrow screens; the icon carries it. */}
+            <span className="hidden sm:inline">Mark all read</span>
+          </Button>
+        ) : null
+      }
+      toolbar={
+        <InboxFilterTabs
+          filter={filter}
+          unreadCount={unreadCount}
+          onChange={setFilter}
+        />
       }
     >
       {filtered === undefined ? (
@@ -151,12 +133,9 @@ export function InboxClient() {
           aria-busy="true"
           aria-label="Loading inbox"
         >
-          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+          <Skeleton className="h-4 w-24" />
           {Array.from({ length: 6 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-14 animate-pulse rounded-md bg-muted/60"
-            />
+            <Skeleton key={i} className="h-14" />
           ))}
         </div>
       ) : groups === undefined || groups.length === 0 ? (

--- a/apps/web/src/lib/components/projects/NewProjectModal.tsx
+++ b/apps/web/src/lib/components/projects/NewProjectModal.tsx
@@ -36,6 +36,7 @@ import { useHotkey } from "@tanstack/react-hotkeys";
 import type { MarkdownEditorHandle } from "@/lib/components/tasks/_components/MarkdownEditor";
 import { PriorityPicker } from "@/lib/components/priority/PriorityPicker";
 import type { Priority } from "@/lib/components/priority/priorityMeta";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 const MarkdownEditor = lazy(() =>
   import("@/lib/components/tasks/_components/MarkdownEditor").then((m) => ({
@@ -131,7 +132,9 @@ export function NewProjectModal({
       if (onCreated) {
         onCreated(projectId);
       } else {
-        navigate({ to: basePath + "/projects/" + projectId });
+        navigate({
+          to: toInternalRepoHref(basePath + "/projects/" + projectId),
+        });
       }
     } catch (error) {
       setIsLoading(false);
@@ -158,7 +161,7 @@ export function NewProjectModal({
         if (!v) handleClose();
       }}
     >
-      <DialogContent className="max-w-2xl gap-0 p-0" hideCloseButton>
+      <DialogContent className="max-w-2xl gap-0 p-0">
         <div className="px-5 pt-5 pb-1">
           <Input
             placeholder="Project title"
@@ -182,14 +185,14 @@ export function NewProjectModal({
               content={description}
               onChange={setDescription}
               editable
-              placeholder="Describe what you want to build..."
+              placeholder="Describe the feature…"
               minHeight="min-h-[160px]"
               className="text-sm [&_.tiptap]:px-0 [&_.tiptap]:py-2"
             />
           </Suspense>
         </div>
 
-        <div className="flex flex-wrap items-center gap-1.5 px-5 py-3 bg-muted/30">
+        <div className="flex flex-wrap items-center gap-1.5 border-t border-border px-5 py-3">
           <Popover>
             <PopoverTrigger asChild>
               <button
@@ -244,9 +247,6 @@ export function NewProjectModal({
                       <IconSparkles size={14} className="mr-2" />
                       <div className="flex-1">
                         <div className="text-sm">With interview/plan</div>
-                        <div className="text-xs text-muted-foreground">
-                          AI interview, then generated spec
-                        </div>
                       </div>
                       {!skipPlanning && (
                         <IconCheck size={14} className="ml-2" />
@@ -261,9 +261,6 @@ export function NewProjectModal({
                       <IconListCheck size={14} className="mr-2" />
                       <div className="flex-1">
                         <div className="text-sm">Tasks only</div>
-                        <div className="text-xs text-muted-foreground">
-                          Skip planning, just a task container
-                        </div>
                       </div>
                       {skipPlanning && <IconCheck size={14} className="ml-2" />}
                     </CommandItem>
@@ -274,7 +271,7 @@ export function NewProjectModal({
           </Popover>
         </div>
 
-        <DialogFooter className="flex-col-reverse gap-2 px-5 py-3 sm:flex-row sm:justify-end bg-muted/15">
+        <DialogFooter className="flex-col-reverse gap-2 border-t border-border px-5 py-3 sm:flex-row sm:justify-end">
           <Button variant="secondary" onClick={handleClose}>
             Cancel
           </Button>

--- a/apps/web/src/lib/components/projects/ProjectActiveLayout.tsx
+++ b/apps/web/src/lib/components/projects/ProjectActiveLayout.tsx
@@ -19,6 +19,7 @@ import type { TaskDetailTab } from "@/lib/components/tasks/_components/task-deta
 import type { ProjectPhase } from "./ProjectPhaseBadge";
 import type { EntityResolveStatus } from "@/lib/components/EntityNumIdGate";
 import { useRepo } from "@/lib/contexts/RepoContext";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 import { TASK_TAGS } from "@eva/shared";
 
 interface Project {
@@ -78,13 +79,17 @@ export function ProjectActiveLayout({
     const taskPathSegment = task ? entityPathSegment(task) : null;
     if (!taskPathSegment) return;
     navigate({
-      to: `${basePath}/projects/${projectPathSegment}/${taskPathSegment}/activity`,
+      to: toInternalRepoHref(
+        `${basePath}/projects/${projectPathSegment}/${taskPathSegment}/activity`,
+      ),
     });
   };
 
   const handleCloseTask = () => {
     if (!projectPathSegment) return;
-    navigate({ to: `${basePath}/projects/${projectPathSegment}` });
+    navigate({
+      to: toInternalRepoHref(`${basePath}/projects/${projectPathSegment}`),
+    });
   };
 
   const activeDetailTab: TaskDetailTab = detailTab ?? "activity";
@@ -99,7 +104,9 @@ export function ProjectActiveLayout({
               const taskPathSegment = entityPathSegment(selectedTask);
               if (!taskPathSegment) return;
               navigate({
-                to: `${basePath}/projects/${projectPathSegment}/${taskPathSegment}/${tab}`,
+                to: toInternalRepoHref(
+                  `${basePath}/projects/${projectPathSegment}/${taskPathSegment}/${tab}`,
+                ),
               });
             },
           },

--- a/apps/web/src/lib/components/projects/ProjectCard.tsx
+++ b/apps/web/src/lib/components/projects/ProjectCard.tsx
@@ -45,6 +45,7 @@ import {
   TooltipTrigger,
 } from "@eva/ui";
 import { DynamicLink } from "@/lib/components/DynamicLink";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 import {
   phaseConfig,
   PROJECT_PHASES,
@@ -170,7 +171,7 @@ export function ProjectCard({
       selected={isActive}
       link={
         href ? (
-          <DynamicLink to={href} search={(prev) => prev} />
+          <DynamicLink to={toInternalRepoHref(href)} search={true} />
         ) : undefined
       }
       onClick={

--- a/apps/web/src/lib/components/projects/ProjectPlanTab.tsx
+++ b/apps/web/src/lib/components/projects/ProjectPlanTab.tsx
@@ -16,6 +16,7 @@ import {
 } from "@tabler/icons-react";
 import { entityPathSegment } from "@/lib/numId";
 import type { ProjectPhase } from "@/lib/components/projects/ProjectPhaseBadge";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface ProjectPlanTabProps {
   projectId: Id<"projects">;
@@ -111,7 +112,9 @@ export function ProjectPlanTab({
       if (project) {
         const segment = entityPathSegment(project);
         if (segment) {
-          navigate({ to: `${basePath}/projects/${segment}` });
+          navigate({
+            to: toInternalRepoHref(`${basePath}/projects/${segment}`),
+          });
         }
       }
     } catch (error) {

--- a/apps/web/src/lib/components/projects/ProjectSandboxPanel.tsx
+++ b/apps/web/src/lib/components/projects/ProjectSandboxPanel.tsx
@@ -23,6 +23,7 @@ import { useComputerTab } from "@/lib/components/sandbox/useComputerTab";
 import { useEditorTab } from "@/lib/components/sandbox/useEditorTab";
 import { withBrowserTab } from "@/lib/components/sandbox/withBrowserTab";
 import { FilesPanel } from "@/routes/_repo/$owner/$repo/sessions/FilesPanel";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface ProjectSandboxPanelProps {
   projectId: Id<"projects">;
@@ -80,13 +81,17 @@ export function ProjectSandboxPanel({
     if (tab === "prd" || !projectPathSegment) return;
     if (tab === "review") {
       void navigate({
-        to: `${basePath}/projects/${projectPathSegment}/sandbox/review/diffs/unified`,
+        to: toInternalRepoHref(
+          `${basePath}/projects/${projectPathSegment}/sandbox/review/diffs/unified`,
+        ),
         search: true,
       });
       return;
     }
     void navigate({
-      to: `${basePath}/projects/${projectPathSegment}/sandbox/${tab}`,
+      to: toInternalRepoHref(
+        `${basePath}/projects/${projectPathSegment}/sandbox/${tab}`,
+      ),
       // Keep diffFile across sandbox tabs.
       search: true,
     });

--- a/apps/web/src/lib/components/projects/ProjectsTimeline.tsx
+++ b/apps/web/src/lib/components/projects/ProjectsTimeline.tsx
@@ -32,6 +32,7 @@ import { TimelineBar } from "./_components/TimelineBar";
 import { TimelineSidebarMeta } from "./_components/TimelineSidebarMeta";
 import { TimelineToolbar } from "./_components/TimelineToolbar";
 import { UnscheduledProjectsSection } from "./_components/UnscheduledProjectsSection";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 type Project = FunctionReturnType<typeof api.projects.list>[number];
 type ProjectProgress = FunctionReturnType<
@@ -191,7 +192,7 @@ export function ProjectsTimeline({
     const project = scheduledProjectMap.get(id);
     const segment = project ? entityPathSegment(project) : null;
     if (!segment) return;
-    navigate({ to: `${basePath}/projects/${segment}` });
+    navigate({ to: toInternalRepoHref(`${basePath}/projects/${segment}`) });
   };
 
   const handleMove = (id: string, startAt: Date, endAt: Date | null) => {

--- a/apps/web/src/lib/components/projects/_components/UnscheduledProjectsSection.tsx
+++ b/apps/web/src/lib/components/projects/_components/UnscheduledProjectsSection.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { IconChevronRight } from "@tabler/icons-react";
 import { phaseConfig } from "@/lib/components/projects/ProjectPhaseBadge";
 import { ScheduleDatesPopover } from "./ScheduleDatesPopover";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 type Project = FunctionReturnType<typeof api.projects.list>[number];
 
@@ -52,7 +53,9 @@ export function UnscheduledProjectsSection({
                 type="button"
                 onClick={() =>
                   navigate({
-                    to: `${basePath}/projects/${entityPathSegment(project) ?? ""}`,
+                    to: toInternalRepoHref(
+                      `${basePath}/projects/${entityPathSegment(project) ?? ""}`,
+                    ),
                   })
                 }
                 className="flex-1 truncate text-left text-xs font-medium hover:text-primary"

--- a/apps/web/src/lib/components/quick-tasks/GroupTasksModal.tsx
+++ b/apps/web/src/lib/components/quick-tasks/GroupTasksModal.tsx
@@ -44,6 +44,7 @@ import { ProjectPhaseBadge } from "@/lib/components/projects/ProjectPhaseBadge";
 import { MarqueeOnHover } from "@/lib/components/ui/MarqueeOnHover";
 import { entityPathSegment } from "@/lib/numId";
 import { IconGripVertical } from "@tabler/icons-react";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 type Task = FunctionReturnType<typeof api.agentTasks.getAllTasks>[number];
 
@@ -162,7 +163,9 @@ export function GroupTasksModal({
       if (created) {
         const segment = entityPathSegment(created);
         if (segment) {
-          navigate({ to: `${basePath}/projects/${segment}` });
+          navigate({
+            to: toInternalRepoHref(`${basePath}/projects/${segment}`),
+          });
         }
       }
     } catch (error) {

--- a/apps/web/src/lib/components/quick-tasks/QuickTaskCard.tsx
+++ b/apps/web/src/lib/components/quick-tasks/QuickTaskCard.tsx
@@ -37,6 +37,7 @@ import {
 import dayjs, { compactRelativeTime } from "@eva/shared/dates";
 import { useState, type MouseEvent } from "react";
 import { DynamicLink } from "@/lib/components/DynamicLink";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 import { DeleteTaskDialog } from "./_components/DeleteTaskDialog";
 import { MoveTaskDialog } from "./_components/MoveTaskDialog";
 import { TaskCardMenuItems } from "./_components/TaskCardMenuItems";
@@ -175,7 +176,7 @@ export function QuickTaskCard({
       selected={isActive}
       link={
         href ? (
-          <DynamicLink to={href} search={(prev) => prev} />
+          <DynamicLink to={toInternalRepoHref(href)} search={true} />
         ) : undefined
       }
       onClick={

--- a/apps/web/src/lib/components/reviews/ReviewDetailClient.tsx
+++ b/apps/web/src/lib/components/reviews/ReviewDetailClient.tsx
@@ -14,6 +14,7 @@ import { REVIEW_DEFAULT_TAB, isReviewTab } from "@/lib/search-params";
 import { EntityNotFound } from "@/lib/components/EntityNotFound";
 import { ReviewTabsPanel } from "./ReviewTabsPanel";
 import { usePrRefresh } from "./usePrOverview";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 /**
  * Standalone Reviews page for one pull request. Owns the PR title block and the
@@ -53,7 +54,7 @@ export function ReviewDetailClient({
     // basePath is already the router's internal `--` form on main
     // (`repoHref`); staging's slash-URL rewrite is not in this slice.
     void navigate({
-      to: `${basePath}/reviews/${prNumber}/${nextTab}`,
+      to: toInternalRepoHref(`${basePath}/reviews/${prNumber}/${nextTab}`),
       search: (prev) => prev,
     });
   };

--- a/apps/web/src/lib/components/sandbox/PrRecapPanel.tsx
+++ b/apps/web/src/lib/components/sandbox/PrRecapPanel.tsx
@@ -27,6 +27,7 @@ import { DynamicLink } from "@/lib/components/DynamicLink";
 import { HtmlPreviewFrame } from "@/lib/components/docs/_components/HtmlPreviewFrame";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { entityPathSegment } from "@/lib/numId";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 type RecapDoc = FunctionReturnType<typeof api.docs.getRecapByPrUrl>;
 
@@ -159,14 +160,16 @@ export function PrRecapPanel({ prUrl, repoId, recapDoc }: PrRecapPanelProps) {
             </a>
             {recapDoc.prNumber !== undefined ? (
               <DynamicLink
-                to={`${basePath}/reviews/${recapDoc.prNumber}/recap`}
+                to={toInternalRepoHref(
+                  `${basePath}/reviews/${recapDoc.prNumber}/recap`,
+                )}
                 className="hover:text-foreground"
               >
                 Open in Reviews
               </DynamicLink>
             ) : docPath ? (
               <DynamicLink
-                to={`${basePath}/docs/${docPath}/recap`}
+                to={toInternalRepoHref(`${basePath}/docs/${docPath}/recap`)}
                 className="hover:text-foreground"
               >
                 Open in Documents

--- a/apps/web/src/lib/components/sidebar/ActiveTasksPopover.tsx
+++ b/apps/web/src/lib/components/sidebar/ActiveTasksPopover.tsx
@@ -7,6 +7,7 @@ import { IconListCheck, IconLoader2 } from "@tabler/icons-react";
 import type { Id } from "@eva/backend";
 import { DynamicLink } from "@/lib/components/DynamicLink";
 import { entityPathSegment } from "@/lib/numId";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface ActiveTasksBadgeProps {
   repoId: Id<"githubRepos">;
@@ -97,7 +98,9 @@ export function ActiveTasksBadge({ repoId, basePath }: ActiveTasksBadgeProps) {
                     key={task._id}
                     title={task.title}
                     taskNumber={task.taskNumber}
-                    to={`${basePath}/quick-tasks/${entityPathSegment(task) ?? ""}`}
+                    to={toInternalRepoHref(
+                      `${basePath}/quick-tasks/${entityPathSegment(task) ?? ""}`,
+                    )}
                   />
                 ))}
               </Section>
@@ -114,7 +117,9 @@ export function ActiveTasksBadge({ repoId, basePath }: ActiveTasksBadgeProps) {
                     key={task._id}
                     title={task.title}
                     taskNumber={task.taskNumber}
-                    to={`${basePath}/quick-tasks/${entityPathSegment(task) ?? ""}`}
+                    to={toInternalRepoHref(
+                      `${basePath}/quick-tasks/${entityPathSegment(task) ?? ""}`,
+                    )}
                   />
                 ))}
               </Section>

--- a/apps/web/src/lib/components/sidebar/AutomationsSidebar.tsx
+++ b/apps/web/src/lib/components/sidebar/AutomationsSidebar.tsx
@@ -29,6 +29,7 @@ import {
   sidebarTextPreview,
 } from "@/lib/components/sidebar/SidebarListHoverCard";
 import { entityPathSegment } from "@/lib/numId";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface AutomationsSidebarProps {
   repoId: Id<"githubRepos">;
@@ -71,7 +72,9 @@ export function AutomationsSidebar({
       }
       setNewTitle("");
       setIsCreateOpen(false);
-      navigate({ to: `${basePath}/automations/${segment}` });
+      navigate({
+        to: toInternalRepoHref(`${basePath}/automations/${segment}`),
+      });
       if (onNavigate) onNavigate();
     } catch (error) {
       setIsCreating(false);
@@ -94,12 +97,17 @@ export function AutomationsSidebar({
             <Spinner size="sm" />
           </div>
         ) : automations.length === 0 ? (
-          <div className="p-4 text-center">
+          <div className="px-4 py-8 text-center">
             <IconPlayerPlay
-              size={28}
-              className="mx-auto mb-2 text-muted-foreground"
+              size={20}
+              className="mx-auto mb-2 text-muted-foreground opacity-50"
             />
-            <p className="text-sm text-muted-foreground">No automations yet</p>
+            <p className="text-sm font-medium text-foreground">
+              No automations yet
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Create one to get started.
+            </p>
           </div>
         ) : (
           <SharedLayoutNav layoutId="automations-nav" className="space-y-1">

--- a/apps/web/src/lib/components/sidebar/BuildingProjectsBadge.tsx
+++ b/apps/web/src/lib/components/sidebar/BuildingProjectsBadge.tsx
@@ -7,6 +7,7 @@ import { IconFolder, IconLoader2 } from "@tabler/icons-react";
 import type { Id } from "@eva/backend";
 import { DynamicLink } from "@/lib/components/DynamicLink";
 import { entityPathSegment } from "@/lib/numId";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface BuildingProjectsBadgeProps {
   repoId: Id<"githubRepos">;
@@ -105,7 +106,9 @@ export function BuildingProjectsBadge({
                   <ProjectRow
                     key={project._id}
                     title={project.title}
-                    to={`${basePath}/projects/${entityPathSegment(project) ?? ""}`}
+                    to={toInternalRepoHref(
+                      `${basePath}/projects/${entityPathSegment(project) ?? ""}`,
+                    )}
                   />
                 ))}
               </Section>
@@ -121,7 +124,9 @@ export function BuildingProjectsBadge({
                   <ProjectRow
                     key={project._id}
                     title={project.title}
-                    to={`${basePath}/projects/${entityPathSegment(project) ?? ""}`}
+                    to={toInternalRepoHref(
+                      `${basePath}/projects/${entityPathSegment(project) ?? ""}`,
+                    )}
                   />
                 ))}
               </Section>

--- a/apps/web/src/lib/components/sidebar/DocsSidebar.tsx
+++ b/apps/web/src/lib/components/sidebar/DocsSidebar.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/components/sidebar/SharedLayoutNav";
 import { SidebarListHoverCard } from "@/lib/components/sidebar/SidebarListHoverCard";
 import { entityPathSegment, routeNumIdFromPath } from "@/lib/numId";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface DocsSidebarProps {
   repoId: Id<"githubRepos">;
@@ -122,7 +123,9 @@ export function DocsSidebar({
       setNewDocTitle("");
       setIsCreateDialogOpen(false);
       navigate({
-        to: `${basePath}/docs/${segment}/${DOC_VIEWER_DEFAULT_TAB}`,
+        to: toInternalRepoHref(
+          `${basePath}/docs/${segment}/${DOC_VIEWER_DEFAULT_TAB}`,
+        ),
         search: (prev) => prev,
       });
       if (onNavigate) onNavigate();
@@ -184,7 +187,9 @@ export function DocsSidebar({
       setPastedPrdContent("");
       setNewDocTitle("");
       navigate({
-        to: `${basePath}/docs/${segment}/${DOC_VIEWER_DEFAULT_TAB}`,
+        to: toInternalRepoHref(
+          `${basePath}/docs/${segment}/${DOC_VIEWER_DEFAULT_TAB}`,
+        ),
         search: (prev) => prev,
       });
       if (onNavigate) onNavigate();
@@ -237,7 +242,7 @@ export function DocsSidebar({
       setDocToDelete(null);
       if (isViewing) {
         navigate({
-          to: `${basePath}/docs`,
+          to: toInternalRepoHref(`${basePath}/docs`),
           search: (prev) => prev,
         });
         if (onNavigate) onNavigate();

--- a/apps/web/src/lib/components/tasks/_components/DescriptionMentionEditor.tsx
+++ b/apps/web/src/lib/components/tasks/_components/DescriptionMentionEditor.tsx
@@ -18,6 +18,7 @@ import {
 import { useDataMentionItems } from "@/lib/hooks/useDataMentionItems";
 import { useDataMentionNavigate } from "@/lib/useDataMentionNavigate";
 import { useInlineSuggestion } from "@/lib/hooks/useInlineSuggestion";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 export type DescriptionMentionEditorHandle = MentionEditorHandle;
 
@@ -86,7 +87,7 @@ export const DescriptionMentionEditor = forwardRef<
   };
 
   const handleSkillChipClick = (_skillId: string) => {
-    navigate({ to: `${basePath}/settings/skills` });
+    navigate({ to: toInternalRepoHref(`${basePath}/settings/skills`) });
   };
   const skills =
     useQuery(api.repoSkills.listByRepo, { repoId: repo._id }) ?? [];
@@ -140,7 +141,7 @@ export const DescriptionMentionEditor = forwardRef<
         <span>
           No available skills.{" "}
           <DynamicLink
-            to={`${basePath}/settings/skills`}
+            to={toInternalRepoHref(`${basePath}/settings/skills`)}
             className="text-foreground underline underline-offset-2"
           >
             Sync skills in Settings

--- a/apps/web/src/lib/contexts/RepoContext.tsx
+++ b/apps/web/src/lib/contexts/RepoContext.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useEffect } from "react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useNavigate, useLocation } from "@tanstack/react-router";
 import { api } from "@eva/backend";
-import { decodeRepoParam } from "@/lib/utils/repoUrl";
+import { decodeRepoParam, toInternalRepoHref } from "@/lib/utils/repoUrl";
 import type { FunctionReturnType } from "convex/server";
 import { Spinner } from "@eva/ui";
 
@@ -62,27 +62,36 @@ export function RepoProvider({
   }, [repo, navigate]);
 
   // Bare /owner/repo URLs for monorepos without a visible root row resolve to an
-  // app repo — canonicalize the path so links and basePath stay consistent.
+  // app repo — canonicalize to the public slash form (router rewrite maps it
+  // to the internal `--` segment for matching).
   useEffect(() => {
     if (!repo?.rootDirectory || appName) return;
     const appSegment = repo.rootDirectory.split("/").pop();
     if (!appSegment) return;
 
-    const barePrefix = `/${owner}/${repoParam}`;
-    const canonicalPrefix = `/${owner}/${name}--${appSegment}`;
+    const barePrefix = `/${owner}/${name}`;
+    const canonicalPrefix = `/${owner}/${name}/${appSegment}`;
     if (!location.pathname.startsWith(barePrefix)) return;
+    const after = location.pathname.slice(barePrefix.length);
+    if (after !== "" && !after.startsWith("/")) return;
     if (barePrefix === canonicalPrefix) return;
 
     navigate({
-      to: `${canonicalPrefix}${location.pathname.slice(barePrefix.length)}`,
+      to: toInternalRepoHref(`${canonicalPrefix}${after}`),
       search: (prev) => prev,
       replace: true,
     });
-  }, [repo, appName, owner, name, repoParam, location.pathname, navigate]);
+  }, [repo, appName, owner, name, location.pathname, navigate]);
 
+  /**
+   * Public path prefix for the active repo. Monorepo apps use slash form
+   * (`/owner/repo/app`) so `<a href>` and the address bar never show `repo--app`.
+   * Pass through {@link toInternalRepoHref} before `navigate({ to })` / `<Link to>`
+   * so the router still matches the single-segment `$repo` param.
+   */
   const resolvedAppName = appName ?? repo?.rootDirectory?.split("/").pop();
   const basePath = resolvedAppName
-    ? `/${owner}/${name}--${resolvedAppName}`
+    ? `/${owner}/${name}/${resolvedAppName}`
     : `/${owner}/${name}`;
 
   const value =

--- a/apps/web/src/lib/utils/repoUrl.test.ts
+++ b/apps/web/src/lib/utils/repoUrl.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  repoHref,
+  repoPublicHref,
+  toDisplayRepoHref,
+  toInternalRepoHref,
+} from "./repoUrl";
+
+describe("repoUrl monorepo slash rewrite", () => {
+  it("repoHref is the public slash form", () => {
+    expect(repoHref("evalucom", "carepulse-ts", "apps/web")).toBe(
+      "/evalucom/carepulse-ts/web",
+    );
+  });
+
+  it("round-trips slash ↔ dash", () => {
+    const slash = "/evalucom/carepulse-ts/web/quick-tasks/204";
+    const dash = "/evalucom/carepulse-ts--web/quick-tasks/204";
+    expect(toInternalRepoHref(slash)).toBe(dash);
+    expect(toDisplayRepoHref(dash)).toBe(slash);
+  });
+
+  it("does not treat repo sections as app names", () => {
+    expect(toInternalRepoHref("/evalucom/carepulse-ts/quick-tasks")).toBe(
+      "/evalucom/carepulse-ts/quick-tasks",
+    );
+    expect(toInternalRepoHref("/evalucom/carepulse-ts/drafts")).toBe(
+      "/evalucom/carepulse-ts/drafts",
+    );
+  });
+
+  // Regression: clicking a monorepo card carried a `?query`/`#hash`, and the
+  // rewrite dropped it — the address bar flipped and the card hard-loaded a bare
+  // dash URL. Both directions must carry the suffix through untouched.
+  it("preserves the query/hash suffix in both directions", () => {
+    expect(
+      toInternalRepoHref("/evalucom/carepulse-ts/web/quick-tasks/204?draft=1"),
+    ).toBe("/evalucom/carepulse-ts--web/quick-tasks/204?draft=1");
+    expect(
+      toDisplayRepoHref("/evalucom/carepulse-ts--web/sessions#thread-9"),
+    ).toBe("/evalucom/carepulse-ts/web/sessions#thread-9");
+  });
+
+  // Regression: `/teams/…` and other global roots share the three-segment shape
+  // of a monorepo path, so a naive rewrite mangled them into `teams--…`.
+  it("leaves global (non-repo) prefixes untouched", () => {
+    expect(toInternalRepoHref("/teams/design/activity")).toBe(
+      "/teams/design/activity",
+    );
+    expect(toInternalRepoHref("/settings/profile/edit")).toBe(
+      "/settings/profile/edit",
+    );
+  });
+
+  // Regression: a href already in dash form must not be re-encoded into
+  // `repo--app--app` when its third segment is an app name, not a sub-page.
+  it("does not double-encode an already-internal dash href", () => {
+    expect(toInternalRepoHref("/evalucom/carepulse-ts--web/dashboard")).toBe(
+      "/evalucom/carepulse-ts--web/dashboard",
+    );
+  });
+
+  // A plain repo URL (no monorepo app) has nothing to convert either way.
+  it("leaves single-repo hrefs unchanged", () => {
+    expect(toDisplayRepoHref("/evalucom/carepulse-ts/sessions")).toBe(
+      "/evalucom/carepulse-ts/sessions",
+    );
+    expect(toInternalRepoHref("/evalucom/carepulse-ts/sessions")).toBe(
+      "/evalucom/carepulse-ts/sessions",
+    );
+  });
+
+  it("repoPublicHref yields slash form for shareable links", () => {
+    expect(repoPublicHref("evalucom", "carepulse-ts", "apps/web")).toBe(
+      "/evalucom/carepulse-ts/web",
+    );
+    expect(repoPublicHref("evalucom", "carepulse-ts")).toBe(
+      "/evalucom/carepulse-ts",
+    );
+  });
+});

--- a/apps/web/src/lib/utils/repoUrl.ts
+++ b/apps/web/src/lib/utils/repoUrl.ts
@@ -1,3 +1,46 @@
+/**
+ * Monorepo apps use one `$repo` path segment internally (`repo--app`). The
+ * router rewrite in `main.tsx` maps that to slash URLs in the address bar
+ * (`repo/app`) and back again on input.
+ */
+
+/** Path segments that are repo sections, not monorepo app names. */
+export const KNOWN_REPO_SUB_PAGES = new Set([
+  "projects",
+  "docs",
+  "reviews",
+  "sessions",
+  "quick-tasks",
+  "settings",
+  "testing-arena",
+  "stats",
+  "automations",
+  "inbox",
+  "drafts",
+]);
+
+/** Global first segments that are never `/$owner/$repo/...`. */
+export const NON_REPO_PATH_PREFIXES = new Set([
+  "home",
+  "sign-in",
+  "sign-up",
+  "setup",
+  "teams",
+  "inbox",
+  "artifacts",
+  "sessions",
+  "api",
+  "settings",
+  "testing",
+  "agent-callback",
+  "mcp",
+]);
+
+/**
+ * Public href for a repo. Monorepo apps use `name/app` so the address bar and
+ * raw `<a href>` never show `repo--app`. Router matching still uses the
+ * encoded form via {@link toInternalRepoHref} / the rewrite in `main.tsx`.
+ */
 export function repoHref(
   owner: string,
   name: string,
@@ -5,9 +48,20 @@ export function repoHref(
 ): string {
   if (!rootDirectory) return `/${owner}/${name}`;
   const appName = rootDirectory.split("/").pop();
-  return `/${owner}/${name}--${appName}`;
+  if (!appName) return `/${owner}/${name}`;
+  return `/${owner}/${name}/${appName}`;
 }
 
+/** @deprecated Alias of {@link repoHref} — both are slash form now. */
+export function repoPublicHref(
+  owner: string,
+  name: string,
+  rootDirectory?: string,
+): string {
+  return repoHref(owner, name, rootDirectory);
+}
+
+/** Parse the router's internal `$repo` param (`name` or `name--app`). */
 export function decodeRepoParam(repoParam: string): {
   name: string;
   appName: string | undefined;
@@ -16,5 +70,59 @@ export function decodeRepoParam(repoParam: string): {
   return {
     name: parts[0],
     appName: parts.length > 1 ? parts[1] : undefined,
+  };
+}
+
+/**
+ * Browser slash URL → router internal `--` URL.
+ * `/owner/repo/app/…` → `/owner/repo--app/…`
+ */
+export function toInternalRepoHref(href: string): string {
+  const { pathname, suffix } = splitHref(href);
+  const segments = pathname.split("/").filter(Boolean);
+  if (
+    segments.length >= 3 &&
+    !NON_REPO_PATH_PREFIXES.has(segments[0]) &&
+    !KNOWN_REPO_SUB_PAGES.has(segments[2]) &&
+    !segments[1].includes("--")
+  ) {
+    const [owner, repo, app, ...rest] = segments;
+    const restPath = rest.length > 0 ? `/${rest.join("/")}` : "";
+    return `/${owner}/${repo}--${app}${restPath}${suffix}`;
+  }
+  return href;
+}
+
+/**
+ * Router internal `--` URL → browser slash URL.
+ * `/owner/repo--app/…` → `/owner/repo/app/…`
+ */
+export function toDisplayRepoHref(href: string): string {
+  const { pathname, suffix } = splitHref(href);
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length >= 2 && segments[1].includes("--")) {
+    const [name, appName] = segments[1].split("--", 2);
+    if (appName) {
+      const rest = segments.length > 2 ? `/${segments.slice(2).join("/")}` : "";
+      return `/${segments[0]}/${name}/${appName}${rest}${suffix}`;
+    }
+  }
+  return href;
+}
+
+function splitHref(href: string): { pathname: string; suffix: string } {
+  const qIdx = href.indexOf("?");
+  const hIdx = href.indexOf("#");
+  const end =
+    qIdx >= 0 && hIdx >= 0
+      ? Math.min(qIdx, hIdx)
+      : qIdx >= 0
+        ? qIdx
+        : hIdx >= 0
+          ? hIdx
+          : href.length;
+  return {
+    pathname: href.substring(0, end),
+    suffix: href.substring(end),
   };
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import { ClerkProvider, useAuth } from "@clerk/clerk-react";
 import { queryClient } from "./lib/queryClient";
 import { routeTree } from "./routeTree.gen";
 import { createAppHistory } from "./lib/history";
+import { toDisplayRepoHref, toInternalRepoHref } from "./lib/utils/repoUrl";
 import { clientEnv } from "./env/client";
 import { convex } from "./lib/components/ClientProvider";
 import { DeploymentErrorFallback } from "./lib/components/DeploymentErrorFallback";
@@ -71,6 +72,18 @@ const router = createRouter({
   // Twice the 50ms default: long enough that dragging the pointer across a
   // sidebar does not queue a fetch for every item it crosses.
   defaultPreloadDelay: 100,
+  // Monorepo apps: address bar + link hrefs use /owner/repo/app/… while the
+  // route tree matches /owner/repo--app/… (single $repo segment).
+  rewrite: {
+    input: ({ url }) => {
+      url.pathname = toInternalRepoHref(url.pathname);
+      return url;
+    },
+    output: ({ url }) => {
+      url.pathname = toDisplayRepoHref(url.pathname);
+      return url;
+    },
+  },
 });
 
 declare module "@tanstack/react-router" {

--- a/apps/web/src/routes/_repo/$owner/$repo/automations/AutomationClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/automations/AutomationClient.tsx
@@ -28,6 +28,7 @@ import { useRepo } from "@/lib/contexts/RepoContext";
 import { entityPathSegment } from "@/lib/numId";
 import { MarqueeOnHover } from "@/lib/components/ui/MarqueeOnHover";
 import { isAutomationTab, type AutomationTab } from "@/lib/search-params";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 type Automation = Doc<"automations">;
 
@@ -105,7 +106,9 @@ export function AutomationClient({
               const segment = entityPathSegment(automation);
               if (!segment) return;
               navigate({
-                to: `${basePath}/automations/${segment}/${v}`,
+                to: toInternalRepoHref(
+                  `${basePath}/automations/${segment}/${v}`,
+                ),
               });
             }
           }}

--- a/apps/web/src/routes/_repo/$owner/$repo/drafts/_components/DraftCard.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/drafts/_components/DraftCard.tsx
@@ -18,6 +18,7 @@ import { tokenizedToDisplayText } from "@/lib/components/mentions";
 import { RelativeDateTime } from "@/lib/components/RelativeDateTime";
 import { entityPathSegment } from "@/lib/numId";
 import type { DraftCardModel } from "../_utils";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface DraftCardProps {
   model: DraftCardModel;
@@ -109,7 +110,7 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
   const handleClick = () => {
     if (model.source === "task") {
       void navigate({
-        to: `${basePath}/quick-tasks`,
+        to: toInternalRepoHref(`${basePath}/quick-tasks`),
         search: { draft: model.row._id },
       });
       return;
@@ -126,7 +127,7 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
           taskProjectId,
         );
         if (path) {
-          await navigate({ to: path });
+          await navigate({ to: toInternalRepoHref(path) });
         }
       })();
       return;
@@ -141,7 +142,7 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
           taskProjectId,
         );
         if (path) {
-          await navigate({ to: path });
+          await navigate({ to: toInternalRepoHref(path) });
         }
       })();
       return;
@@ -155,7 +156,9 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
           return;
         }
         await navigate({
-          to: `${basePath}/projects/${segment}/sandbox/preview`,
+          to: toInternalRepoHref(
+            `${basePath}/projects/${segment}/sandbox/preview`,
+          ),
         });
       })();
       return;
@@ -168,7 +171,9 @@ export function DraftCard({ model, basePath }: DraftCardProps) {
         if (!segment) {
           return;
         }
-        await navigate({ to: `${basePath}/sessions/${segment}/preview` });
+        await navigate({
+          to: toInternalRepoHref(`${basePath}/sessions/${segment}/preview`),
+        });
       })();
       return;
     }

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/QuickTasksClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/QuickTasksClient.tsx
@@ -30,6 +30,7 @@ import {
 import { QuickTasksBulkModals } from "./_components/QuickTasksBulkModals";
 import { useFilteredQuickTasks, useQuickTaskFilters } from "./_utils";
 import { useAgentTaskByNumId } from "@/lib/useResolveByNumId";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 import { TASK_TAGS } from "@eva/shared";
 
 export function QuickTasksClient() {
@@ -374,7 +375,7 @@ export function QuickTasksClient() {
               // split); kanban shows the board, so close the task.
               if (selectedTaskId && v !== "list") {
                 navigate({
-                  to: `${basePath}/quick-tasks`,
+                  to: toInternalRepoHref(`${basePath}/quick-tasks`),
                   search: (prev) => prev,
                 });
               }

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/ActiveFiltersBar.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/ActiveFiltersBar.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import { IconX } from "@tabler/icons-react";
 
 interface ActiveFiltersBarProps {
-  filters: Array<{ key: string; label: string }>;
+  filters: Array<{ key: string; label: ReactNode }>;
   onClearFilter: (key: string) => void;
   onClearAll: () => void;
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/QuickTaskTaskPageContent.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_components/QuickTaskTaskPageContent.tsx
@@ -10,6 +10,7 @@ import { EntityNotFound } from "@/lib/components/EntityNotFound";
 import type { TaskDetailTab } from "@/lib/components/tasks/_components/task-detail-constants";
 import type { TaskRouteSandboxTab } from "@/lib/search-params";
 import type { QuickTaskRouteState } from "../_utils/useQuickTaskRouteState";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface QuickTaskTaskPageContentProps {
   taskId: Id<"agentTasks">;
@@ -51,26 +52,32 @@ export function QuickTaskTaskPageContent({
           onSandboxTabChange: (tab: TaskRouteSandboxTab) => {
             if (tab === "review") {
               void navigate({
-                to: `${basePath}/quick-tasks/${pathSegment}/sandbox/review/diffs/unified`,
+                to: toInternalRepoHref(
+                  `${basePath}/quick-tasks/${pathSegment}/sandbox/review/diffs/unified`,
+                ),
                 search: true,
               });
               return;
             }
             void navigate({
-              to: `${basePath}/quick-tasks/${pathSegment}/sandbox/${tab}`,
+              to: toInternalRepoHref(
+                `${basePath}/quick-tasks/${pathSegment}/sandbox/${tab}`,
+              ),
               // Keep diffFile across sandbox tabs.
               search: true,
             });
           },
           onExitSandboxView: () => {
             navigate({
-              to: `${basePath}/quick-tasks/${pathSegment}`,
+              to: toInternalRepoHref(`${basePath}/quick-tasks/${pathSegment}`),
               search: (prev) => prev,
             });
           },
           onOpenFile: (path: string) => {
             navigate({
-              to: `${basePath}/quick-tasks/${pathSegment}/sandbox/files`,
+              to: toInternalRepoHref(
+                `${basePath}/quick-tasks/${pathSegment}/sandbox/files`,
+              ),
               search: (prev) => ({ ...prev, file: path }),
             });
           },
@@ -85,20 +92,24 @@ export function QuickTaskTaskPageContent({
         detailTab,
         onDetailTabChange: (_tab: TaskDetailTab) => {
           navigate({
-            to: `${basePath}/quick-tasks/${pathSegment}`,
+            to: toInternalRepoHref(`${basePath}/quick-tasks/${pathSegment}`),
             search: (prev) => prev,
           });
         },
         onOpenSandboxView: (sandboxTab: TaskRouteSandboxTab) => {
           if (sandboxTab === "review") {
             void navigate({
-              to: `${basePath}/quick-tasks/${pathSegment}/sandbox/review/diffs/unified`,
+              to: toInternalRepoHref(
+                `${basePath}/quick-tasks/${pathSegment}/sandbox/review/diffs/unified`,
+              ),
               search: (prev) => prev,
             });
             return;
           }
           void navigate({
-            to: `${basePath}/quick-tasks/${pathSegment}/sandbox/${sandboxTab}`,
+            to: toInternalRepoHref(
+              `${basePath}/quick-tasks/${pathSegment}/sandbox/${sandboxTab}`,
+            ),
             search: (prev) => prev,
           });
         },
@@ -127,7 +138,10 @@ export function QuickTaskTaskPageContent({
   return (
     <TaskDetailInline
       onClose={() =>
-        navigate({ to: `${basePath}/quick-tasks`, search: (prev) => prev })
+        navigate({
+          to: toInternalRepoHref(`${basePath}/quick-tasks`),
+          search: (prev) => prev,
+        })
       }
       taskId={taskId}
       allTags={allTags}

--- a/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_utils/useQuickTaskNeighbors.ts
+++ b/apps/web/src/routes/_repo/$owner/$repo/quick-tasks/_utils/useQuickTaskNeighbors.ts
@@ -8,6 +8,7 @@ import { useRepo } from "@/lib/contexts/RepoContext";
 import { entityPathSegment } from "@/lib/numId";
 import { useFilteredQuickTasks, useQuickTaskFilters } from "../_utils";
 import type { TaskRouteSandboxTab } from "@/lib/search-params";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface UseQuickTaskNeighborsArgs {
   taskId: string;
@@ -62,19 +63,23 @@ export function useQuickTaskNeighbors({
     if (navSurface === "sandbox" && sandboxTab) {
       if (sandboxTab === "review") {
         void navigate({
-          to: `${basePath}/quick-tasks/${segment}/sandbox/review/diffs/unified`,
+          to: toInternalRepoHref(
+            `${basePath}/quick-tasks/${segment}/sandbox/review/diffs/unified`,
+          ),
           search: (prev) => prev,
         });
         return;
       }
       void navigate({
-        to: `${basePath}/quick-tasks/${segment}/sandbox/${sandboxTab}`,
+        to: toInternalRepoHref(
+          `${basePath}/quick-tasks/${segment}/sandbox/${sandboxTab}`,
+        ),
         search: (prev) => prev,
       });
       return;
     }
     navigate({
-      to: `${basePath}/quick-tasks/${segment}`,
+      to: toInternalRepoHref(`${basePath}/quick-tasks/${segment}`),
       search: (prev) => prev,
     });
   };
@@ -91,7 +96,10 @@ export function useQuickTaskNeighbors({
       if (nextTaskId) goToTask(nextTaskId);
     },
     handleBack: () => {
-      navigate({ to: `${basePath}/quick-tasks`, search: (prev) => prev });
+      navigate({
+        to: toInternalRepoHref(`${basePath}/quick-tasks`),
+        search: (prev) => prev,
+      });
     },
   };
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SessionPrdPlanView.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_components/SessionPrdPlanView.tsx
@@ -40,6 +40,7 @@ import {
   normalizePlanMarkdownForExport,
   proposedPlanTitle,
 } from "./planExport";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface SessionPrdPlanViewProps {
   sessionId: Id<"sessions">;
@@ -141,7 +142,9 @@ export function SessionPrdPlanView({
         const segment = entityPathSegment(doc);
         if (segment) {
           navigate({
-            to: `${basePath}/docs/${segment}/${DOC_VIEWER_DEFAULT_TAB}`,
+            to: toInternalRepoHref(
+              `${basePath}/docs/${segment}/${DOC_VIEWER_DEFAULT_TAB}`,
+            ),
           });
         }
       }

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/EnvVariablesPageClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/EnvVariablesPageClient.tsx
@@ -7,6 +7,7 @@ import { useRepo } from "@/lib/contexts/RepoContext";
 import { SettingsPage } from "@/lib/components/settings/SettingsPage";
 import { EnvVariablesClient } from "./EnvVariablesClient";
 import { TeamEnvVarsClient } from "./TeamEnvVarsClient";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 export function EnvVariablesPageClient({ scope }: { scope: EnvVarScope }) {
   const navigate = useNavigate();
@@ -22,7 +23,9 @@ export function EnvVariablesPageClient({ scope }: { scope: EnvVarScope }) {
           onValueChange={(value) => {
             if (value === "repo" || value === "team") {
               navigate({
-                to: `${basePath}/settings/env-variables/${value}`,
+                to: toInternalRepoHref(
+                  `${basePath}/settings/env-variables/${value}`,
+                ),
               });
             }
           }}

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/SnapshotsClient.tsx
@@ -42,6 +42,7 @@ import { formatDurationMs } from "@eva/shared/duration";
 import { parseCommandLines, formatFileSize } from "./_utils";
 import { RebuildRequiredWarning } from "./_components/RebuildRequiredWarning";
 import { BuildRow, BuildStatusBadge } from "./_components/BuildRow";
+import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 /** Every command box on this page is a monospace, resizable textarea. */
 const COMMAND_TEXTAREA_CLASS = "resize-y bg-background font-mono text-xs";
@@ -185,7 +186,7 @@ export function SnapshotsClient({
   const handleSnapshotsTabChange = (value: string) => {
     if (!isSnapshotSettingsTab(value)) return;
     navigate({
-      to: `${basePath}/settings/snapshots/${value}`,
+      to: toInternalRepoHref(`${basePath}/settings/snapshots/${value}`),
     });
   };
 


### PR DESCRIPTION
## Summary
- Address bar and public hrefs use `/owner/repo/app` instead of `repo--app`.
- TanStack `rewrite` + `toInternalRepoHref` / `toDisplayRepoHref` keep routing on the single `$repo` segment.
- `basePath` is slash-form; navigate/Link call sites wrap with `toInternalRepoHref`.
- Includes `ActiveFiltersBar` `ReactNode` label typing so web typecheck stays green.

## Notes
- Split from staging / #546. Sidebar lazy-load left on staging (not required for slash URLs).

## Test plan
- [ ] Open a monorepo app — URL shows `/owner/repo/app/...` not `--`
- [ ] Navigate projects / quick-tasks / settings / automations / inbox links — SPA, slash URL preserved
- [ ] Hard-refresh a deep slash URL — still resolves
- [ ] Non-monorepo repo paths unchanged