### PR TITLE
test: harden two weeks of regressions

### DIFF
--- a/apps/web/src/lib/components/quick-tasks/quickTaskNavigationContract.test.ts
+++ b/apps/web/src/lib/components/quick-tasks/quickTaskNavigationContract.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const directory = dirname(fileURLToPath(import.meta.url));
+const card = readFileSync(join(directory, "QuickTaskCard.tsx"), "utf8");
+const callers = [
+  "QuickTasksKanbanBoard.tsx",
+  "QuickTasksListView.tsx",
+  "../projects/ProjectTaskListPanel.tsx",
+].map((path) => ({
+  path,
+  source: readFileSync(join(directory, path), "utf8"),
+}));
+
+describe("quick-task SPA navigation", () => {
+  test("the stretched card link is a TanStack-aware DynamicLink", () => {
+    expect(card).toContain(
+      'import { DynamicLink } from "@/lib/components/DynamicLink"',
+    );
+    expect(card).toContain(
+      "<DynamicLink to={toInternalRepoHref(href)} search={true} />",
+    );
+  });
+
+  test("never falls back to a location assignment", () => {
+    for (const { path, source } of callers) {
+      expect(source, path).not.toMatch(/(?:window\.)?location\.href\s*=/);
+    }
+    expect(card).not.toMatch(/(?:window\.)?location\.href\s*=/);
+  });
+
+  test.each(callers)("$path supplies an in-app href", ({ source }) => {
+    expect(source).toContain("href={");
+    expect(source).toContain("/quick-tasks/");
+  });
+
+  test("selection mode cancels navigation before toggling selection", () => {
+    for (const { path, source } of callers.slice(0, 2)) {
+      const toggleAt = source.indexOf("onToggleSelect(task._id)");
+      const preventAt = source.lastIndexOf("event.preventDefault()", toggleAt);
+      expect(toggleAt, path).toBeGreaterThan(-1);
+      expect(preventAt, path).toBeGreaterThan(-1);
+      expect(toggleAt - preventAt, path).toBeLessThan(200);
+    }
+  });
+});

--- a/apps/web/src/lib/components/sidebar/_utils/sessionsSidebarSettings.test.ts
+++ b/apps/web/src/lib/components/sidebar/_utils/sessionsSidebarSettings.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_SESSION_PREVIEW_COUNT,
+  MAX_SESSION_PREVIEW_COUNT,
+  MIN_SESSION_PREVIEW_COUNT,
+  clampSessionPreviewCount,
+  isAppSortOrder,
+  isSessionLayout,
+  isSessionListMode,
+  isSessionSortOrder,
+  sessionActivityAt,
+  sortAppsForSidebar,
+  sortSessionsForSidebar,
+} from "./sessionsSidebarSettings";
+
+describe("sessions sidebar settings parsing", () => {
+  test.each(["updated_at", "created_at", "manual"])(
+    "accepts app sort %s",
+    (value) => expect(isAppSortOrder(value)).toBe(true),
+  );
+
+  test.each(["updated_at", "created_at"])("accepts session sort %s", (value) =>
+    expect(isSessionSortOrder(value)).toBe(true),
+  );
+
+  test.each(["active", "archived"])("accepts list mode %s", (value) => {
+    expect(isSessionListMode(value)).toBe(true);
+  });
+
+  test.each(["list", "folder"])("accepts layout %s", (value) => {
+    expect(isSessionLayout(value)).toBe(true);
+  });
+
+  test.each(["", "recent", "grid", "ACTIVE"])(
+    "rejects stale persisted value %s",
+    (value) => {
+      expect(isAppSortOrder(value)).toBe(false);
+      expect(isSessionSortOrder(value)).toBe(false);
+      expect(isSessionListMode(value)).toBe(false);
+      expect(isSessionLayout(value)).toBe(false);
+    },
+  );
+});
+
+describe("session preview count", () => {
+  test("clamps below and above the supported range", () => {
+    expect(clampSessionPreviewCount(-1)).toBe(MIN_SESSION_PREVIEW_COUNT);
+    expect(clampSessionPreviewCount(100)).toBe(MAX_SESSION_PREVIEW_COUNT);
+  });
+
+  test("rounds persisted fractional values", () => {
+    expect(clampSessionPreviewCount(4.6)).toBe(5);
+    expect(clampSessionPreviewCount(4.4)).toBe(4);
+  });
+
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "falls back for non-finite %s",
+    (value) => {
+      expect(clampSessionPreviewCount(value)).toBe(
+        DEFAULT_SESSION_PREVIEW_COUNT,
+      );
+    },
+  );
+});
+
+describe("sidebar activity ordering", () => {
+  const older = { id: "older", _id: "older", _creationTime: 10, updatedAt: 30 };
+  const newer = { id: "newer", _id: "newer", _creationTime: 20, updatedAt: 40 };
+  const createdOnly = { id: "created", _id: "created", _creationTime: 50 };
+
+  test("uses updatedAt when present and creation time otherwise", () => {
+    expect(sessionActivityAt(older)).toBe(30);
+    expect(sessionActivityAt(createdOnly)).toBe(50);
+  });
+
+  test("sorts sessions by activity without mutating the query result", () => {
+    const input = [older, createdOnly, newer];
+    expect(
+      sortSessionsForSidebar(input, "updated_at").map((row) => row.id),
+    ).toEqual(["created", "newer", "older"]);
+    expect(input.map((row) => row.id)).toEqual(["older", "created", "newer"]);
+  });
+
+  test("sorts sessions by creation independently of message activity", () => {
+    expect(
+      sortSessionsForSidebar([older, createdOnly, newer], "created_at").map(
+        (row) => row.id,
+      ),
+    ).toEqual(["created", "newer", "older"]);
+  });
+
+  test("sorts apps by latest child activity with creation fallback", () => {
+    const activity = new Map<string, number>([["older", 100]]);
+    expect(
+      sortAppsForSidebar(
+        [newer, createdOnly, older],
+        "updated_at",
+        activity,
+      ).map((row) => row.id),
+    ).toEqual(["older", "created", "newer"]);
+  });
+
+  test("keeps manual app order untouched", () => {
+    const input = [newer, older, createdOnly];
+    expect(sortAppsForSidebar(input, "manual", new Map())).toBe(input);
+  });
+});

