### PR TITLE
fix(web): surface silent failures as error toasts

### DIFF
--- a/apps/web/src/lib/components/kanban/KanbanBoard.tsx
+++ b/apps/web/src/lib/components/kanban/KanbanBoard.tsx
@@ -16,6 +16,7 @@ import {
   KanbanCard,
   KanbanProvider,
   motionBase,
+  toast,
   type KanbanColumnDef,
   type KanbanItem,
 } from "@eva/ui";
@@ -118,6 +119,7 @@ export function KanbanBoard<T extends BaseTask>({
           await onStatusChange(activeId, targetStatus);
         } catch (err) {
           console.error("Failed to update status:", err);
+          toast.error("Could not move the card. Try again.");
         }
       }
       return;
@@ -129,6 +131,7 @@ export function KanbanBoard<T extends BaseTask>({
         await onStatusChange(activeId, overItemData.status);
       } catch (err) {
         console.error("Failed to update status:", err);
+        toast.error("Could not move the card. Try again.");
       }
     }
   };

--- a/apps/web/src/lib/components/projects/useProjectSandbox.ts
+++ b/apps/web/src/lib/components/projects/useProjectSandbox.ts
@@ -5,6 +5,7 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import type { Id } from "@eva/backend";
+import { toast } from "@eva/ui";
 
 const PREVIEW_SANDBOX_ALLOWED_PHASES = [
   "in_progress",
@@ -57,6 +58,7 @@ export function useProjectSandbox(
       await startProjectSandboxMutation({ projectId });
     } catch (err) {
       console.error("Failed to start project sandbox:", err);
+      toast.error("Could not start the sandbox. Try again.");
     }
     setIsStartingLocal(false);
   };
@@ -67,6 +69,7 @@ export function useProjectSandbox(
       await stopProjectSandboxMutation({ projectId });
     } catch (err) {
       console.error("Failed to stop project sandbox:", err);
+      toast.error("Could not stop the sandbox. Try again.");
     }
     setIsStoppingLocal(false);
   };
@@ -77,6 +80,7 @@ export function useProjectSandbox(
       await retryStartupCommandsMutation({ projectId });
     } catch (err) {
       console.error("Failed to retry project startup commands:", err);
+      toast.error("Could not rerun the startup commands. Try again.");
     }
     setIsRetryingStartupCommands(false);
   };
@@ -87,6 +91,7 @@ export function useProjectSandbox(
       await runBackgroundCommandsMutation({ projectId });
     } catch (err) {
       console.error("Failed to run project background commands:", err);
+      toast.error("Could not run the background commands. Try again.");
     }
     setIsRunningBackgroundCommands(false);
   };

--- a/apps/web/src/lib/components/quick-tasks/QuickTasksKanbanBoard.tsx
+++ b/apps/web/src/lib/components/quick-tasks/QuickTasksKanbanBoard.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { KanbanBoard } from "@/lib/components/kanban/KanbanBoard";
 import { QuickTaskCard } from "./QuickTaskCard";
 import { RunAllDialog } from "./RunAllDialog";
-import { Button, Spinner } from "@eva/ui";
+import { Button, Spinner, toast } from "@eva/ui";
 import { IconPlayerPlay } from "@tabler/icons-react";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { entityPathSegment } from "@/lib/numId";
