### PR TITLE
fix(ui): mouse wheel broken by blanket scrollbar overscroll contain

### DIFF
--- a/apps/web/src/globals.css
+++ b/apps/web/src/globals.css
@@ -292,14 +292,13 @@
 }
 
 @utility scrollbar {
-  /* Matches global base scrollbar chrome; class kept for scroll-fade pairing. */
-
-  /* Every element carrying this class is an inner pane, so a wheel or swipe that
-     reaches its end should stop there rather than scrolling whatever is behind
-     it. Chaining is why flicking a sidebar list or a kanban column to the bottom
-     used to drag the page with it. Only three of the app's 78 scroll containers
-     opted into this by hand; putting it here covers 36 of them at once. */
-  overscroll-behavior: contain;
+  /* Matches global base scrollbar chrome; class kept for scroll-fade pairing.
+     Do not put overscroll-behavior here: Chrome treats every overflow:auto
+     element as a scroll container even when it has no overflow, so contain on
+     this utility created wheel dead-zones — nested panes and horizontal boards
+     (overflow-y-hidden) swallowed vertical wheel while the ancestor scrollbar
+     still dragged fine. Opt in per pane with overscroll-y-contain /
+     overscroll-contain instead. */
   scrollbar-width: thin;
   scrollbar-color: rgb(var(--muted-foreground) / 0.35) transparent;
   &:hover {

--- a/apps/web/src/lib/components/kanban/KanbanColumn.tsx
+++ b/apps/web/src/lib/components/kanban/KanbanColumn.tsx
@@ -84,7 +84,7 @@ export function KanbanColumn({
       </div>
       <div
         ref={ref}
-        className="flex min-h-0 flex-1 flex-col overflow-y-auto p-1.5 pt-0 scrollbar scroll-fade md:p-1.5 md:pt-0"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-y-contain p-1.5 pt-0 scrollbar scroll-fade md:p-1.5 md:pt-0"
       >
         {count === 0 ? (
           <div className="flex flex-1 items-center justify-center py-6 text-xs text-muted-foreground/50">

--- a/apps/web/src/lib/components/mentions/MentionPickerPopup.tsx
+++ b/apps/web/src/lib/components/mentions/MentionPickerPopup.tsx
@@ -88,7 +88,7 @@ export function MentionPickerPopup<TItem extends { id: string }>({
       {items.length > 0 ? (
         <div
           ref={listRef}
-          className="scrollbar scroll-fade min-h-0 flex-1 overflow-y-auto py-1"
+          className="scrollbar scroll-fade min-h-0 flex-1 overflow-y-auto overscroll-contain py-1"
         >
           {items.map((item, index) => {
             const isSelected = index === selectedIndex;

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Mouse wheel dead-zones from blanket overscroll contain - 2026-08-08
+
+Putting `overscroll-behavior: contain` on `@utility scrollbar` made every `overflow:auto` pane a contain target, including ones with no overflow and horizontal boards with `overflow-y-hidden`. Chrome treats those as scroll containers at their boundary, so the wheel was swallowed while dragging the ancestor scrollbar still worked. Removed contain from the utility; restored `overscroll-y-contain` / `overscroll-contain` on the kanban column and mention picker that had opted in before.
+
 ## Anonymous landing no longer waits for Clerk - 2026-08-08
 
 Boot held first paint on Clerk's `isLoaded` for everyone. For a returning signed-in user that is correct — protected routes need the restored session and the alternative is a landing-page flash. For an anonymous visitor it means a blank screen while ~210 kB of clerk-js downloads from Clerk's CDN and completes a handshake, to restore a session that does not exist. Measured on production: clerk-js is 30% of the 700 kB cold landing payload, and FCP (~500 ms) was gated on it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Yesterday’s Apple-design pass put `overscroll-behavior: contain` on `@utility scrollbar` so inner panes would stop chaining scroll to the page. That also made **every** `overflow:auto` / `overflow-x-auto` pane a contain target — including ones with no overflow and horizontal boards with `overflow-y-hidden`.

Chrome treats those as scroll containers already at their boundary, so the **mouse wheel was swallowed** while **dragging the scrollbar thumb still worked**.

Reproduced in headless Chrome:
- nested `overflow:auto` + `contain`, no overflow → parent `scrollTop` stays `0` on wheel
- same nested structure without `contain` → parent scrolls

## Fix

- Remove `overscroll-behavior: contain` from `@utility scrollbar`
- Restore the prior opt-ins: `overscroll-y-contain` on kanban columns, `overscroll-contain` on the mention picker
- Leave a comment on the utility so this doesn’t get re-blanket’d

## Test plan

- [ ] Wheel-scroll a sidebar / list / page pane — should move with the mouse wheel again
- [ ] Drag the scrollbar thumb — still works
- [ ] Kanban column: scroll to the end; leftover wheel should not drag the page behind it
- [ ] Mention picker list: same overscroll contain behavior as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58ae5616-97d1-423c-8352-3ac04cd85fc7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58ae5616-97d1-423c-8352-3ac04cd85fc7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