--- a/apps/web/src/lib/components/sidebar/session-tabs/sessionTabsPartition.test.ts
+++ b/apps/web/src/lib/components/sidebar/session-tabs/sessionTabsPartition.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { partitionSessionsForChromeTabs } from "./sessionTabsPartition";
+
+type Row = {
+  id: string;
+  archived?: boolean;
+  prState?: "draft" | "open" | "merged" | "closed";
+};
+
+describe("partitionSessionsForChromeTabs", () => {
+  const draft: Row = { id: "draft", prState: "draft" };
+  const open: Row = { id: "open", prState: "open" };
+  const noPr: Row = { id: "no-pr" };
+  const merged: Row = { id: "merged", prState: "merged" };
+  const closed: Row = { id: "closed", prState: "closed" };
+  const manuallyArchived: Row = { id: "archived", archived: true };
+
+  test("keeps draft, open and no-PR sessions active in input order", () => {
+    const result = partitionSessionsForChromeTabs(
+      [draft, merged, open, closed, noPr],
+      [manuallyArchived],
+    );
+    expect(result.active.map((row) => row.id)).toEqual([
+      "draft",
+      "open",
+      "no-pr",
+    ]);
+  });
+
+  test("folds merged and closed sessions into Archived", () => {
+    const result = partitionSessionsForChromeTabs(
+      [draft, merged, open, closed],
+      [],
+    );
+    expect(result.archivedMenu.map((row) => row.id)).toEqual([
+      "merged",
+      "closed",
+    ]);
+  });
+
+  test("puts PR-terminal rows before manually archived query results", () => {
+    const result = partitionSessionsForChromeTabs(
+      [merged, closed],
+      [manuallyArchived],
+    );
+    expect(result.archivedMenu.map((row) => row.id)).toEqual([
+      "merged",
+      "closed",
+      "archived",
+    ]);
+  });
+
+  test("does not duplicate manually archived rows from the non-archived query", () => {
+    const result = partitionSessionsForChromeTabs(
+      [manuallyArchived, open],
+      [manuallyArchived],
+    );
+    expect(result.active.map((row) => row.id)).toEqual(["open"]);
+    expect(result.archivedMenu.map((row) => row.id)).toEqual(["archived"]);
+  });
+
+  test("handles empty query pages", () => {
+    expect(partitionSessionsForChromeTabs([], [])).toEqual({
+      active: [],
+      archivedMenu: [],
+    });
+  });
+});

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/_utils/sessionReadOnly.test.ts
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/_utils/sessionReadOnly.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import {
+  getSessionReadOnlyMessage,
+  isSessionPrReadOnly,
+  isSessionSidebarActive,
+  type SessionPrState,
+} from "./sessionReadOnly";
+
+describe("session PR read-only state", () => {
+  test.each<[SessionPrState | undefined, boolean]>([
+    [undefined, false],
+    ["draft", false],
+    ["open", false],
+    ["merged", true],
+    ["closed", true],
+  ])("%s -> %s", (state, expected) => {
+    expect(isSessionPrReadOnly(state)).toBe(expected);
+  });
+
+  test("manual archive removes an otherwise live session from Active", () => {
+    expect(isSessionSidebarActive({ archived: true, prState: "open" })).toBe(
+      false,
+    );
+  });
+
+  test.each<SessionPrState>(["merged", "closed"])(
+    "%s removes a non-archived session from Active",
+    (prState) => {
+      expect(isSessionSidebarActive({ archived: false, prState })).toBe(false);
+    },
+  );
+
+  test("draft, open and no-PR sessions remain active", () => {
+    expect(isSessionSidebarActive({ prState: "draft" })).toBe(true);
+    expect(isSessionSidebarActive({ prState: "open" })).toBe(true);
+    expect(isSessionSidebarActive({})).toBe(true);
+  });
+
+  test("terminal PR reason wins over the generic archive message", () => {
+    expect(
+      getSessionReadOnlyMessage({ isArchived: true, prState: "merged" }),
+    ).toContain("merged");
+    expect(
+      getSessionReadOnlyMessage({ isArchived: true, prState: "closed" }),
+    ).toContain("closed");
+  });
+
+  test("manual archive has its own fallback and live sessions have none", () => {
+    expect(
+      getSessionReadOnlyMessage({ isArchived: true, prState: "open" }),
+    ).toContain("archived");
+    expect(
+      getSessionReadOnlyMessage({ isArchived: false, prState: "open" }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/surfaceTokens.test.ts
+++ b/apps/web/src/surfaceTokens.test.ts
@@ -16,19 +16,19 @@ const css = readFileSync(
  * reads as a darker panel — are invisible to every other kind of test.
  */
 function tokensFor(selector: string): Map<string, number[]> {
-  const start = css.indexOf(`${selector} {`);
-  expect(
-    start,
-    `${selector} block is missing from globals.css`,
-  ).toBeGreaterThan(-1);
-  const block = css.slice(start, css.indexOf("\n  }", start));
-  const tokens = new Map<string, number[]>();
-  for (const [, name, triple] of block.matchAll(
-    /--([\w-]+):\s*(\d+ \d+ \d+);/g,
-  )) {
-    tokens.set(name, triple.split(" ").map(Number));
+  let start = css.indexOf(`${selector} {`);
+  while (start >= 0) {
+    const block = css.slice(start, css.indexOf("\n  }", start));
+    const tokens = new Map<string, number[]>();
+    for (const [, name, triple] of block.matchAll(
+      /--([\w-]+):\s*(\d+ \d+ \d+);/g,
+    )) {
+      tokens.set(name, triple.split(" ").map(Number));
+    }
+    if (tokens.has("background")) return tokens;
+    start = css.indexOf(`${selector} {`, start + selector.length + 2);
   }
-  return tokens;
+  expect.fail(`${selector} has no surface-token block in globals.css`);
 }
 
 /** Mean channel value, as a stand-in for how light a surface reads. */

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Two-week regression hardening - 2026-08-09
+
+Audited 472 commits from July 27 through August 9, grouped 183 fix-like commits into regression families, repaired all 18 stale tests on `main`, and added 79 deterministic cases for auth rebinding, PR/archive lifecycle, automation reinstall, callback termination, preview annotation bundling, slash-form URLs, snapshot policy, session navigation/state, and desktop media tooling.
+
+The test strategy now separates deterministic Vitest contracts from browser interaction, disposable GitHub integration, executable Linux runtime checks, and live Vercel chaos scenarios so provider and visual regressions are tested at the layer that can actually observe them.
+
 ## Touch drag for the quick-tasks list, one sensor split for every drag surface - 2026-08-07
 
 A tenth Apple-design pass over `apps/web` and `packages/ui` found one real defect left in the drag layer, and fixing it properly meant collapsing three copies of the same configuration into one.

--- a/internal/plans/implemented/two-week-regression-hardening.md
+++ b/internal/plans/implemented/two-week-regression-hardening.md
@@ -1,0 +1,152 @@
+# Two-week regression hardening audit
+
+**Status:** implemented for deterministic repository tests; browser, connector, and live-sandbox layers remain planned
+
+**Audit window:** 2026-07-27 00:00 through 2026-08-09 23:59 Europe/London
+
+## Audit inventory
+
+- 472 commits reachable from `origin/main` in the window; 398 are non-merge commits.
+- 183 non-merge subjects matched fix, revert, repair, restore, bug, or hardening terms; 161 titles remain after exact-title deduplication.
+- 15 explicit test/automation commits landed in the same period, including daily “tests for past fix commits” jobs.
+- GitHub returned no standalone closed issues for the window; bug history is carried primarily in commit messages and pull requests.
+- Recent PR descriptions documented 18 known failures on `main`: 10 backend, 6 web, and 2 UI assertions.
+- Staging/main duplicate histories, reverts, and iterative visual adjustments were collapsed into failure-mode families before choosing tests.
+
+## What this branch implements
+
+### Restore a trustworthy baseline
+
+All 18 pre-existing failures are repaired to assert the current intended contracts:
+
+- ffmpeg is probed by execution, not binary presence, so missing `libjack.so.0` is detectable;
+- monorepo links use slash path segments rather than the retired `repo--app` form;
+- bulk snapshot-retention repair is an explicitly allowed resume-after-stop path;
+- persistent snapshots never expire and are deleted through the entity lifecycle;
+- light-theme tokens are read from the real surface-token block after Tailwind v4 introduced earlier `:root` blocks;
+- drag-sensor and kanban highlight source matchers follow their current multi-line forms.
+
+### Add deterministic regression coverage
+
+This branch adds 79 cases around failure modes that daily automation missed:
+
+| Failure family              | Added coverage                                                                                                                |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Auth snapshot rebinding     | Clerk-ID lookup precedence, email guard, in-place rebind, insert-only-after-both-miss                                         |
+| Session PR lifecycle        | merged/closed mapping, draft/reopen mapping, archive/unarchive, sandbox stop, grace delete/cancel, merge-verification fencing |
+| System automation lifecycle | authorization ordering, row revival, schedule preservation, cron replacement/removal, idempotent uninstall, soft delete       |
+| Preview annotations         | predeploy build hook, pre-bundle typecheck, helper rejection, protocol marker, checked-in bundle, generated-script injection  |
+| Callback termination        | heartbeat/tool precedence, every timeout phase, OOM kill, interrupted kill, ordinary non-zero exit                            |
+| Eva URL generation          | slash-form app paths, nested root directories, empty/trailing roots, all entity destinations                                  |
+| Snapshot policy             | never-expire persistent policy, one-day ephemeral floor, Vercel update payload, explicit retention repair allow-list          |
+| Session read-only UI        | every PR state, manual archive, terminal reason precedence, live-state behavior                                               |
+| Session tab partitioning    | active/terminal/manual archive partitions, stable ordering, duplicate avoidance, empty pages                                  |
+| Sidebar settings            | every persisted enum, stale values, preview count bounds/non-finite input, activity fallback, immutable sorting, manual order |
+| Quick-task navigation       | TanStack-aware stretched link, no location assignment, href at every caller, selection-mode cancellation                      |
+| Desktop media tooling       | executable ffmpeg probe, repair ordering, libjack fallback, idempotent fail-open install                                      |
+
+## Full test architecture to add next
+
+The remaining bugs are not all best represented by Vitest source contracts. The robust end state is a test pyramid with explicit ownership.
+
+### 1. Convex mutation integration suite
+
+Add an isolated Convex test database harness and exercise real mutations rather than only source ordering:
+
+- provision a user by Clerk ID, restore with a new Clerk ID and the same email, and prove every owned record remains attached;
+- prove an email-less MCP identity never claims another email-less record;
+- feed every GitHub PR webhook action and verify `prState`, `archived`, sandbox-stop request, grace schedule, and reopen cancellation;
+- replay duplicate and out-of-order PR events and verify idempotency;
+- install, customize, uninstall, and reinstall every system automation while preserving runs and schedule;
+- test session owner/provider-account visibility across two users and a shared team;
+- test recap timeout recovery, pending-without-workflow recovery, and retry eligibility;
+- test stale sandbox reconciliation for sessions, tasks, and projects with mismatched sandbox IDs;
+- test snapshot cleanup candidates at 47h59m, 48h, reopen, and already-deleted boundaries;
+- test authorization-negative cases for every public action that accepts a repo, task, session, message, sandbox, or installation ID.
+
+### 2. Callback and process integration suite
+
+Run the callback against controlled child processes and a fake Convex HTTP endpoint:
+
+- exit 0 with a result, exit 0 without a result, ordinary non-zero exit, SIGTERM, SIGKILL, and an OOM-shaped 137;
+- silence before first event, before first assistant text, after first text, during a tool, and after a terminal result;
+- cancellation while idle, in a tool, while finalizing, and while a queued turn is claimed;
+- daemon pidfile ownership, incumbent signature mismatch, stale owner, duplicate spawn, and teardown races;
+- completion delivery before and after media upload for chat versus proof runs;
+- delayed old-turn completion and stream writes after a newer turn starts;
+- Cursor reasoning parameter, variant, unsupported-level, and bare-model fallback paths against recorded SDK model payloads.
+
+### 3. Shell/runtime executable contracts
+
+Execute generated shell fragments inside the closest available Linux image:
+
+- ffmpeg present and healthy; present but missing libjack; absent; package-manager failure; repeated start;
+- git-lfs registration with missing `/opt/git/etc`, pre-existing config, and a failed registration;
+- pnpm/yarn/npm/pip manifest combinations and independent Node/Python lockfile drift;
+- swap provisioning under adequate, marginal, and insufficient disk; repeated provisioning; snapshot release;
+- startup marker success/failure ordering and commands containing shell blocks;
+- preview recovery with dead proxy, dead dev server, OOM exit, throttled repeat, and user stop.
+
+### 4. Component tests in a browser DOM
+
+Add a single maintained browser-DOM component harness, then cover:
+
+- localStorage hydration and cross-tab synchronization for sidebar layout, group-open state, shortcut overrides, and explicit reasoning levels;
+- composer send failure, optimistic user bubble, no optimistic assistant bubble, queued-message placement, paste undo, and type-to-focus newline;
+- quick-task cards in ordinary, selection, context-menu, keyboard, and nested-control interactions;
+- terminal/preview tab APIs and keyboard shortcuts, including custom `Mod+J` bindings;
+- drag/drop enter-leave nesting, drop highlight, mouse distance, touch hold, keyboard drag, and cancel;
+- terminal PR banners, archive controls, and reopened state;
+- external-link chip labeling and URL-first mention parsing.
+
+### 5. Playwright interaction and visual suite
+
+Use `/?agent` and preserve SPA state while testing real browser behavior:
+
+- assert quick-task/list/project navigation never increments the document navigation count;
+- assert monorepo slash URLs survive reload, back/forward, copied links, and every entity route;
+- wheel-scroll nested panes at top/bottom, drag scrollbar thumbs, and verify only explicit overscroll containers contain chaining;
+- touch-reveal every hover-only control and perform kanban, gantt, and quick-task drag with touch emulation;
+- capture light/dark/neutral surface-token screenshots for cards, sidebars, overlays, focus rings, switches, toasts, and tab seams;
+- verify favicon unread badges at 0, 1, 9, 10, 99, and 100+ under each theme accent;
+- test dictation probe failures, ZDR copy, retry, AudioContext reuse, and reply-row positioning;
+- verify message enter/crossfade/collapsible motion and motion utility output without layout-animation regressions;
+- test annotation select mode against native inputs, nested elements, transformed iframes, navigation, and stale proxy restart.
+
+### 6. GitHub integration suite
+
+Use a disposable repository and GitHub App installation:
+
+- a turn with no commits neither pushes nor opens/refreshes a PR;
+- a pushed branch targets the session base branch, adopts an existing PR, and handles a not-ahead branch;
+- merge, close, reopen, convert-to-draft, and ready-for-review events converge session state;
+- duplicate-tip merge verification detaches only the false-positive PR;
+- oversized diffs rebuild from `listFiles`, including binary, renamed, deleted, truncated, and paginated files;
+- first-install ownership proof and installation/repository filtering reject cross-tenant metadata.
+
+### 7. Live Vercel sandbox chaos suite
+
+Run nightly or before sandbox-runtime releases because mocks cannot prove provider behavior:
+
+- kill a runner during staged, launching, running, tool-active, finalizing, summary, and completion phases;
+- stop/resume while prewarm, deadline extension, preview healing, snapshot capture, and bulk-retention repair race;
+- verify a background prewarm never resurrects a user-stopped sandbox;
+- create multiple auto-snapshots, confirm keep-last-one, archive/complete the owner, wait through a shortened grace, and confirm sandbox plus snapshots disappear;
+- delete the current snapshot and prove session/task/project start falls through to a fresh sandbox and re-checks out the remote branch;
+- exhaust memory and disk independently and verify recoverable status, useful error copy, and bounded cleanup;
+- verify IPv4-only dependency, Git LFS, package install, desktop, PTY scrollback, and preview readiness on a fresh seed.
+
+## CI layout
+
+1. Every PR: TypeScript, all Vitest suites, generated-bundle freshness, compiler bailout check.
+2. Browser PR lane for changed web/UI paths: component DOM tests plus targeted Playwright specs.
+3. Nightly: full Playwright matrix, disposable GitHub integration, shell image matrix.
+4. Scheduled/provider release: live Vercel chaos and snapshot billing lifecycle.
+5. Quarantine is time-boxed and owner-tagged; a red deterministic suite is never accepted as the baseline again.
+
+## Scope decisions
+
+- Pure styling iterations are grouped into visual scenarios instead of one brittle class-string test per commit.
+- Reverted/staging-only copies are not tested twice.
+- Open PRs whose production code is absent from `main` keep their regression tests on those PR branches; this branch does not encode contracts for code it cannot execute.
+- Destructive snapshot and sandbox cases stay out of ordinary PR CI and use isolated provider projects.

--- a/packages/backend/callback-src/tests/completionErrorMessage.test.ts
+++ b/packages/backend/callback-src/tests/completionErrorMessage.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import { buildErrorMessage } from "../runtime/completion.js";
+
+describe("one-shot completion errors", () => {
+  test("fatal heartbeat errors win over every local diagnosis", () => {
+    expect(
+      buildErrorMessage(
+        137,
+        "lease lost",
+        "tool stalled",
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+      ),
+    ).toBe("lease lost");
+  });
+
+  test("tool stalls win over timeout flags", () => {
+    expect(
+      buildErrorMessage(
+        1,
+        "",
+        "tool stalled",
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+      ),
+    ).toBe("tool stalled");
+  });
+
+  test("names each timeout phase", () => {
+    expect(
+      buildErrorMessage(1, "", "", true, false, false, false, false, false),
+    ).toContain("max runtime");
+    expect(
+      buildErrorMessage(1, "", "", false, true, false, false, false, false),
+    ).toContain("no stdout");
+    expect(
+      buildErrorMessage(1, "", "", false, false, true, false, false, false),
+    ).toContain("no parseable");
+    expect(
+      buildErrorMessage(1, "", "", false, false, false, true, false, false),
+    ).toContain("no assistant response");
+    expect(
+      buildErrorMessage(1, "", "", false, false, false, false, true, false),
+    ).toContain("stalled after first text");
+    expect(
+      buildErrorMessage(1, "", "", false, false, false, false, false, true),
+    ).toContain("zombie state");
+  });
+
+  test("reports SIGKILL-style exits as memory interruptions", () => {
+    const message = buildErrorMessage(
+      137,
+      "",
+      "",
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    );
+    expect(message).toContain("ran out of memory");
+    expect(message).toContain("nothing was completed");
+  });
+
+  test("reports SIGTERM-style exits as cancellations, never success", () => {
+    const message = buildErrorMessage(
+      143,
+      "",
+      "",
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    );
+    expect(message).toContain("run was interrupted");
+    expect(message).toContain("nothing was completed");
+  });
+
+  test("keeps ordinary non-zero exits diagnosable", () => {
+    expect(
+      buildErrorMessage(23, "", "", false, false, false, false, false, false),
+    ).toBe("Claude CLI exited with code 23");
+  });
+});

--- a/packages/backend/tests/authRebindContract.test.ts
+++ b/packages/backend/tests/authRebindContract.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const source = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../convex/auth.ts"),
+  "utf8",
+);
+const body = definitionBody(source, "ensureUserExists");
+
+describe("ensureUserExists identity recovery", () => {
+  test("looks up the stable Clerk identity before the email fallback", () => {
+    const clerkLookupAt = body.indexOf('withIndex("by_clerk_id"');
+    const emailLookupAt = body.indexOf('withIndex("by_email"');
+    expect(clerkLookupAt).toBeGreaterThan(-1);
+    expect(emailLookupAt).toBeGreaterThan(clerkLookupAt);
+  });
+
+  test("never performs the fallback for an identity without an email", () => {
+    const emailGuardAt = body.indexOf("if (email) {");
+    const emailLookupAt = body.indexOf('withIndex("by_email"');
+    expect(emailGuardAt).toBeGreaterThan(-1);
+    expect(emailLookupAt).toBeGreaterThan(emailGuardAt);
+  });
+
+  test("rebinds the existing record instead of inserting a duplicate", () => {
+    const emailLookupAt = body.indexOf('withIndex("by_email"');
+    const patchAt = body.indexOf(
+      "ctx.db.patch(userWithSameEmail._id",
+      emailLookupAt,
+    );
+    const insertAt = body.indexOf('ctx.db.insert("users"', emailLookupAt);
+    expect(patchAt).toBeGreaterThan(emailLookupAt);
+    expect(patchAt).toBeLessThan(insertAt);
+    expect(body.slice(patchAt, insertAt)).toContain("clerkId: clerkUserId");
+    expect(body.slice(patchAt, insertAt)).toContain("wasCreated: false");
+  });
+
+  test("inserts only after both lookup paths miss", () => {
+    const emailLookupAt = body.indexOf('withIndex("by_email"');
+    const insertAt = body.indexOf('ctx.db.insert("users"');
+    expect(insertAt).toBeGreaterThan(emailLookupAt);
+    expect(body.slice(insertAt)).toContain("wasCreated: true");
+  });
+});
+
+function definitionBody(input: string, name: string): string {
+  const startAt = input.indexOf(`export const ${name} =`);
+  expect(startAt, `${name} moved or was renamed`).toBeGreaterThan(-1);
+  const endAt = input.indexOf("\n});", startAt);
+  return input.slice(startAt, endAt < 0 ? undefined : endAt);
+}

--- a/packages/backend/tests/desktopFfmpegInstallContract.test.ts
+++ b/packages/backend/tests/desktopFfmpegInstallContract.test.ts
@@ -34,7 +34,7 @@ const desktopStartBody = (() => {
  * The install has to come before either gate.
  */
 test("desktop start installs ffmpeg before the health gate and install guard", () => {
-  const ffmpegAt = desktopStartBody.indexOf("command -v ffmpeg");
+  const ffmpegAt = desktopStartBody.indexOf("ffmpeg -version");
   expect(ffmpegAt, "desktop start must install ffmpeg").toBeGreaterThan(-1);
 
   const gates = [
@@ -55,7 +55,7 @@ test("desktop start installs ffmpeg before the health gate and install guard", (
 
 /** Soft-failing and idempotent, so a dnf hiccup cannot block desktop startup. */
 test("the ffmpeg install is idempotent and cannot block startup", () => {
-  const installAt = desktopStartBody.indexOf("if ! command -v ffmpeg");
+  const installAt = desktopStartBody.indexOf("if ! ffmpeg -version");
   expect(
     installAt,
     "the install must be gated on `command -v` so re-running is a no-op",
@@ -64,5 +64,20 @@ test("the ffmpeg install is idempotent and cannot block startup", () => {
   expect(
     installBlock,
     "a failing dnf must not throw out of desktop startup",
+  ).toContain("|| true");
+});
+
+test("the health probe catches a present but unloadable ffmpeg binary", () => {
+  expect(desktopStartBody).not.toContain("command -v ffmpeg");
+  expect(desktopStartBody.match(/if ! ffmpeg -version/g)).toHaveLength(2);
+});
+
+test("the repair installs ffmpeg before its missing libjack dependency", () => {
+  const ffmpegInstallAt = desktopStartBody.indexOf("ffmpeg-free");
+  const libjackInstallAt = desktopStartBody.indexOf("libjack.so.0");
+  expect(ffmpegInstallAt).toBeGreaterThan(-1);
+  expect(libjackInstallAt).toBeGreaterThan(ffmpegInstallAt);
+  expect(
+    desktopStartBody.slice(libjackInstallAt, libjackInstallAt + 500),
   ).toContain("|| true");
 });

--- a/packages/backend/tests/evaUrls.test.ts
+++ b/packages/backend/tests/evaUrls.test.ts
@@ -25,15 +25,13 @@ test("buildEvaDocUrl uses numeric doc id and monorepo app segment", () => {
   // GitHub Eva links must use numId paths, not Convex document ids.
   expect(
     buildEvaDocUrl("evalucom", "carepulse-ts", 42, "content", "apps/web"),
-  ).toBe("https://eva.example.com/evalucom/carepulse-ts--web/docs/42/content");
+  ).toBe("https://eva.example.com/evalucom/carepulse-ts/web/docs/42/content");
 });
 
 test("buildEvaReviewUrl uses GitHub PR number under Reviews", () => {
   expect(
     buildEvaReviewUrl("evalucom", "carepulse-ts", 138, "recap", "apps/web"),
-  ).toBe(
-    "https://eva.example.com/evalucom/carepulse-ts--web/reviews/138/recap",
-  );
+  ).toBe("https://eva.example.com/evalucom/carepulse-ts/web/reviews/138/recap");
 });
 
 test("buildEvaTaskUrl routes project tasks to project URL", () => {
@@ -46,7 +44,7 @@ test("buildEvaTaskUrl routes project tasks to project URL", () => {
       "apps/eprocurement",
     ),
   ).toBe(
-    "https://eva.example.com/evalucom/carepulse-ts--eprocurement/projects/proj_1",
+    "https://eva.example.com/evalucom/carepulse-ts/eprocurement/projects/proj_1",
   );
 });
 
@@ -58,9 +56,24 @@ test("buildEvaTaskUrl uses quick-tasks path without project", () => {
 
 test("buildEvaSessionUrl and buildEvaProjectUrl include app segment when set", () => {
   expect(buildEvaSessionUrl("vvedantb", "eva", "sess_1", "apps/web")).toBe(
-    "https://eva.example.com/vvedantb/eva--web/sessions/sess_1",
+    "https://eva.example.com/vvedantb/eva/web/sessions/sess_1",
   );
   expect(buildEvaProjectUrl("vvedantb", "eva", "proj_2", "apps/web")).toBe(
-    "https://eva.example.com/vvedantb/eva--web/projects/proj_2",
+    "https://eva.example.com/vvedantb/eva/web/projects/proj_2",
+  );
+});
+
+test("rootDirectory contributes only its final app segment", () => {
+  expect(buildEvaSessionUrl("owner", "repo", "session", "apps/admin/web")).toBe(
+    "https://eva.example.com/owner/repo/web/sessions/session",
+  );
+});
+
+test("an empty or trailing-slash rootDirectory keeps the repository route", () => {
+  expect(buildEvaProjectUrl("owner", "repo", "project", "")).toBe(
+    "https://eva.example.com/owner/repo/projects/project",
+  );
+  expect(buildEvaProjectUrl("owner", "repo", "project", "apps/")).toBe(
+    "https://eva.example.com/owner/repo/projects/project",
   );
 });

--- a/packages/backend/tests/previewAnnotationBuildContract.test.ts
+++ b/packages/backend/tests/previewAnnotationBuildContract.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const backendRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const buildSource = readFileSync(
+  join(backendRoot, "scripts/build-annotation-script.mjs"),
+  "utf8",
+);
+const generatedSource = readFileSync(
+  join(
+    backendRoot,
+    "convex/_sandbox_runtime/previewAnnotationScript.generated.ts",
+  ),
+  "utf8",
+);
+const proxySource = readFileSync(
+  join(backendRoot, "convex/_sandbox_runtime/previewProxy.ts"),
+  "utf8",
+);
+const packageJson = readFileSync(join(backendRoot, "package.json"), "utf8");
+
+describe("preview annotation bundle", () => {
+  test("is rebuilt before every backend deploy", () => {
+    expect(packageJson).toContain(
+      '"predeploy": "pnpm run build:callback && pnpm run build:annotation"',
+    );
+  });
+
+  test("typechecks its browser entry before bundling", () => {
+    const typecheckAt = buildSource.indexOf('"tsc", "--noEmit"');
+    const buildAt = buildSource.indexOf("await esbuild.build(");
+    expect(typecheckAt).toBeGreaterThan(-1);
+    expect(buildAt).toBeGreaterThan(typecheckAt);
+  });
+
+  test("rejects external esbuild helper references", () => {
+    expect(buildSource).toContain("__name|__defProp|__spreadValues|__async");
+    expect(buildSource).toContain("process.exit(1)");
+  });
+
+  test("refuses to write a bundle without the ready protocol", () => {
+    expect(buildSource).toContain(
+      'bundled.includes("eva-preview-annotate-ready")',
+    );
+  });
+
+  test("checks in a substantial self-contained protocol bundle", () => {
+    expect(generatedSource.length).toBeGreaterThan(10_000);
+    expect(generatedSource).toContain("eva-preview-annotate-ready");
+    expect(generatedSource).not.toMatch(
+      /\b(__name|__defProp|__spreadValues|__async)\b/,
+    );
+  });
+
+  test("injects the generated bundle rather than stringifying its function", () => {
+    expect(proxySource).toContain(
+      'import { PREVIEW_ANNOTATION_SCRIPT } from "./previewAnnotationScript.generated"',
+    );
+    expect(proxySource).toContain(
+      "const ANNOTATION_SCRIPT = ${JSON.stringify(PREVIEW_ANNOTATION_SCRIPT)}",
+    );
+    expect(proxySource).not.toContain("PREVIEW_ANNOTATION_SCRIPT.toString");
+  });
+});

--- a/packages/backend/tests/prewarmNeverResurrects.test.ts
+++ b/packages/backend/tests/prewarmNeverResurrects.test.ts
@@ -175,6 +175,8 @@ describe("resumeAfterStop call sites", () => {
     "_sandbox_runtime/sessions.ts",
     // ensureSandboxRunning itself: forwards the caller's option.
     "_sandbox_runtime/helpers.ts",
+    // Explicit retention repair cycles a live sandbox to mint a policy-compliant snap.
+    "_sandbox_runtime/bulkSnapshotRetention.ts",
   ];
 
   test("all sit in a file on the allow-list", () => {

--- a/packages/backend/tests/sessionPrLifecycleContract.test.ts
+++ b/packages/backend/tests/sessionPrLifecycleContract.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const source = stripComments(
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../convex/githubWebhook.ts"),
+    "utf8",
+  ),
+);
+const derive = functionBody(source, "function deriveSessionPrState(");
+const handler = definitionBody(source, "handleSessionPrEvent");
+
+describe("session pull-request lifecycle", () => {
+  test("distinguishes merged closes from unmerged closes", () => {
+    expect(derive).toContain('return merged ? "merged" : "closed"');
+  });
+
+  test("maps draft, ready, open and reopen events", () => {
+    expect(derive).toContain('action === "converted_to_draft"');
+    expect(derive).toContain('action === "ready_for_review"');
+    expect(derive).toContain('action === "opened" || action === "reopened"');
+  });
+
+  test("archives both terminal states and unarchives every live state", () => {
+    expect(handler).toContain(
+      'const isTerminal = nextState === "merged" || nextState === "closed"',
+    );
+    expect(handler).toContain(
+      "...(isTerminal ? { archived: true } : { archived: false })",
+    );
+  });
+
+  test("stops a terminal session before scheduling its grace deletion", () => {
+    const stopAt = handler.indexOf("requestSessionSandboxStop(");
+    const deleteAt = handler.indexOf("scheduleSessionSandboxGraceDelete(");
+    expect(stopAt).toBeGreaterThan(-1);
+    expect(deleteAt).toBeGreaterThan(stopAt);
+  });
+
+  test("only schedules deletion for a newly archived session", () => {
+    expect(handler).toContain(
+      "const needsArchive = isTerminal && session.archived !== true",
+    );
+    expect(handler).toContain("if (needsArchive) {");
+  });
+
+  test("reopen cancels an already scheduled deletion", () => {
+    expect(handler).toContain(
+      "const needsUnarchive = !isTerminal && session.archived === true",
+    );
+    expect(handler).toContain("cancelSessionSandboxGraceDelete(");
+  });
+
+  test("merged verification is fenced by PR number and merge SHA", () => {
+    const verifyAt = handler.indexOf("internal.github.verifySessionPrMerged");
+    expect(verifyAt).toBeGreaterThan(-1);
+    const gate = handler.slice(Math.max(0, verifyAt - 500), verifyAt);
+    expect(gate).toContain('nextState === "merged"');
+    expect(gate).toContain("args.prNumber !== undefined");
+    expect(gate).toContain("args.mergeCommitSha !== undefined");
+  });
+});
+
+function definitionBody(input: string, name: string): string {
+  const startAt = input.indexOf(`export const ${name} =`);
+  expect(startAt, `${name} moved or was renamed`).toBeGreaterThan(-1);
+  const endAt = input.indexOf("\n});", startAt);
+  return input.slice(startAt, endAt < 0 ? undefined : endAt);
+}
+
+function functionBody(input: string, declaration: string): string {
+  const startAt = input.indexOf(declaration);
+  expect(startAt, `${declaration} moved or was renamed`).toBeGreaterThan(-1);
+  const endAt = input.indexOf("\n}", startAt);
+  return input.slice(startAt, endAt < 0 ? undefined : endAt);
+}
+
+function stripComments(input: string): string {
+  return input
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[^\S\n]*\/\/.*$/gm, "");
+}

--- a/packages/backend/tests/snapshotPurgeSafety.test.ts
+++ b/packages/backend/tests/snapshotPurgeSafety.test.ts
@@ -64,9 +64,7 @@ describe("purgeUnreferencedVercelSnapshots builds its protected set first", () =
   });
 
   test("only protects sandboxes Eva still references", () => {
-    expect(body).toContain(
-      "internal.repoSnapshots.listReferencedSandboxIds",
-    );
+    expect(body).toContain("internal.repoSnapshots.listReferencedSandboxIds");
     expect(body).toContain("knownSandboxIds.has(sandbox.name)");
   });
 
@@ -124,9 +122,8 @@ describe("keepLastSnapshots is applied wherever a snapshot is written", () => {
     expect(KEEP_LAST_SNAPSHOTS.deleteEvicted).toBe(true);
   });
 
-  test("gives evicted snapshots an explicit TTL", () => {
-    // Inheriting a seed snap's expiration:0 means never-expire storage.
-    expect(KEEP_LAST_SNAPSHOTS.expiration).toBeGreaterThan(0);
+  test("keeps the surviving persistent snapshot alive until entity cleanup", () => {
+    expect(KEEP_LAST_SNAPSHOTS.expiration).toBe(0);
   });
 
   test("only persistent sandboxes get retention at create time", () => {
@@ -139,13 +136,13 @@ describe("keepLastSnapshots is applied wherever a snapshot is written", () => {
   });
 
   /** Vercel rejects any snapshotExpiration between 0 and one day. */
-  test("every create-time TTL is zero or at least a day", () => {
+  test("persistent TTL is zero and every non-zero TTL is at least a day", () => {
     const day = 24 * 60 * 60 * 1000;
     expect(EPHEMERAL_SNAPSHOT_TTL_MS).toBeGreaterThanOrEqual(day);
     for (const persistent of [true, false]) {
-      expect(
-        vercelSnapshotCreateOptions(persistent).snapshotExpiration,
-      ).toBeGreaterThanOrEqual(day);
+      const expiration =
+        vercelSnapshotCreateOptions(persistent).snapshotExpiration;
+      expect(expiration === 0 || expiration >= day).toBe(true);
     }
   });
 
@@ -188,9 +185,9 @@ describe("keepLastSnapshots is applied wherever a snapshot is written", () => {
       providerSource,
       "  private async ensureSnapshotRetention(): Promise<void> {",
     );
-    expect(body).toContain(
-      "this.sandbox.update({ keepLastSnapshots: KEEP_LAST_SNAPSHOTS })",
-    );
+    expect(body).toContain("this.sandbox.update({");
+    expect(body).toContain("snapshotExpiration: 0");
+    expect(body).toContain("keepLastSnapshots: KEEP_LAST_SNAPSHOTS");
   });
 });
 

--- a/packages/backend/tests/systemAutomationLifecycleContract.test.ts
+++ b/packages/backend/tests/systemAutomationLifecycleContract.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const source = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../convex/_automations/systemInstall.ts",
+  ),
+  "utf8",
+);
+const install = definitionBody(source, "installSystemAutomation");
+const uninstall = definitionBody(source, "uninstallSystemAutomation");
+
+describe("system automation install lifecycle", () => {
+  test("authorizes before reading or mutating an install", () => {
+    expect(install.indexOf("authorizeInstall(")).toBeLessThan(
+      install.indexOf("findInstall("),
+    );
+    expect(uninstall.indexOf("authorizeInstall(")).toBeLessThan(
+      uninstall.indexOf("findInstall("),
+    );
+  });
+
+  test("reuses a soft-deleted row instead of duplicating its history", () => {
+    expect(install).toContain("existing?._id ??");
+    expect(install).toContain('ctx.db.insert("automations"');
+  });
+
+  test("preserves a customized schedule when reinstalling", () => {
+    expect(install).toContain(
+      "existing?.cronSchedule || entry.defaultCronSchedule",
+    );
+  });
+
+  test("revives and enables the row before registering its cron", () => {
+    expect(install).toContain("deletedAt: undefined");
+    expect(install).toContain("enabled: true");
+    expect(install).toContain("cronJobId: await safeReplaceCron(");
+  });
+
+  test("uninstall is idempotent for missing or deleted rows", () => {
+    expect(uninstall).toContain(
+      "if (!install || install.deletedAt !== undefined) return null",
+    );
+  });
+
+  test("removes the cron before soft-deleting the row", () => {
+    const deleteCronAt = uninstall.indexOf("safeDeleteCron(");
+    const patchAt = uninstall.indexOf("ctx.db.patch(");
+    expect(deleteCronAt).toBeGreaterThan(-1);
+    expect(patchAt).toBeGreaterThan(deleteCronAt);
+  });
+
+  test("disables without destroying run history or the schedule", () => {
+    expect(uninstall).toContain("enabled: false");
+    expect(uninstall).toContain("cronJobId: undefined");
+    expect(uninstall).toContain("deletedAt: now");
+    expect(uninstall).not.toContain("ctx.db.delete(");
+  });
+});
+
+function definitionBody(input: string, name: string): string {
+  const startAt = input.indexOf(`export const ${name} =`);
+  expect(startAt, `${name} moved or was renamed`).toBeGreaterThan(-1);
+  const endAt = input.indexOf("\n});", startAt);
+  return input.slice(startAt, endAt < 0 ? undefined : endAt);
+}

--- a/packages/ui/src/kibo/kanbanDropTarget.test.ts
+++ b/packages/ui/src/kibo/kanbanDropTarget.test.ts
@@ -72,7 +72,7 @@ test("KanbanBoard applies the drop highlight after the caller's className", () =
   );
   const classNameAt = source.indexOf("        className,");
   const highlightAt = source.indexOf(
-    'isDropTarget && "border-primary/40 bg-primary/10"',
+    'isDropTarget && "border border-primary/40 bg-primary/10"',
   );
   expect(classNameAt, "KanbanBoard's cn() call moved").toBeGreaterThan(-1);
   expect(

--- a/packages/ui/src/utils/useDragSensors.test.ts
+++ b/packages/ui/src/utils/useDragSensors.test.ts
@@ -111,7 +111,8 @@ describe("every shared drag surface uses the split", () => {
 function sensorCall(sensor: string): string {
   const startAt = hook.indexOf(`useSensor(${sensor}`);
   expect(startAt, `${sensor} is no longer armed`).toBeGreaterThan(-1);
-  return hook.slice(startAt, hook.indexOf("),\n", startAt));
+  const nextAt = hook.indexOf("useSensor(", startAt + 1);
+  return hook.slice(startAt, nextAt < 0 ? undefined : nextAt);
 }
 
 function stripComments(source: string): string {


### PR DESCRIPTION
## What changed

- audited the 2026-07-27 through 2026-08-09 history: 472 commits, 183 fix-like commits, 161 exact-title-deduplicated fix subjects, recent PRs, and the daily regression-test automation
- repaired all 18 stale assertions already failing on `main`
- added 79 deterministic regression cases across auth rebinding, session PR/archive lifecycle, system automation reinstall, callback termination, preview annotation bundling, slash-form Eva URLs, snapshot policy, sidebar/session state, quick-task SPA navigation, and desktop ffmpeg/libjack repair
- documented the complete follow-on architecture for Convex mutation integration, callback/process tests, executable Linux runtime contracts, browser component tests, Playwright, disposable GitHub integration, and live Vercel chaos testing

## Why

The daily automation had added useful focused coverage, but the full baseline was still red: 10 backend, 6 web, and 2 UI assertions no longer matched intentional product changes. A permanently red suite cannot distinguish a new regression from accepted drift. This change restores a zero-failure baseline and covers the highest-risk gaps that can be observed deterministically in the repository.

## Impact

The repository now has 804 passing tests across backend, web, and UI. Production behavior is unchanged; this PR updates and expands regression contracts plus the internal test plan and changelog.

## Validation

- `corepack pnpm --filter @eva/backend test` — 608 passed
- `corepack pnpm --filter @eva/web test` — 150 passed
- `corepack pnpm --filter @eva/ui test` — 46 passed
- `corepack pnpm typecheck` — web, backend, and callback TypeScript checks passed
- `git diff --check`