@@ -118,6 +118,9 @@ export function QuickTasksKanbanBoard({
       if (failedCount > 0) {
         console.error(
           `Run All started ${ownedTodoTasks.length - failedCount} of ${ownedTodoTasks.length} tasks`,
+        );
+        toast.error(
+          `Could not start ${failedCount} of ${ownedTodoTasks.length} tasks.`,
         );
       }
     } catch (err) {

--- a/apps/web/src/lib/components/quick-tasks/QuickTasksListView.tsx
+++ b/apps/web/src/lib/components/quick-tasks/QuickTasksListView.tsx
@@ -21,6 +21,7 @@ import {
   ListHeader,
   ListItems,
   ListItem,
+  toast,
   type ListDragEndEvent,
 } from "@eva/ui";
 import { IconChevronRight, IconPlayerPlay } from "@tabler/icons-react";
@@ -153,6 +154,7 @@ export function QuickTasksListView({
       await updateStatus({ id: task._id, status: targetStatus });
     } catch (err) {
       console.error("Failed to update status:", err);
+      toast.error("Could not change the task status. Try again.");
     }
   };
 
@@ -175,6 +177,9 @@ export function QuickTasksListView({
       if (failedCount > 0) {
         console.error(
           `Run All started ${ownedTodoTasks.length - failedCount} of ${ownedTodoTasks.length} tasks`,
+        );
+        toast.error(
+          `Could not start ${failedCount} of ${ownedTodoTasks.length} tasks.`,
         );
       }
     } catch (err) {

--- a/apps/web/src/lib/components/quick-tasks/_components/DeleteTaskDialog.tsx
+++ b/apps/web/src/lib/components/quick-tasks/_components/DeleteTaskDialog.tsx
@@ -4,6 +4,7 @@ import { api } from "@eva/backend";
 import type { Id } from "@eva/backend";
 import { useMutation } from "convex/react";
 import { useState } from "react";
+import { toast } from "@eva/ui";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { ConfirmDialog } from "./ConfirmDialog";
 
@@ -42,6 +43,7 @@ export function DeleteTaskDialog({
       onClose();
     } catch (err) {
       console.error("Failed to delete task:", err);
+      toast.error("Could not delete the task. Try again.");
     }
     setIsDeleting(false);
   };

--- a/apps/web/src/lib/components/quick-tasks/_components/MoveTaskDialog.tsx
+++ b/apps/web/src/lib/components/quick-tasks/_components/MoveTaskDialog.tsx
@@ -4,6 +4,7 @@ import { api } from "@eva/backend";
 import type { Id } from "@eva/backend";
 import { useMutation } from "convex/react";
 import { useState } from "react";
+import { toast } from "@eva/ui";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { ConfirmDialog } from "./ConfirmDialog";
 
@@ -50,6 +51,7 @@ export function MoveTaskDialog({
       onClose();
     } catch (err) {
       console.error("Failed to move task:", err);
+      toast.error("Could not move the task. Try again.");
     }
     setIsMoving(false);
   };

--- a/apps/web/src/lib/components/sidebar/DocsSidebar.tsx
+++ b/apps/web/src/lib/components/sidebar/DocsSidebar.tsx
@@ -21,6 +21,7 @@ import {
   Spinner,
   Surface,
   Textarea,
+  toast,
 } from "@eva/ui";
 import { IconFile, IconPlus, IconTrash, IconUpload } from "@tabler/icons-react";
 import { DOC_VIEWER_DEFAULT_TAB } from "@/lib/search-params";
@@ -195,6 +196,7 @@ export function DocsSidebar({
       if (onNavigate) onNavigate();
     } catch (error) {
       console.error("PRD upload failed", error);
+      toast.error("Could not create the document. Try again.");
     }
     setIsUploading(false);
   };
@@ -211,6 +213,7 @@ export function DocsSidebar({
       await createDocFromPrd({ title, prdContent });
     } catch (error) {
       console.error("PRD upload failed", error);
+      toast.error("Could not read that file. Pick a plain text file.");
     }
   };
 

--- a/apps/web/src/lib/components/tasks/_components/ActivityTimeline.tsx
+++ b/apps/web/src/lib/components/tasks/_components/ActivityTimeline.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
   Spinner,
+  toast,
 } from "@eva/ui";
 import { IconLoader2 } from "@tabler/icons-react";
 import type { FunctionReturnType } from "convex/server";
@@ -164,6 +165,7 @@ export function ActivityTimeline({
       setDeletingCommentId(null);
     } catch (err) {
       console.error("Failed to delete comment:", err);
+      toast.error("Could not delete the comment. Try again.");
     }
     setIsDeletingComment(false);
   };

--- a/apps/web/src/lib/components/tasks/_components/CommentActivityItem.tsx
+++ b/apps/web/src/lib/components/tasks/_components/CommentActivityItem.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  toast,
 } from "@eva/ui";
 import { IconDots, IconPencil, IconTrash } from "@tabler/icons-react";
 import { mentionTokensToEditableText } from "@/lib/components/mentions/mentionToken";
@@ -148,6 +149,7 @@ export function CommentActivityItem({
       setEditText("");
     } catch (err) {
       console.error("Failed to update comment:", err);
+      toast.error("Could not save the comment. Try again.");
     }
     setIsSaving(false);
   };

--- a/apps/web/src/lib/components/tasks/_components/CommentReplyComposer.tsx
+++ b/apps/web/src/lib/components/tasks/_components/CommentReplyComposer.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@eva/backend";
 import type { Id } from "@eva/backend";
 import { UserInitials } from "@eva/shared";
+import { toast } from "@eva/ui";
 import { tokenizedToEditable } from "@/lib/components/mentions";
 import {
   CommentMentionInput,
@@ -88,6 +89,7 @@ function CommentReplyComposerForm({
       if (mention) mention.focus();
     } catch (err) {
       console.error("Failed to post reply:", err);
+      toast.error("Could not post the reply. Your text has been kept.");
     }
     setIsSubmitting(false);
   };

--- a/apps/web/src/lib/components/tasks/_components/TaskActivityComposerForm.tsx
+++ b/apps/web/src/lib/components/tasks/_components/TaskActivityComposerForm.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuCheckboxItem,
   ModelSelect,
   Switch,
+  toast,
 } from "@eva/ui";
 import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
 import { api, normalizeAIModel } from "@eva/backend";
@@ -138,6 +139,7 @@ export function TaskActivityComposerForm({
       await createComment({ taskId, content });
     } catch (err) {
       console.error("Failed to add comment:", err);
+      toast.error("Could not post the comment. Try again.");
     }
     setIsSubmitting(false);
   };

--- a/apps/web/src/lib/components/tasks/useTaskDetail.tsx
+++ b/apps/web/src/lib/components/tasks/useTaskDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useElapsedSeconds } from "@eva/ui";
+import { toast, useElapsedSeconds } from "@eva/ui";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useAction, useMutation } from "convex/react";
 import { api } from "@eva/backend";
