### PR TITLE
refactor(sandbox): centralize workspace surfaces

### DIFF
--- a/apps/web/src/lib/components/projects/ProjectSandboxPanel.tsx
+++ b/apps/web/src/lib/components/projects/ProjectSandboxPanel.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@eva/backend";
-import type { Id } from "@eva/backend";
+import type { Id, SandboxOwner } from "@eva/backend";
 import {
   isSessionSandboxTab,
   type SandboxTab,
@@ -12,17 +12,8 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { entityPathSegment } from "@/lib/numId";
 import { useRepo } from "@/lib/contexts/RepoContext";
-import { SandboxTabBar } from "@/routes/_repo/$owner/$repo/sessions/_components/SandboxTabBar";
-import { SandboxPaneSlots } from "@/lib/components/sandbox/SandboxPaneSlots";
-import {
-  useSandboxPanes,
-  type SharedTerminalPane,
-} from "@/lib/components/sandbox/useSandboxPanes";
-import { useSandboxPreview } from "@/lib/components/sandbox/useSandboxPreview";
-import { useComputerTab } from "@/lib/components/sandbox/useComputerTab";
-import { useEditorTab } from "@/lib/components/sandbox/useEditorTab";
-import { withBrowserTab } from "@/lib/components/sandbox/withBrowserTab";
-import { FilesPanel } from "@/routes/_repo/$owner/$repo/sessions/FilesPanel";
+import { SandboxWorkspace } from "@/lib/components/sandbox/SandboxWorkspace";
+import type { SharedTerminalPane } from "@/lib/components/sandbox/useSandboxPanes";
 import { toInternalRepoHref } from "@/lib/utils/repoUrl";
 
 interface ProjectSandboxPanelProps {
@@ -59,23 +50,22 @@ export function ProjectSandboxPanel({
   const projectPathSegment = entityPathSegment({ numId: projectNumId });
   const projectIdStr = String(projectId);
 
-  const project = useQuery(api.projects.get, { id: projectId });
-  const setPreviewPath = useMutation(api.projects.setPreviewPath);
-  const setPreviewPort = useMutation(api.projects.setPreviewPort);
-  const setTerminalHistoryTail = useMutation(
-    api.projects.setTerminalHistoryTail,
-  );
-  const releaseBrowserLock = useMutation(api.projects.releaseBrowserLock);
-
-  const activeTab: SandboxTab = sandboxTab;
-
-  // Stable identity: a fresh literal each render would re-run TerminalPanel's
-  // connect effect, flashing the spinner and dropping the dev-server auto-start
-  // (the reconnect sees an existing PTY, so isNewPty is false).
-  const owner = useMemo(
-    () => ({ kind: "project" as const, projectId }),
+  // Deliberate identity memo: terminal connection effects key off this object.
+  const owner = useMemo<SandboxOwner>(
+    () => ({ kind: "project", projectId }),
     [projectId],
   );
+  const viewState = useQuery(api.sandboxPanes.getViewState, { owner });
+  const setPreviewPath = useMutation(api.sandboxPanes.setPreviewPath);
+  const setPreviewPort = useMutation(api.sandboxPanes.setPreviewPort);
+  const setTerminalHistoryTail = useMutation(
+    api.sandboxPanes.setTerminalHistoryTail,
+  );
+  const releaseBrowserLock = useMutation(
+    api.sandboxPanes.releaseBrowserLock,
+  );
+
+  const activeTab: SandboxTab = sandboxTab;
 
   const navigateToSandboxTab = (tab: SandboxTab) => {
     if (tab === "prd" || !projectPathSegment) return;
@@ -97,108 +87,45 @@ export function ProjectSandboxPanel({
     });
   };
 
-  const preview = useSandboxPreview({
-    sandboxId,
-    isActive,
-    repoId,
-    devPort,
-    onPortPersist: (port) => {
-      void setPreviewPort({ id: projectId, port });
-    },
-  });
-
-  const panes = useSandboxPanes({
-    owner,
-    storageScope: `project:${projectIdStr}`,
-    isActive,
-    activeTab,
-    setActiveTab: navigateToSandboxTab,
-    terminalPanes,
-  });
-
   // This surface has no custom tabs, so the tab bar only emits builtin ids.
   const handleTabChange = (tab: string) => {
     if (!isSessionSandboxTab(tab) || tab === "prd") return;
     navigateToSandboxTab(tab);
   };
 
-  const {
-    computerTabOpen,
-    computerRunning,
-    setComputerRunning,
-    openComputer,
-    closeComputer,
-  } = useComputerTab(`project:${projectIdStr}`, activeTab, handleTabChange);
-  const { editorTabOpen, openEditor, closeEditor } = useEditorTab(
-    `project:${projectIdStr}`,
-    activeTab,
-    handleTabChange,
-  );
-
-  const enabledTabs = withBrowserTab(panes.enabledTabs);
-
   return (
-    <div className="h-full flex flex-col">
-      <SandboxTabBar
-        activeTab={activeTab}
-        onTabChange={handleTabChange}
-        onNewPreview={panes.handleNewPreview}
-        onNewTerminal={panes.handleNewTerminal}
-        newPreviewDisabled={panes.newPreviewDisabled}
-        newTerminalDisabled={panes.newTerminalDisabled}
-        enabledTabs={enabledTabs}
-        showFilesTab
-        agentBrowsingAt={project?.agentBrowsingAt}
-        computerTabOpen={computerTabOpen}
-        computerRunning={computerRunning}
-        onOpenComputer={openComputer}
-        onCloseComputer={closeComputer}
-        editorTabOpen={editorTabOpen}
-        onOpenEditor={openEditor}
-        onCloseEditor={closeEditor}
-      />
-      <div className="flex-1 overflow-hidden bg-card">
-        <div className={activeTab === "files" ? "h-full min-h-0" : "hidden"}>
-          <FilesPanel
-            sandboxId={sandboxId}
-            repoId={repoId}
-            isActive={isActive}
-          />
-        </div>
-        <SandboxPaneSlots
-          activeTab={activeTab}
-          panes={panes}
-          preview={preview}
-          owner={owner}
-          sandboxId={sandboxId}
-          isActive={isActive}
-          repoId={repoId}
-          cacheKey={projectIdStr}
-          devCommand={devCommand}
-          prUrl={prUrl}
-          agentBrowsingAt={project?.agentBrowsingAt}
-          onReleaseBrowserLock={() =>
-            void releaseBrowserLock({ id: projectId })
-          }
-          // Backend starts the app in the Console tmux session after startup.
-          runConsoleDevCommandOnConnect={false}
-          onComputerRunningChange={setComputerRunning}
-          onStartSandbox={onStartSandbox}
-          isSandboxStarting={isSandboxStarting}
-          stickyPreviewPath={project?.previewPath}
-          onStickyPreviewPathChange={(path) => {
-            void setPreviewPath({ id: projectId, path });
-          }}
-          stickyTerminalHistoryTail={
-            project === undefined
-              ? undefined
-              : (project?.terminalHistoryTail ?? "")
-          }
-          onStickyTerminalHistoryTailChange={(tail) => {
-            void setTerminalHistoryTail({ id: projectId, tail });
-          }}
-        />
-      </div>
-    </div>
+    <SandboxWorkspace
+      owner={owner}
+      storageScope={`project:${projectIdStr}`}
+      cacheKey={projectIdStr}
+      sandboxId={sandboxId}
+      isActive={isActive}
+      repoId={repoId}
+      prUrl={prUrl}
+      devPort={devPort}
+      devCommand={devCommand}
+      terminalPanes={terminalPanes}
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
+      agentBrowsingAt={viewState?.agentBrowsingAt}
+      onReleaseBrowserLock={() => void releaseBrowserLock({ owner })}
+      onStartSandbox={onStartSandbox}
+      isSandboxStarting={isSandboxStarting}
+      stickyPreviewPath={viewState?.previewPath}
+      onStickyPreviewPathChange={(path) => {
+        void setPreviewPath({ owner, path });
+      }}
+      onPreviewPortPersist={(port) => {
+        void setPreviewPort({ owner, port });
+      }}
+      stickyTerminalHistoryTail={
+        viewState === undefined
+          ? undefined
+          : (viewState?.terminalHistoryTail ?? "")
+      }
+      onStickyTerminalHistoryTailChange={(tail) => {
+        void setTerminalHistoryTail({ owner, tail });
+      }}
+    />
   );
 }

--- a/apps/web/src/lib/components/sandbox/SandboxPaneSlots.tsx
+++ b/apps/web/src/lib/components/sandbox/SandboxPaneSlots.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import type { Doc, Id } from "@eva/backend";
+import type { Doc, Id, SandboxOwner } from "@eva/backend";
 import { cn } from "@eva/ui";
 import { slugifyAppTabName } from "@/lib/utils/appTabSlug";
 import { CustomTabPanel } from "./CustomTabPanel";
 import { TerminalPanel } from "@/routes/_repo/$owner/$repo/sessions/TerminalPanel";
-import type { PtyOwner } from "@/routes/_repo/$owner/$repo/sessions/TerminalPanel";
 import { WebPreviewPanel } from "@/routes/_repo/$owner/$repo/sessions/WebPreviewPanel";
 import { EditorPanel } from "@/routes/_repo/$owner/$repo/sessions/EditorPanel";
 import { DesktopPanel } from "@/routes/_repo/$owner/$repo/sessions/DesktopPanel";
@@ -21,7 +20,7 @@ interface SandboxPaneSlotsProps {
   activeTab: string;
   panes: SandboxPanesApi;
   preview: SandboxPreviewApi;
-  owner: PtyOwner;
+  owner: SandboxOwner;
   sandboxId: string | undefined;
   isActive: boolean;
   repoId: Id<"githubRepos">;

--- a/apps/web/src/lib/components/sandbox/SandboxWorkspace.tsx
+++ b/apps/web/src/lib/components/sandbox/SandboxWorkspace.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { Doc, Id, SandboxOwner } from "@eva/backend";
+import { isSessionSandboxTab } from "@/lib/search-params";
+import { FilesPanel } from "@/routes/_repo/$owner/$repo/sessions/FilesPanel";
+import { SandboxTabBar } from "@/routes/_repo/$owner/$repo/sessions/_components/SandboxTabBar";
+import { SandboxPaneSlots } from "./SandboxPaneSlots";
+import {
+  useSandboxPanes,
+  type SharedTerminalPane,
+} from "./useSandboxPanes";
+import {
+  useSandboxPreview,
+  type SandboxPreviewApi,
+} from "./useSandboxPreview";
+import { useComputerTab } from "./useComputerTab";
+import { useEditorTab } from "./useEditorTab";
+import { withBrowserTab } from "./withBrowserTab";
+
+interface OptionalTabCapability {
+  hasContent: boolean;
+}
+
+interface SandboxWorkspaceExtensions {
+  plan?: OptionalTabCapability;
+  designs?: OptionalTabCapability;
+  customTabs?: ReadonlyArray<Doc<"appTabs">>;
+  renderPanes?: (preview: SandboxPreviewApi) => ReactNode;
+}
+
+interface SandboxWorkspaceProps {
+  owner: SandboxOwner;
+  storageScope: string;
+  cacheKey: string;
+  sandboxId: string | undefined;
+  isActive: boolean;
+  isRouteActive?: boolean;
+  repoId: Id<"githubRepos">;
+  prUrl?: string;
+  devPort?: number;
+  devCommand?: string;
+  terminalPanes?: SharedTerminalPane[];
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+  agentBrowsingAt?: number;
+  onReleaseBrowserLock?: () => void;
+  onStartSandbox?: () => void;
+  isSandboxStarting?: boolean;
+  stickyPreviewPath?: string;
+  onStickyPreviewPathChange?: (path: string) => void;
+  onPreviewPortPersist?: (port: number) => void;
+  stickyTerminalHistoryTail?: string;
+  onStickyTerminalHistoryTailChange?: (tail: string) => void;
+  onAnnotationSubmit?: (display: string, full: string) => Promise<void>;
+  extensions?: SandboxWorkspaceExtensions;
+}
+
+/**
+ * The common sandbox workspace used by sessions, quick tasks, and projects.
+ * Owner-specific surfaces provide lifecycle actions and optional tab panes;
+ * preview, files, PTYs, browser/computer, editor, and review live here once.
+ */
+export function SandboxWorkspace({
+  owner,
+  storageScope,
+  cacheKey,
+  sandboxId,
+  isActive,
+  isRouteActive = true,
+  repoId,
+  prUrl,
+  devPort,
+  devCommand,
+  terminalPanes,
+  activeTab,
+  onTabChange,
+  agentBrowsingAt,
+  onReleaseBrowserLock,
+  onStartSandbox,
+  isSandboxStarting,
+  stickyPreviewPath,
+  onStickyPreviewPathChange,
+  onPreviewPortPersist,
+  stickyTerminalHistoryTail,
+  onStickyTerminalHistoryTailChange,
+  onAnnotationSubmit,
+  extensions,
+}: SandboxWorkspaceProps) {
+  const preview = useSandboxPreview({
+    sandboxId,
+    isActive,
+    isRouteActive,
+    repoId,
+    devPort,
+    onPortPersist: onPreviewPortPersist,
+  });
+  const panes = useSandboxPanes({
+    owner,
+    storageScope,
+    isActive,
+    activeTab: isSessionSandboxTab(activeTab) ? activeTab : null,
+    setActiveTab: onTabChange,
+    terminalPanes,
+  });
+  const {
+    computerTabOpen,
+    computerRunning,
+    setComputerRunning,
+    openComputer,
+    closeComputer,
+  } = useComputerTab(storageScope, activeTab, onTabChange);
+  const { editorTabOpen, openEditor, closeEditor } = useEditorTab(
+    storageScope,
+    activeTab,
+    onTabChange,
+  );
+  const enabledTabs = withBrowserTab(panes.enabledTabs);
+
+  return (
+    <div className="flex h-full flex-col">
+      <SandboxTabBar
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        onNewPreview={panes.handleNewPreview}
+        onNewTerminal={panes.handleNewTerminal}
+        newPreviewDisabled={panes.newPreviewDisabled}
+        newTerminalDisabled={panes.newTerminalDisabled}
+        enabledTabs={enabledTabs}
+        showPrdTab={extensions?.plan !== undefined}
+        hasPrdContent={extensions?.plan?.hasContent}
+        showDesignsTab={extensions?.designs !== undefined}
+        hasDesignsContent={extensions?.designs?.hasContent}
+        showFilesTab
+        customTabs={extensions?.customTabs}
+        agentBrowsingAt={agentBrowsingAt}
+        computerTabOpen={computerTabOpen}
+        computerRunning={computerRunning}
+        onOpenComputer={openComputer}
+        onCloseComputer={closeComputer}
+        editorTabOpen={editorTabOpen}
+        onOpenEditor={openEditor}
+        onCloseEditor={closeEditor}
+        hotkeysEnabled={isRouteActive}
+      />
+      <div className="flex-1 overflow-hidden bg-card">
+        {extensions?.renderPanes?.(preview)}
+        <div className={activeTab === "files" ? "h-full min-h-0" : "hidden"}>
+          <FilesPanel
+            sandboxId={sandboxId}
+            repoId={repoId}
+            isActive={isActive}
+          />
+        </div>
+        <SandboxPaneSlots
+          activeTab={activeTab}
+          panes={panes}
+          preview={preview}
+          owner={owner}
+          sandboxId={sandboxId}
+          isActive={isActive}
+          repoId={repoId}
+          cacheKey={cacheKey}
+          devCommand={devCommand}
+          prUrl={prUrl}
+          customTabs={extensions?.customTabs}
+          agentBrowsingAt={agentBrowsingAt}
+          onReleaseBrowserLock={onReleaseBrowserLock}
+          runConsoleDevCommandOnConnect={false}
+          onComputerRunningChange={setComputerRunning}
+          onStartSandbox={onStartSandbox}
+          isSandboxStarting={isSandboxStarting}
+          onAnnotationSubmit={onAnnotationSubmit}
+          stickyPreviewPath={stickyPreviewPath}
+          onStickyPreviewPathChange={onStickyPreviewPathChange}
+          stickyTerminalHistoryTail={stickyTerminalHistoryTail}
+          onStickyTerminalHistoryTailChange={
+            onStickyTerminalHistoryTailChange
+          }
+          consoleHotkeyEnabled={isRouteActive}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/components/sandbox/previewConsoleLaunchContract.test.ts
+++ b/apps/web/src/lib/components/sandbox/previewConsoleLaunchContract.test.ts
@@ -6,18 +6,22 @@ import { expect, test } from "vitest";
 const here = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Backend owns Preview Console launch; panels must not re-enable connect-time
- * auto-type (reconnect sees an existing tmux session and skips forever).
+ * Backend owns Preview Console launch. The shared workspace must keep that
+ * policy centralized so one owner surface cannot drift from the others.
  */
-test("session, task, and project sandbox panels disable console auto-type", () => {
+test("the shared sandbox workspace disables console auto-type once", () => {
+  const workspace = readFileSync(join(here, "SandboxWorkspace.tsx"), "utf8");
+  expect(workspace).toContain("runConsoleDevCommandOnConnect={false}");
+
   const panels = [
     join(here, "../../../routes/_repo/$owner/$repo/sessions/SandboxPanel.tsx"),
     join(here, "../tasks/TaskSandboxPanel.tsx"),
     join(here, "../projects/ProjectSandboxPanel.tsx"),
   ];
   for (const path of panels) {
-    expect(readFileSync(path, "utf8")).toContain(
-      "runConsoleDevCommandOnConnect={false}",
-    );
+    const panel = readFileSync(path, "utf8");
+    expect(panel).toContain("<SandboxWorkspace");
+    expect(panel).not.toContain("<SandboxPaneSlots");
+    expect(panel).not.toContain("<SandboxTabBar");
   }
 });

--- a/apps/web/src/lib/components/sandbox/useSandboxPanes.ts
+++ b/apps/web/src/lib/components/sandbox/useSandboxPanes.ts
@@ -3,9 +3,8 @@
 import { useEffect } from "react";
 import { useAction, useMutation } from "convex/react";
 import { api } from "@eva/backend";
-import type { Doc } from "@eva/backend";
+import type { Doc, SandboxOwner } from "@eva/backend";
 import { useLocalStorage } from "usehooks-ts";
-import type { PtyOwner } from "@/routes/_repo/$owner/$repo/sessions/TerminalPanel";
 import type { SandboxTab } from "@/lib/search-params";
 
 const MAX_TERMINAL_PANES = 8;
@@ -60,7 +59,7 @@ export interface SandboxPanesApi {
 }
 
 interface UseSandboxPanesArgs {
-  owner: PtyOwner;
+  owner: SandboxOwner;
   /**
    * Full localStorage namespace for pane state — e.g. `session:<id>` or
    * `task:<id>`. Final keys: `eva:<storageScope>:previews` and

--- a/apps/web/src/lib/components/tasks/TaskSandboxPanel.tsx
+++ b/apps/web/src/lib/components/tasks/TaskSandboxPanel.tsx
@@ -3,19 +3,10 @@
 import { useEffect, useMemo } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@eva/backend";
-import type { Id } from "@eva/backend";
+import type { Id, SandboxOwner } from "@eva/backend";
 import { isSessionSandboxTab, type SandboxTab } from "@/lib/search-params";
-import { SandboxTabBar } from "@/routes/_repo/$owner/$repo/sessions/_components/SandboxTabBar";
-import { SandboxPaneSlots } from "@/lib/components/sandbox/SandboxPaneSlots";
-import {
-  useSandboxPanes,
-  type SharedTerminalPane,
-} from "@/lib/components/sandbox/useSandboxPanes";
-import { useSandboxPreview } from "@/lib/components/sandbox/useSandboxPreview";
-import { useComputerTab } from "@/lib/components/sandbox/useComputerTab";
-import { useEditorTab } from "@/lib/components/sandbox/useEditorTab";
-import { withBrowserTab } from "@/lib/components/sandbox/withBrowserTab";
-import { FilesPanel } from "@/routes/_repo/$owner/$repo/sessions/FilesPanel";
+import { SandboxWorkspace } from "@/lib/components/sandbox/SandboxWorkspace";
+import type { SharedTerminalPane } from "@/lib/components/sandbox/useSandboxPanes";
 
 interface TaskSandboxPanelProps {
   taskId: Id<"agentTasks">;
@@ -65,37 +56,20 @@ export function TaskSandboxPanel({
 }: TaskSandboxPanelProps) {
   const taskIdStr = String(taskId);
 
-  const task = useQuery(api.agentTasks.get, { id: taskId });
-  const setPreviewPath = useMutation(api.agentTasks.setPreviewPath);
-  const setPreviewPort = useMutation(api.agentTasks.setPreviewPort);
-  const setTerminalHistoryTail = useMutation(
-    api.agentTasks.setTerminalHistoryTail,
+  // Deliberate identity memo: terminal connection effects key off this object.
+  const owner = useMemo<SandboxOwner>(
+    () => ({ kind: "task", taskId }),
+    [taskId],
   );
-  const releaseBrowserLock = useMutation(api.agentTasks.releaseBrowserLock);
-
-  // Stable identity: a fresh literal each render would re-run TerminalPanel's
-  // connect effect, flashing the spinner and dropping the dev-server auto-start
-  // (the reconnect sees an existing PTY, so isNewPty is false).
-  const owner = useMemo(() => ({ kind: "task" as const, taskId }), [taskId]);
-
-  const preview = useSandboxPreview({
-    sandboxId,
-    isActive,
-    repoId,
-    devPort,
-    onPortPersist: (port) => {
-      void setPreviewPort({ id: taskId, port });
-    },
-  });
-
-  const panes = useSandboxPanes({
-    owner,
-    storageScope: `task:${taskIdStr}`,
-    isActive,
-    activeTab,
-    setActiveTab: onTabChange,
-    terminalPanes,
-  });
+  const viewState = useQuery(api.sandboxPanes.getViewState, { owner });
+  const setPreviewPath = useMutation(api.sandboxPanes.setPreviewPath);
+  const setPreviewPort = useMutation(api.sandboxPanes.setPreviewPort);
+  const setTerminalHistoryTail = useMutation(
+    api.sandboxPanes.setTerminalHistoryTail,
+  );
+  const releaseBrowserLock = useMutation(
+    api.sandboxPanes.releaseBrowserLock,
+  );
 
   useEffect(() => {
     if (activeTab !== "prd") return;
@@ -110,79 +84,39 @@ export function TaskSandboxPanel({
     onTabChange(tab);
   };
 
-  const {
-    computerTabOpen,
-    computerRunning,
-    setComputerRunning,
-    openComputer,
-    closeComputer,
-  } = useComputerTab(`task:${taskIdStr}`, tabBarValue, handleTabChange);
-  const { editorTabOpen, openEditor, closeEditor } = useEditorTab(
-    `task:${taskIdStr}`,
-    tabBarValue,
-    handleTabChange,
-  );
-
-  const enabledTabs = withBrowserTab(panes.enabledTabs);
-
   return (
-    <div className="h-full flex flex-col">
-      <SandboxTabBar
-        activeTab={tabBarValue}
-        onTabChange={handleTabChange}
-        onNewPreview={panes.handleNewPreview}
-        onNewTerminal={panes.handleNewTerminal}
-        newPreviewDisabled={panes.newPreviewDisabled}
-        newTerminalDisabled={panes.newTerminalDisabled}
-        enabledTabs={enabledTabs}
-        showFilesTab
-        agentBrowsingAt={task?.agentBrowsingAt}
-        computerTabOpen={computerTabOpen}
-        computerRunning={computerRunning}
-        onOpenComputer={openComputer}
-        onCloseComputer={closeComputer}
-        editorTabOpen={editorTabOpen}
-        onOpenEditor={openEditor}
-        onCloseEditor={closeEditor}
-      />
-      <div className="flex-1 overflow-hidden bg-card">
-        <div className={tabBarValue === "files" ? "h-full min-h-0" : "hidden"}>
-          <FilesPanel
-            sandboxId={sandboxId}
-            repoId={repoId}
-            isActive={isActive}
-          />
-        </div>
-        <SandboxPaneSlots
-          activeTab={tabBarValue}
-          panes={panes}
-          preview={preview}
-          owner={owner}
-          sandboxId={sandboxId}
-          isActive={isActive}
-          repoId={repoId}
-          cacheKey={taskIdStr}
-          devCommand={devCommand}
-          prUrl={prUrl}
-          agentBrowsingAt={task?.agentBrowsingAt}
-          onReleaseBrowserLock={() => void releaseBrowserLock({ id: taskId })}
-          // Backend starts the app in the Console tmux session after startup.
-          runConsoleDevCommandOnConnect={false}
-          onComputerRunningChange={setComputerRunning}
-          onStartSandbox={onStartSandbox}
-          isSandboxStarting={isSandboxStarting}
-          stickyPreviewPath={task?.previewPath}
-          onStickyPreviewPathChange={(path) => {
-            void setPreviewPath({ id: taskId, path });
-          }}
-          stickyTerminalHistoryTail={
-            task === undefined ? undefined : (task?.terminalHistoryTail ?? "")
-          }
-          onStickyTerminalHistoryTailChange={(tail) => {
-            void setTerminalHistoryTail({ id: taskId, tail });
-          }}
-        />
-      </div>
-    </div>
+    <SandboxWorkspace
+      owner={owner}
+      storageScope={`task:${taskIdStr}`}
+      cacheKey={taskIdStr}
+      sandboxId={sandboxId}
+      isActive={isActive}
+      repoId={repoId}
+      devPort={devPort}
+      devCommand={devCommand}
+      terminalPanes={terminalPanes}
+      prUrl={prUrl}
+      activeTab={tabBarValue}
+      onTabChange={handleTabChange}
+      agentBrowsingAt={viewState?.agentBrowsingAt}
+      onReleaseBrowserLock={() => void releaseBrowserLock({ owner })}
+      onStartSandbox={onStartSandbox}
+      isSandboxStarting={isSandboxStarting}
+      stickyPreviewPath={viewState?.previewPath}
+      onStickyPreviewPathChange={(path) => {
+        void setPreviewPath({ owner, path });
+      }}
+      onPreviewPortPersist={(port) => {
+        void setPreviewPort({ owner, port });
+      }}
+      stickyTerminalHistoryTail={
+        viewState === undefined
+          ? undefined
+          : (viewState?.terminalHistoryTail ?? "")
+      }
+      onStickyTerminalHistoryTailChange={(tail) => {
+        void setTerminalHistoryTail({ owner, tail });
+      }}
+    />
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/SandboxPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/SandboxPanel.tsx
@@ -1,22 +1,18 @@
 import { useEffect, useMemo } from "react";
 import { useMutation, useQuery } from "convex/react";
-import { api, normalizeAIModel, type Id } from "@eva/backend";
+import {
+  api,
+  normalizeAIModel,
+  type Id,
+  type SandboxOwner,
+} from "@eva/backend";
 import { isSessionSandboxTab } from "@/lib/search-params";
 import { slugifyAppTabName } from "@/lib/utils/appTabSlug";
 import { IconClipboardList } from "@tabler/icons-react";
-import { SandboxTabBar } from "./_components/SandboxTabBar";
 import { SessionPrdPlanView } from "./_components/SessionPrdPlanView";
 import { DesignVariationsPanel } from "./_components/DesignVariationsPanel";
-import { FilesPanel } from "./FilesPanel";
-import { SandboxPaneSlots } from "@/lib/components/sandbox/SandboxPaneSlots";
-import {
-  useSandboxPanes,
-  type SharedTerminalPane,
-} from "@/lib/components/sandbox/useSandboxPanes";
-import { useSandboxPreview } from "@/lib/components/sandbox/useSandboxPreview";
-import { useComputerTab } from "@/lib/components/sandbox/useComputerTab";
-import { useEditorTab } from "@/lib/components/sandbox/useEditorTab";
-import { withBrowserTab } from "@/lib/components/sandbox/withBrowserTab";
+import { SandboxWorkspace } from "@/lib/components/sandbox/SandboxWorkspace";
+import type { SharedTerminalPane } from "@/lib/components/sandbox/useSandboxPanes";
 import { useSessionModel } from "@/lib/hooks/useSessionModel";
 import { useRepo } from "@/lib/contexts/RepoContext";
 import { useSessionAnnotationSend } from "./_components/useSessionAnnotationSend";
@@ -26,14 +22,12 @@ import {
 } from "./_utils/designVariations";
 import { isAssistantTurnInProgress } from "@/lib/components/chat/chatBodyUtils";
 import type { SessionMode } from "@/lib/hooks/useSessionSettings";
+
 interface SandboxPanelProps {
   sessionId: Id<"sessions">;
   sandboxId: string | undefined;
   isActive: boolean;
-  /**
-   * False while another session is shown but this shell stays mounted.
-   * Preview freezes instead of clearing on shared URL search churn.
-   */
+  /** False while another kept-alive session shell is visible. */
   isRouteActive?: boolean;
   repoId: Id<"githubRepos">;
   prUrl?: string;
@@ -45,13 +39,13 @@ interface SandboxPanelProps {
   lastMode?: SessionMode;
   selectedVariationIndex?: number;
   isArchived?: boolean;
-  /** Builtin tab id (SandboxTab) or a custom tab's name slug. */
   activeTab: string;
   onTabChange: (tab: string) => void;
   agentBrowsingAt?: number;
   onStartSandbox?: () => void;
   isSandboxStarting?: boolean;
 }
+
 export function SandboxPanel({
   sessionId,
   sandboxId,
@@ -85,56 +79,23 @@ export function SandboxPanel({
   const showDesignsTab = lastMode === "design" || latestVariations.length > 0;
   const hasDesignsContent = latestVariations.length > 0;
   const isDesignExecuting = isAssistantTurnInProgress(messages);
-  // Sticky Preview path/port + console tail (same sessions.get as the shell).
-  const session = useQuery(api.sessions.get, { id: sessionId });
-  const setPreviewPath = useMutation(api.sessions.setPreviewPath);
-  const setPreviewPort = useMutation(api.sessions.setPreviewPort);
-  const setTerminalHistoryTail = useMutation(
-    api.sessions.setTerminalHistoryTail,
-  );
-  const releaseBrowserLock = useMutation(api.sessions.releaseBrowserLock);
-  // Stable identity: a fresh literal each render would re-run TerminalPanel's
-  // connect effect, flashing the spinner and dropping the dev-server auto-start
-  // (the reconnect sees an existing PTY, so isNewPty is false).
-  const owner = useMemo(
-    () => ({ kind: "session" as const, sessionId }),
+  // Deliberate identity memo: cached session terminal effects key off this object.
+  const owner = useMemo<SandboxOwner>(
+    () => ({ kind: "session", sessionId }),
     [sessionId],
   );
-  const preview = useSandboxPreview({
-    sandboxId,
-    isActive,
-    isRouteActive,
-    repoId,
-    devPort,
-    onPortPersist: (port) => {
-      void setPreviewPort({ id: sessionId, port });
-    },
-  });
-  const panes = useSandboxPanes({
-    owner,
-    storageScope: `session:${sessionIdStr}`,
-    isActive,
-    activeTab: isSessionSandboxTab(activeTab) ? activeTab : null,
-    setActiveTab: onTabChange,
-    terminalPanes,
-  });
-  const {
-    computerTabOpen,
-    computerRunning,
-    setComputerRunning,
-    openComputer,
-    closeComputer,
-  } = useComputerTab(`session:${sessionIdStr}`, activeTab, onTabChange);
-  const { editorTabOpen, openEditor, closeEditor } = useEditorTab(
-    `session:${sessionIdStr}`,
-    activeTab,
-    onTabChange,
+  const viewState = useQuery(api.sandboxPanes.getViewState, { owner });
+  const setPreviewPath = useMutation(api.sandboxPanes.setPreviewPath);
+  const setPreviewPort = useMutation(api.sandboxPanes.setPreviewPort);
+  const setTerminalHistoryTail = useMutation(
+    api.sandboxPanes.setTerminalHistoryTail,
   );
-  // User-defined tabs for this app, in display order, enabled only.
+  const releaseBrowserLock = useMutation(
+    api.sandboxPanes.releaseBrowserLock,
+  );
   const allCustomTabs = useQuery(api.appTabs.list, { repoId });
   const customTabs = (allCustomTabs ?? []).filter((tab) => tab.enabled);
-  // If the URL points at a custom tab that no longer exists (deleted / disabled /
-  // renamed), fall back to preview. Wait for the query to load before deciding.
+
   useEffect(() => {
     if (isSessionSandboxTab(activeTab)) return;
     if (allCustomTabs === undefined) return;
@@ -142,128 +103,108 @@ export function SandboxPanel({
       onTabChange("preview");
     }
   }, [activeTab, allCustomTabs, customTabs, onTabChange]);
-  const enabledTabs = withBrowserTab(panes.enabledTabs);
-  const previewUrl = preview.previewInfo?.url ?? null;
+
   return (
-    <div className="h-full flex flex-col">
-      <SandboxTabBar
-        activeTab={activeTab}
-        onTabChange={onTabChange}
-        onNewPreview={panes.handleNewPreview}
-        onNewTerminal={panes.handleNewTerminal}
-        newPreviewDisabled={panes.newPreviewDisabled}
-        newTerminalDisabled={panes.newTerminalDisabled}
-        enabledTabs={enabledTabs}
-        showPrdTab
-        hasPrdContent={
-          typeof planContent === "string" && planContent.trim().length > 0
-        }
-        showDesignsTab={showDesignsTab}
-        hasDesignsContent={hasDesignsContent}
-        showFilesTab
-        customTabs={customTabs}
-        agentBrowsingAt={agentBrowsingAt}
-        computerTabOpen={computerTabOpen}
-        computerRunning={computerRunning}
-        onOpenComputer={openComputer}
-        onCloseComputer={closeComputer}
-        editorTabOpen={editorTabOpen}
-        onOpenEditor={openEditor}
-        onCloseEditor={closeEditor}
-        hotkeysEnabled={isRouteActive}
-      />
-      <div className="flex-1 overflow-hidden bg-card">
-        <div
-          className={
-            activeTab === "prd"
-              ? "flex h-full min-h-0 flex-col overflow-hidden"
-              : "hidden"
-          }
-        >
-          {planContent ? (
-            <SessionPrdPlanView
-              sessionId={sessionId}
-              planContent={planContent}
-              onApprovePlan={() => setMode("edit")}
-              variant="panel"
-              isArchived={isArchived}
-            />
-          ) : (
-            <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
-              <IconClipboardList className="h-10 w-10 text-muted-foreground/60" />
-              <div className="max-w-md space-y-1">
-                <p className="text-sm font-medium">No plan yet</p>
-                <p className="text-sm text-muted-foreground">
-                  Switch the composer to Plan mode and describe what you want to
-                  build — the plan will appear here once generated.
-                </p>
-              </div>
+    <SandboxWorkspace
+      owner={owner}
+      storageScope={`session:${sessionIdStr}`}
+      cacheKey={sessionIdStr}
+      sandboxId={sandboxId}
+      isActive={isActive}
+      isRouteActive={isRouteActive}
+      repoId={repoId}
+      prUrl={prUrl}
+      devPort={devPort}
+      devCommand={devCommand}
+      terminalPanes={terminalPanes}
+      activeTab={activeTab}
+      onTabChange={onTabChange}
+      agentBrowsingAt={agentBrowsingAt}
+      onReleaseBrowserLock={() => void releaseBrowserLock({ owner })}
+      onStartSandbox={onStartSandbox}
+      isSandboxStarting={isSandboxStarting}
+      stickyPreviewPath={viewState?.previewPath}
+      onStickyPreviewPathChange={(path) => {
+        void setPreviewPath({ owner, path });
+      }}
+      onPreviewPortPersist={(port) => {
+        void setPreviewPort({ owner, port });
+      }}
+      stickyTerminalHistoryTail={
+        viewState === undefined
+          ? undefined
+          : (viewState?.terminalHistoryTail ?? "")
+      }
+      onStickyTerminalHistoryTailChange={(tail) => {
+        void setTerminalHistoryTail({ owner, tail });
+      }}
+      onAnnotationSubmit={submitAnnotation}
+      extensions={{
+        plan: {
+          hasContent:
+            typeof planContent === "string" && planContent.trim().length > 0,
+        },
+        ...(showDesignsTab
+          ? { designs: { hasContent: hasDesignsContent } }
+          : {}),
+        customTabs,
+        renderPanes: (preview) => (
+          <>
+            <div
+              className={
+                activeTab === "prd"
+                  ? "flex h-full min-h-0 flex-col overflow-hidden"
+                  : "hidden"
+              }
+            >
+              {planContent ? (
+                <SessionPrdPlanView
+                  sessionId={sessionId}
+                  planContent={planContent}
+                  onApprovePlan={() => setMode("edit")}
+                  variant="panel"
+                  isArchived={isArchived}
+                />
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+                  <IconClipboardList className="h-10 w-10 text-muted-foreground/60" />
+                  <div className="max-w-md space-y-1">
+                    <p className="text-sm font-medium">No plan yet</p>
+                    <p className="text-sm text-muted-foreground">
+                      Switch the composer to Plan mode and describe what you
+                      want to build; the plan will appear here once generated.
+                    </p>
+                  </div>
+                </div>
+              )}
             </div>
-          )}
-        </div>
-        <div
-          className={
-            activeTab === "designs"
-              ? "flex h-full min-h-0 flex-col overflow-hidden"
-              : "hidden"
-          }
-        >
-          <DesignVariationsPanel
-            previewUrl={previewUrl}
-            sandboxRunning={isActive}
-            isArchived={isArchived === true}
-            isExecuting={isDesignExecuting}
-            latestVariations={latestVariations}
-            selectedVariationIndex={selectedVariationIndex}
-            isSandboxStarting={isSandboxStarting === true}
-            onStartSandbox={() => onStartSandbox?.()}
-            onSelectVariation={(index) => {
-              void selectVariation({ id: sessionId, variationIndex: index });
-            }}
-          />
-        </div>
-        <div className={activeTab === "files" ? "h-full min-h-0" : "hidden"}>
-          <FilesPanel
-            sandboxId={sandboxId}
-            repoId={repoId}
-            isActive={isActive}
-          />
-        </div>
-        <SandboxPaneSlots
-          activeTab={activeTab}
-          panes={panes}
-          preview={preview}
-          owner={owner}
-          sandboxId={sandboxId}
-          isActive={isActive}
-          repoId={repoId}
-          cacheKey={sessionIdStr}
-          devCommand={devCommand}
-          prUrl={prUrl}
-          customTabs={customTabs}
-          agentBrowsingAt={agentBrowsingAt}
-          onReleaseBrowserLock={() => void releaseBrowserLock({ sessionId })}
-          // Backend starts the app in the Console tmux session after startup.
-          runConsoleDevCommandOnConnect={false}
-          onComputerRunningChange={setComputerRunning}
-          onStartSandbox={onStartSandbox}
-          isSandboxStarting={isSandboxStarting}
-          onAnnotationSubmit={submitAnnotation}
-          stickyPreviewPath={session?.previewPath}
-          onStickyPreviewPathChange={(path) => {
-            void setPreviewPath({ id: sessionId, path });
-          }}
-          stickyTerminalHistoryTail={
-            session === undefined
-              ? undefined
-              : (session?.terminalHistoryTail ?? "")
-          }
-          onStickyTerminalHistoryTailChange={(tail) => {
-            void setTerminalHistoryTail({ id: sessionId, tail });
-          }}
-          consoleHotkeyEnabled={isRouteActive}
-        />
-      </div>
-    </div>
+            <div
+              className={
+                activeTab === "designs"
+                  ? "flex h-full min-h-0 flex-col overflow-hidden"
+                  : "hidden"
+              }
+            >
+              <DesignVariationsPanel
+                previewUrl={preview.previewInfo?.url ?? null}
+                sandboxRunning={isActive}
+                isArchived={isArchived === true}
+                isExecuting={isDesignExecuting}
+                latestVariations={latestVariations}
+                selectedVariationIndex={selectedVariationIndex}
+                isSandboxStarting={isSandboxStarting === true}
+                onStartSandbox={() => onStartSandbox?.()}
+                onSelectVariation={(index) => {
+                  void selectVariation({
+                    id: sessionId,
+                    variationIndex: index,
+                  });
+                }}
+              />
+            </div>
+          </>
+        ),
+      }}
+    />
   );
 }

--- a/apps/web/src/routes/_repo/$owner/$repo/sessions/TerminalPanel.tsx
+++ b/apps/web/src/routes/_repo/$owner/$repo/sessions/TerminalPanel.tsx
@@ -3,7 +3,7 @@ import { Button, Spinner } from "@eva/ui";
 import { IconRefresh, IconTerminal2 } from "@tabler/icons-react";
 import { useAction } from "convex/react";
 import { api } from "@eva/backend";
-import type { Id } from "@eva/backend";
+import type { SandboxOwner } from "@eva/backend";
 import { useSessionStorage } from "usehooks-ts";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -27,13 +27,8 @@ import {
  * or a project. The PTY backend resolves the sandbox and repo from whichever
  * is provided.
  */
-export type PtyOwner =
-  | { kind: "session"; sessionId: Id<"sessions"> }
-  | { kind: "task"; taskId: Id<"agentTasks"> }
-  | { kind: "project"; projectId: Id<"projects"> };
-
 interface TerminalPanelProps {
-  owner: PtyOwner;
+  owner: SandboxOwner;
   sandboxId: string | undefined;
   isActive: boolean;
   ptyInstanceId: string;

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## One sandbox workspace for sessions, quick tasks, and projects - 2026-08-08
+
+Sessions, quick tasks, and projects rendered the same sandbox tabs through three separate orchestrators, and each surface called its own copies of the sticky preview, terminal-history, and browser-lock APIs. The shared hooks prevented some drift, but a feature or correctness fix still had to be wired through every panel independently.
+
+\SandboxWorkspace\ now owns Preview, Browser, Editor, Terminal, Computer, Review, Files, pane persistence, preview resolution, and console policy once. The three owner panels are thin compositions; sessions supply Plan, Designs, custom app tabs, annotations, and kept-alive behavior through typed extensions rather than a second sandbox implementation.
+
+The backend now exports one validator-derived \SandboxOwner\ contract and one authorization resolver for sessions, tasks, and projects. PTYs, terminal panes, sticky view state, and browser takeover share it. Existing entity-specific mutations remain available as compatibility APIs, so this release centralizes behavior without changing URLs or migrating persisted sandbox fields. Moving those fields into a dedicated table remains a later widen/backfill/cutover/narrow deployment.
+
+Verified: backend and web TypeScript checks clean; focused web and backend centralization contracts pass. React Doctor scored the changed web files 85/100; its three manual-memoization warnings are intentional identity guarantees for owner objects consumed by connection effects, while the restricted-import and effect-dependency findings predate this change. The full web test command still has the six pre-existing light \surfaceTokens.test.ts\ failures on \main\. Convex codegen also remains blocked by the pre-existing \pty.js: l is not a function\ deployment analysis failure.
+
 ## Two-week regression hardening - 2026-08-09
 
 Audited 472 commits from July 27 through August 9, grouped 183 fix-like commits into regression families, repaired all 18 stale tests on `main`, and added 79 deterministic cases for auth rebinding, PR/archive lifecycle, automation reinstall, callback termination, preview annotation bundling, slash-form URLs, snapshot policy, session navigation/state, and desktop media tooling.

--- a/packages/backend/convex/_pty/owners.ts
+++ b/packages/backend/convex/_pty/owners.ts
@@ -1,27 +1,17 @@
-import { v } from "convex/values";
 import type { ActionCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
+import {
+  sandboxOwnerValidator,
+  type SandboxOwner,
+} from "../_sandbox/owner";
 
 /**
  * Discriminated owner — a PTY belongs to a session, a quick task, or a project.
  * All expose a sandbox and a repo; sessions additionally track a default
  * `ptySessionId` for the legacy single-terminal flow.
  */
-export const ownerArg = v.union(
-  v.object({
-    kind: v.literal("session"),
-    sessionId: v.id("sessions"),
-  }),
-  v.object({
-    kind: v.literal("task"),
-    taskId: v.id("agentTasks"),
-  }),
-  v.object({
-    kind: v.literal("project"),
-    projectId: v.id("projects"),
-  }),
-);
+export const ownerArg = sandboxOwnerValidator;
 
 export interface ResolvedOwner {
   sandboxId: string;
@@ -48,10 +38,7 @@ function isStoppingOrClosed(status: string | undefined): boolean {
 
 export async function resolveOwner(
   ctx: ActionCtx,
-  owner:
-    | { kind: "session"; sessionId: Id<"sessions"> }
-    | { kind: "task"; taskId: Id<"agentTasks"> }
-    | { kind: "project"; projectId: Id<"projects"> },
+  owner: SandboxOwner,
 ): Promise<ResolvedOwner> {
   if (owner.kind === "session") {
     const session = await ctx.runQuery(internal.sessions.getInternal, {

--- a/packages/backend/convex/_sandbox/owner.ts
+++ b/packages/backend/convex/_sandbox/owner.ts
@@ -1,0 +1,84 @@
+import { v, type Infer } from "convex/values";
+import type { GenericDatabaseReader } from "convex/server";
+import type { DataModel, Doc, Id } from "../_generated/dataModel";
+import { hasRepoAccess, hasTaskAccess } from "../functions";
+
+/** One sandbox owner contract shared by view state, PTYs, panes, and runtime APIs. */
+export const sandboxOwnerValidator = v.union(
+  v.object({
+    kind: v.literal("session"),
+    sessionId: v.id("sessions"),
+  }),
+  v.object({
+    kind: v.literal("task"),
+    taskId: v.id("agentTasks"),
+  }),
+  v.object({
+    kind: v.literal("project"),
+    projectId: v.id("projects"),
+  }),
+);
+
+export type SandboxOwner = Infer<typeof sandboxOwnerValidator>;
+
+export type ResolvedSandboxOwner =
+  | {
+      kind: "session";
+      ownerKey: string;
+      doc: Doc<"sessions">;
+    }
+  | {
+      kind: "task";
+      ownerKey: string;
+      doc: Doc<"agentTasks">;
+    }
+  | {
+      kind: "project";
+      ownerKey: string;
+      doc: Doc<"projects">;
+    };
+
+export function sandboxOwnerKey(owner: SandboxOwner): string {
+  if (owner.kind === "session") return `session-${owner.sessionId}`;
+  if (owner.kind === "task") return `task-${owner.taskId}`;
+  return `project-${owner.projectId}`;
+}
+
+/** Resolves and authorizes any sandbox owner without duplicating table policy. */
+export async function resolveSandboxOwnerForUser(
+  db: GenericDatabaseReader<DataModel>,
+  userId: Id<"users">,
+  owner: SandboxOwner,
+): Promise<ResolvedSandboxOwner | null> {
+  if (owner.kind === "session") {
+    const session = await db.get(owner.sessionId);
+    if (!session || !(await hasRepoAccess(db, session.repoId, userId))) {
+      return null;
+    }
+    return {
+      kind: "session",
+      ownerKey: sandboxOwnerKey(owner),
+      doc: session,
+    };
+  }
+
+  if (owner.kind === "task") {
+    const task = await db.get(owner.taskId);
+    if (!task || !(await hasTaskAccess(db, task, userId))) return null;
+    return {
+      kind: "task",
+      ownerKey: sandboxOwnerKey(owner),
+      doc: task,
+    };
+  }
+
+  const project = await db.get(owner.projectId);
+  if (!project || !(await hasRepoAccess(db, project.repoId, userId))) {
+    return null;
+  }
+  return {
+    kind: "project",
+    ownerKey: sandboxOwnerKey(owner),
+    doc: project,
+  };
+}

--- a/packages/backend/convex/sandboxPanes.ts
+++ b/packages/backend/convex/sandboxPanes.ts
@@ -1,52 +1,37 @@
 import { v } from "convex/values";
-import { authMutation, hasRepoAccess, hasTaskAccess } from "./functions";
-import type {
-  GenericDatabaseReader,
-  GenericDatabaseWriter,
-} from "convex/server";
-import type { DataModel, Id } from "./_generated/dataModel";
+import { authMutation, authQuery } from "./functions";
+import type { GenericDatabaseWriter } from "convex/server";
+import type { DataModel, Doc, Id } from "./_generated/dataModel";
 import { terminalPaneValidator } from "./validators";
+import {
+  resolveSandboxOwnerForUser,
+  sandboxOwnerValidator,
+  type ResolvedSandboxOwner,
+  type SandboxOwner,
+} from "./_sandbox/owner";
+import {
+  assertStickyPreviewPort,
+  normalizeStickyPreviewPath,
+  truncateTerminalHistoryTail,
+} from "./_sandbox/stickyPreview";
 
-const ownerArg = v.union(
-  v.object({
-    kind: v.literal("session"),
-    sessionId: v.id("sessions"),
-  }),
-  v.object({
-    kind: v.literal("task"),
-    taskId: v.id("agentTasks"),
-  }),
-  v.object({
-    kind: v.literal("project"),
-    projectId: v.id("projects"),
-  }),
-);
+type TerminalPane = NonNullable<Doc<"sessions">["terminalPanes"]>[number];
 
-type TerminalPane = {
-  id: string;
-  title: string;
-  createdAt: number;
-};
+const viewStateValidator = v.object({
+  previewPath: v.optional(v.string()),
+  terminalHistoryTail: v.optional(v.string()),
+  agentBrowsingAt: v.optional(v.number()),
+});
 
-type ResolvedOwner =
-  | {
-      table: "sessions";
-      id: Id<"sessions">;
-      ownerKey: string;
-      panes: TerminalPane[] | undefined;
-    }
-  | {
-      table: "agentTasks";
-      id: Id<"agentTasks">;
-      ownerKey: string;
-      panes: TerminalPane[] | undefined;
-    }
-  | {
-      table: "projects";
-      id: Id<"projects">;
-      ownerKey: string;
-      panes: TerminalPane[] | undefined;
-    };
+async function resolveOwnerOrThrow(
+  db: GenericDatabaseWriter<DataModel>,
+  userId: Id<"users">,
+  owner: SandboxOwner,
+): Promise<ResolvedSandboxOwner> {
+  const resolved = await resolveSandboxOwnerForUser(db, userId, owner);
+  if (!resolved) throw new Error("Sandbox owner not found");
+  return resolved;
+}
 
 function defaultPane(ownerKey: string, createdAt: number): TerminalPane {
   return {
@@ -72,85 +57,40 @@ function nextPane(
 
 /** Existing panes, or a fresh list seeded with the stable default pane. */
 function panesOrDefault(
-  owner: ResolvedOwner,
+  owner: ResolvedSandboxOwner,
   createdAt: number,
 ): TerminalPane[] {
-  return owner.panes && owner.panes.length > 0
-    ? owner.panes
+  return owner.doc.terminalPanes && owner.doc.terminalPanes.length > 0
+    ? owner.doc.terminalPanes
     : [defaultPane(owner.ownerKey, createdAt)];
-}
-
-async function resolveOwner(
-  db: GenericDatabaseReader<DataModel>,
-  userId: Id<"users">,
-  owner:
-    | { kind: "session"; sessionId: Id<"sessions"> }
-    | { kind: "task"; taskId: Id<"agentTasks"> }
-    | { kind: "project"; projectId: Id<"projects"> },
-): Promise<ResolvedOwner | null> {
-  if (owner.kind === "session") {
-    const session = await db.get(owner.sessionId);
-    if (!session || !(await hasRepoAccess(db, session.repoId, userId))) {
-      return null;
-    }
-    return {
-      table: "sessions",
-      id: owner.sessionId,
-      ownerKey: `session-${owner.sessionId}`,
-      panes: session.terminalPanes,
-    };
-  }
-
-  if (owner.kind === "task") {
-    const task = await db.get(owner.taskId);
-    if (!task || !(await hasTaskAccess(db, task, userId))) {
-      return null;
-    }
-    return {
-      table: "agentTasks",
-      id: owner.taskId,
-      ownerKey: `task-${owner.taskId}`,
-      panes: task.terminalPanes,
-    };
-  }
-
-  const project = await db.get(owner.projectId);
-  if (!project || !(await hasRepoAccess(db, project.repoId, userId))) {
-    return null;
-  }
-  return {
-    table: "projects",
-    id: owner.projectId,
-    ownerKey: `project-${owner.projectId}`,
-    panes: project.terminalPanes,
-  };
 }
 
 async function patchPanes(
   db: GenericDatabaseWriter<DataModel>,
-  owner: ResolvedOwner,
+  owner: ResolvedSandboxOwner,
   panes: TerminalPane[],
 ) {
-  // Per-table narrowing: db.patch's union of Id<"sessions"> | Id<"agentTasks">
-  // | Id<"projects"> doesn't distribute over the generic, so each branch needs
-  // its own call.
-  if (owner.table === "sessions") {
-    await db.patch(owner.id, { terminalPanes: panes });
-  } else if (owner.table === "agentTasks") {
-    await db.patch(owner.id, { terminalPanes: panes });
+  if (owner.kind === "session") {
+    await db.patch(owner.doc._id, { terminalPanes: panes });
+  } else if (owner.kind === "task") {
+    await db.patch(owner.doc._id, { terminalPanes: panes });
   } else {
-    await db.patch(owner.id, { terminalPanes: panes });
+    await db.patch(owner.doc._id, { terminalPanes: panes });
   }
 }
 
 /** Ensures every active sandbox has a stable shared default terminal pane. */
 export const ensureDefaultTerminalPane = authMutation({
-  args: { owner: ownerArg },
+  args: { owner: sandboxOwnerValidator },
   returns: v.array(terminalPaneValidator),
   handler: async (ctx, args) => {
-    const owner = await resolveOwner(ctx.db, ctx.userId, args.owner);
+    const owner = await resolveSandboxOwnerForUser(
+      ctx.db,
+      ctx.userId,
+      args.owner,
+    );
     if (!owner) return [];
-    const panes = owner.panes ?? [];
+    const panes = owner.doc.terminalPanes ?? [];
     if (panes.length > 0) return panes;
     const next = [defaultPane(owner.ownerKey, Date.now())];
     await patchPanes(ctx.db, owner, next);
@@ -160,10 +100,14 @@ export const ensureDefaultTerminalPane = authMutation({
 
 /** Adds one shared terminal pane. All users viewing the sandbox see it. */
 export const createTerminalPane = authMutation({
-  args: { owner: ownerArg },
+  args: { owner: sandboxOwnerValidator },
   returns: terminalPaneValidator,
   handler: async (ctx, args) => {
-    const owner = await resolveOwner(ctx.db, ctx.userId, args.owner);
+    const owner = await resolveSandboxOwnerForUser(
+      ctx.db,
+      ctx.userId,
+      args.owner,
+    );
     if (!owner) throw new Error("Sandbox owner not found");
     const createdAt = Date.now();
     const panes = panesOrDefault(owner, createdAt);
@@ -176,17 +120,108 @@ export const createTerminalPane = authMutation({
 /** Removes one shared terminal pane, keeping the stable dev-server terminal. */
 export const closeTerminalPane = authMutation({
   args: {
-    owner: ownerArg,
+    owner: sandboxOwnerValidator,
     paneId: v.string(),
   },
   returns: v.array(terminalPaneValidator),
   handler: async (ctx, args) => {
-    const owner = await resolveOwner(ctx.db, ctx.userId, args.owner);
+    const owner = await resolveSandboxOwnerForUser(
+      ctx.db,
+      ctx.userId,
+      args.owner,
+    );
     if (!owner) return [];
     const panes = panesOrDefault(owner, Date.now());
     if (panes[0]?.id === args.paneId) return panes;
     const next = panes.filter((pane) => pane.id !== args.paneId);
     await patchPanes(ctx.db, owner, next);
     return next;
+  },
+});
+
+/** Shared sticky view state for every sandbox owner. */
+export const getViewState = authQuery({
+  args: { owner: sandboxOwnerValidator },
+  returns: v.union(v.null(), viewStateValidator),
+  handler: async (ctx, args) => {
+    const owner = await resolveSandboxOwnerForUser(
+      ctx.db,
+      ctx.userId,
+      args.owner,
+    );
+    if (!owner) return null;
+    return {
+      previewPath: owner.doc.previewPath,
+      terminalHistoryTail: owner.doc.terminalHistoryTail,
+      agentBrowsingAt: owner.doc.agentBrowsingAt,
+    };
+  },
+});
+
+export const setPreviewPath = authMutation({
+  args: { owner: sandboxOwnerValidator, path: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const owner = await resolveOwnerOrThrow(ctx.db, ctx.userId, args.owner);
+    const previewPath = normalizeStickyPreviewPath(args.path);
+    if (owner.kind === "session") {
+      await ctx.db.patch(owner.doc._id, { previewPath });
+    } else if (owner.kind === "task") {
+      await ctx.db.patch(owner.doc._id, { previewPath });
+    } else {
+      await ctx.db.patch(owner.doc._id, { previewPath });
+    }
+    return null;
+  },
+});
+
+export const setPreviewPort = authMutation({
+  args: { owner: sandboxOwnerValidator, port: v.number() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const owner = await resolveOwnerOrThrow(ctx.db, ctx.userId, args.owner);
+    assertStickyPreviewPort(args.port);
+    if (owner.kind === "session") {
+      await ctx.db.patch(owner.doc._id, { devPort: args.port });
+    } else if (owner.kind === "task") {
+      await ctx.db.patch(owner.doc._id, { devPort: args.port });
+    } else {
+      await ctx.db.patch(owner.doc._id, { devPort: args.port });
+    }
+    return null;
+  },
+});
+
+export const setTerminalHistoryTail = authMutation({
+  args: { owner: sandboxOwnerValidator, tail: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const owner = await resolveOwnerOrThrow(ctx.db, ctx.userId, args.owner);
+    const terminalHistoryTail = truncateTerminalHistoryTail(args.tail);
+    if (owner.kind === "session") {
+      await ctx.db.patch(owner.doc._id, { terminalHistoryTail });
+    } else if (owner.kind === "task") {
+      await ctx.db.patch(owner.doc._id, { terminalHistoryTail });
+    } else {
+      await ctx.db.patch(owner.doc._id, { terminalHistoryTail });
+    }
+    return null;
+  },
+});
+
+export const releaseBrowserLock = authMutation({
+  args: { owner: sandboxOwnerValidator },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const owner = await resolveOwnerOrThrow(ctx.db, ctx.userId, args.owner);
+    const patch = { agentBrowsingAt: undefined, updatedAt: Date.now() };
+    if (owner.kind === "session") {
+      await ctx.db.patch(owner.doc._id, patch);
+    } else if (owner.kind === "task") {
+      await ctx.db.patch(owner.doc._id, patch);
+    } else {
+      await ctx.db.patch(owner.doc._id, patch);
+    }
+    return null;
   },
 });

--- a/packages/backend/index.ts
+++ b/packages/backend/index.ts
@@ -1,5 +1,6 @@
 export type { Id, Doc } from "./convex/_generated/dataModel";
 export type { BackgroundAgentEntry } from "./convex/_validators/tableFields";
+export type { SandboxOwner } from "./convex/_sandbox/owner";
 export { api } from "./convex/_generated/api";
 export {
   AI_MODEL_OPTIONS,

--- a/packages/backend/tests/sandboxOwnerUnificationContract.test.ts
+++ b/packages/backend/tests/sandboxOwnerUnificationContract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const backendDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(backendDir, relativePath), "utf8").replaceAll(
+    "\r\n",
+    "\n",
+  );
+}
+
+test("PTYs and panes share the canonical sandbox owner validator", () => {
+  const owner = readSource("convex/_sandbox/owner.ts");
+  const ptyOwners = readSource("convex/_pty/owners.ts");
+  const panes = readSource("convex/sandboxPanes.ts");
+
+  expect(owner).toContain("export const sandboxOwnerValidator = v.union(");
+  expect(ptyOwners).toContain("export const ownerArg = sandboxOwnerValidator");
+  expect(panes).toContain("args: { owner: sandboxOwnerValidator }");
+  expect(ptyOwners).not.toContain("export const ownerArg = v.union(");
+});
+
+test("shared sandbox view state is exposed from one owner-aware module", () => {
+  const panes = readSource("convex/sandboxPanes.ts");
+  for (const functionName of [
+    "getViewState",
+    "setPreviewPath",
+    "setPreviewPort",
+    "setTerminalHistoryTail",
+    "releaseBrowserLock",
+  ]) {
+    expect(panes).toContain(`export const ${functionName} =`);
+  }
+  expect(panes).toContain("resolveSandboxOwnerForUser(");
+});


### PR DESCRIPTION
## Summary
- Re-opened after reverting the merge of #558 from `main`.
- Centralize session, quick-task, and project sandbox rendering in a shared `SandboxWorkspace`.
- Add a canonical validator-derived `SandboxOwner` and owner-aware sandbox view-state API.
- Preserve existing URLs, sandbox IDs, and entity-specific compatibility APIs.

Supersedes / reopens: https://github.com/vvedantb/eva/pull/558

## Test plan
- [ ] `pnpm --filter @eva/backend typecheck`
- [ ] `pnpm --filter @eva/web typecheck`
- [ ] Focused sandbox owner / workspace contract tests
- [ ] Confirm Convex prod deploy story (known `pty.js` analyzer issue)