@@ -206,6 +206,7 @@ export function useTaskDetail(
       await cancelExecution({ taskId });
     } catch (err) {
       console.error("Failed to stop execution:", err);
+      toast.error("Could not stop the run. Try again.");
     }
     setIsStopping(false);
   };
@@ -248,6 +249,7 @@ export function useTaskDetail(
       openSandboxAfterStart();
     } catch (err) {
       console.error("Failed to start sandbox:", err);
+      toast.error("Could not start the sandbox. Try again.");
     }
     setIsSandboxStarting(false);
   };
@@ -258,6 +260,7 @@ export function useTaskDetail(
       await stopTaskSandboxMutation({ taskId });
     } catch (err) {
       console.error("Failed to stop sandbox:", err);
+      toast.error("Could not stop the sandbox. Try again.");
     }
     setIsSandboxStopping(false);
   };
@@ -269,6 +272,7 @@ export function useTaskDetail(
       openSandboxAfterStart();
     } catch (err) {
       console.error("Failed to retry startup commands:", err);
+      toast.error("Could not rerun the startup commands. Try again.");
     }
     setIsRetryingStartupCommands(false);
   };

--- a/apps/web/src/routes/_global/home/ReposClient.tsx
+++ b/apps/web/src/routes/_global/home/ReposClient.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
   DialogFooter,
   Skeleton,
+  toast,
 } from "@eva/ui";
 import {
   IconDots,
@@ -74,6 +75,7 @@ export function ReposClient() {
       await syncRepos();
     } catch (err) {
       console.error("Sync failed:", err);
+      toast.error("Could not sync your repositories. Try again.");
     }
     setSyncing(false);
   };

--- a/apps/web/src/routes/_global/settings/sync.tsx
+++ b/apps/web/src/routes/_global/settings/sync.tsx
@@ -6,7 +6,7 @@ import { api } from "@eva/backend";
 import { SettingsPage } from "@/lib/components/settings/SettingsPage";
 import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
-import { Button, Checkbox, Spinner } from "@eva/ui";
+import { Button, Checkbox, Spinner, toast } from "@eva/ui";
 import { IconGitBranch, IconRefresh } from "@tabler/icons-react";
 
 type RepoEntry = {
@@ -93,6 +93,7 @@ function SyncSettingsRoute() {
       setGithubRepos(repos);
     } catch (err) {
       console.error("Failed to fetch repos:", err);
+      toast.error("Could not load repositories from GitHub. Try again.");
     }
     setFetching(false);
   };

--- a/apps/web/src/routes/_global/setup/RepoSetupClient.tsx
+++ b/apps/web/src/routes/_global/setup/RepoSetupClient.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useAction, useMutation } from "convex/react";
 import { api } from "@eva/backend";
 import { Container } from "@/lib/components/ui/Container";
-import { Button, Spinner } from "@eva/ui";
+import { Button, Spinner, toast } from "@eva/ui";
 import { RepoSetupCard } from "./_components/RepoSetupCard";
 import { MonorepoAppsPanel } from "./_components/MonorepoAppsPanel";
 import type { GitHubRepo } from "./_components/RepoSetupCard";
@@ -122,7 +122,9 @@ export function RepoSetupClient({
         rootDirectory,
       });
       setAddedRepos((prev) => new Set([...prev, key]));
-    } catch {}
+    } catch {
+      toast.error(`Could not add ${repo.fullName}. Try again.`);
+    }
   };
 
   if (loading || syncing) {

--- a/apps/web/src/routes/_repo/$owner/$repo/projects/ProjectDetailClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/projects/ProjectDetailClient.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuSeparator,
   DialogBody,
   Spinner,
+  toast,
 } from "@eva/ui";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { entityPathSegment } from "@/lib/numId";
@@ -194,6 +195,7 @@ export function ProjectDetailClient({
       await cancelBuild({ projectId: projectId });
     } catch (err) {
       console.error("Failed to stop build:", err);
+      toast.error("Could not stop the build. Try again.");
     }
     setIsStoppingBuild(false);
   };

--- a/apps/web/src/routes/_repo/$owner/$repo/settings/MonorepoClient.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/settings/MonorepoClient.tsx
@@ -7,7 +7,7 @@ import { api } from "@eva/backend";
 import type { FunctionReturnType } from "convex/server";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { SettingsPage } from "@/lib/components/settings/SettingsPage";
-import { Button, Input, Spinner, Badge } from "@eva/ui";
+import { Button, Input, Spinner, Badge, toast } from "@eva/ui";
 import { SettingsSection } from "@/lib/components/settings/SettingsSection";
 import { SettingsEmptyState } from "@/lib/components/settings/SettingsEmptyState";
 import {
@@ -93,6 +93,7 @@ export function MonorepoClient() {
       });
     } catch (err) {
       console.error("Failed to add app:", err);
+      toast.error("Could not add the app. Try again.");
     }
     setAddingPath(null);
   };

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Silent failures in apps/web now surface as error toasts - 2026-08-09
+
+A sweep of `apps/web/src` for user-facing async work whose failure path ended in a `console.error` or an empty `catch` found 26 of them, and on every one the interface simply carried on as if nothing had happened. Deleting a task, moving it to another app, posting or editing a comment, uploading a PRD, dragging a card between kanban columns, starting or stopping a sandbox, stopping a build, syncing repositories, adding a monorepo app — each of these could fail against the backend and leave the user looking at an unchanged screen with no way to tell whether the click registered. Two of them lose typed text on the way: the task composer clears the comment box before the mutation resolves, and Run All reported a partial failure only to the console, so a batch that started three of eight tasks looked identical to one that started all eight.
+
+Every site now calls `toast.error` with a specific message alongside the existing log. Control flow is untouched — nothing is swallowed differently and nothing new is rethrown — because the bug was never the handling, it was that the handling was invisible. Reason: an action the user initiated and that failed must say so; a console line is not a user interface.
+
+Deliberately left alone: polling loops, `useEffect` background subscriptions, websocket reconnects and PTY resize retries all swallow errors on purpose, and a toast there would fire repeatedly. Paths that already show the failure inline — the artifact upload dialog, the Linear import modal, the resolve-conflicts execution error — keep their existing text rather than gaining a second channel. The bulk task modals (delete, assign, label, status, group) rethrow from an async click handler, which no error boundary can catch, so they are still effectively silent and want a separate fix.
+
 ## Touch drag for the quick-tasks list, one sensor split for every drag surface - 2026-08-07
 
 A tenth Apple-design pass over `apps/web` and `packages/ui` found one real defect left in the drag layer, and fixing it properly meant collapsing three copies of the same configuration into one.


### PR DESCRIPTION
## Toast styling

`954d9557` ("fix(ui): make toast styling actually apply HeroUI metrics and tokens") is already an ancestor of `main`, so no cherry-pick was needed. Verified on this branch that `packages/ui/src/ui/sonner.tsx` still carries `unstyled: true`, `text-muted-foreground!` and `wrap-break-word` (Tailwind v4 syntax — `apps/web` is on v4, left as-is).

## Silent-failure pass over apps/web

A sweep for user-facing async work whose failure path ended in a `console.error` or an empty `catch` found 26 sites. On every one the UI carried on unchanged, so a failed delete, comment, upload, sandbox start, build stop or repo sync was indistinguishable from a click that never registered. Two also lose typed input: the task composer clears the comment box before the mutation resolves, and Run All reported partial failures only to the console.

Each site now calls `toast.error` alongside the existing log. **Control flow is identical** — nothing is swallowed differently, nothing new is rethrown, no success/info/loading toasts added, no existing toast changed.

### Call sites touched (26)

| File | Sites | Action |
| --- | --- | --- |
| `lib/components/quick-tasks/_components/DeleteTaskDialog.tsx` | 1 | delete task |
| `lib/components/quick-tasks/_components/MoveTaskDialog.tsx` | 1 | move task to another app |
| `lib/components/tasks/_components/CommentReplyComposer.tsx` | 1 | post reply |
| `lib/components/tasks/_components/CommentActivityItem.tsx` | 1 | save comment edit |
| `lib/components/tasks/_components/TaskActivityComposerForm.tsx` | 1 | post comment |
| `lib/components/tasks/_components/ActivityTimeline.tsx` | 1 | delete comment |
| `lib/components/sidebar/DocsSidebar.tsx` | 2 | create doc from PRD, read uploaded file |
| `lib/components/kanban/KanbanBoard.tsx` | 2 | drag card to column / onto another card |
| `lib/components/quick-tasks/QuickTasksListView.tsx` | 2 | drag status change, Run All partial failure |
| `lib/components/quick-tasks/QuickTasksKanbanBoard.tsx` | 1 | Run All partial failure |
| `lib/components/tasks/useTaskDetail.tsx` | 4 | stop run, start/stop sandbox, rerun startup commands |
| `lib/components/projects/useProjectSandbox.ts` | 4 | start/stop sandbox, rerun startup, run background commands |
| `routes/_repo/$owner/$repo/settings/MonorepoClient.tsx` | 1 | add monorepo app |
| `routes/_global/home/ReposClient.tsx` | 1 | sync repositories |
| `routes/_global/settings/sync.tsx` | 1 | load repositories from GitHub |
| `routes/_repo/$owner/$repo/projects/ProjectDetailClient.tsx` | 1 | stop build |
| `routes/_global/setup/RepoSetupClient.tsx` | 1 | add repository during setup |

### Deliberately skipped

- **Repeating paths** — `.catch(() => {})` in `TerminalPanel` (websocket reconnect, PTY resize), `ClientProvider` (`updatePath`, `ensureUserExists`), `useLiveCursors`, `useTypingPresence`, `useInlineSuggestion`, `ProjectActiveLayout` sandbox cleanup effect, `DesktopPanel` iframe-ready callback, `useBranches` effect load. A toast on any of these would spam.
- **Already surfaced** — `ArtifactUploadDialog` and `ImportLinearModal` render inline error text; `useTaskDetail.handleResolveConflicts` sets `executionError`.
- **Not a failure** — `LogEntryGroup`'s `catch {}` is a JSON pretty-print fallback.
- **Out of the stated scope, worth a follow-up** — the bulk task modals (`DeleteTasksModal`, `AssignTasksModal`, `AddLabelsModal`, `ChangeStatusModal`, `GroupTasksModal`), `DocNewCommentComposer` and `NewProjectModal` rethrow from an async click handler. No error boundary can catch that, so these bulk destructive actions are still effectively silent.

## Verification

`pnpm --filter @eva/web typecheck` — clean. `packages/ui` has no typecheck script and is covered transitively (it is consumed as source). No new `any` / `unknown` / `as` / non-null `!`.

Pre-existing and untouched: `prettier --check` already fails on these files on `main`, from CRLF line endings in the checkout rather than real formatting drift.
