### PR TITLE
chore: pin Claude and Cursor SDKs

### DIFF
--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -4,7 +4,7 @@
 
 The Claude Agent SDK and Cursor SDK were loaded by exact version inside sandbox callbacks, but neither version was declared in the backend workspace. That left local installs without the official packages and allowed the handwritten callback boundary types to drift without an inspectable, locked SDK beside them. New snapshots also preinstalled only Cursor's SDK, so the first Claude SDK task paid for a user-local fallback install.
 
-Both SDKs are now exact backend dependencies and are locked at the same versions used by the callback loaders. Snapshot seeding preinstalls both packages and verifies both directories before skipping the agent-tool install. The user-local dynamic loader remains for older snapshots; Cursor's package cannot be safely folded into the standalone callback bundle because its published ESM graph includes Bun-only and declaration-map imports.
+Both SDKs are now exact backend dependencies and are locked at the same versions used by the callback loaders. The provider boundaries import their official query, permission, agent, run, model, store, MCP, and usage types instead of restating those public APIs. Snapshot seeding preinstalls both packages and verifies both directories before skipping the agent-tool install. The user-local dynamic loader remains for older snapshots; the imports are type-only because Cursor's package cannot be safely folded into the standalone callback bundle—its published ESM graph includes Bun-only and declaration-map imports.
 
 ## Component data survives a sync to a local backend - 2026-08-12
 

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Claude and Cursor SDK versions now match their sandbox runtimes - 2026-08-12
+
+The Claude Agent SDK and Cursor SDK were loaded by exact version inside sandbox callbacks, but neither version was declared in the backend workspace. That left local installs without the official packages and allowed the handwritten callback boundary types to drift without an inspectable, locked SDK beside them. New snapshots also preinstalled only Cursor's SDK, so the first Claude SDK task paid for a user-local fallback install.
+
+Both SDKs are now exact backend dependencies and are locked at the same versions used by the callback loaders. Snapshot seeding preinstalls both packages and verifies both directories before skipping the agent-tool install. The user-local dynamic loader remains for older snapshots; Cursor's package cannot be safely folded into the standalone callback bundle because its published ESM graph includes Bun-only and declaration-map imports.
+
 ## Component data survives a sync to a local backend - 2026-08-12
 
 `sync:prod-to-local` imported the snapshot zip whole, and a zip that holds component tables cannot be imported that way. The import failed with "New table `X` in '\<component\>' has IDs that conflict with existing system table", because the CLI addresses a component namespace by name through `--component`, not by the `_components/` directories inside the zip. Every namespace also numbers its user tables from 10001, so a single whole-zip import puts two namespaces on the same numbers.

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -1,5 +1,10 @@
 import { execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
+import type {
+  CanUseTool,
+  Options,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
 import {
   ALLOWED_TOOLS,
   BLOCKING_QUESTIONS_ENABLED,
@@ -33,17 +38,6 @@ const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 const SDK_VERSION = "0.3.201";
 const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 
-/**
- * The subset of the Agent SDK `query()` surface this runner uses. The SDK is
- * dynamically imported from the sandbox's global npm root (it is installed in
- * the seed snapshot alongside the Claude CLI), so these local types stand in for
- * the SDK's own — kept intentionally narrow.
- */
-type SdkQueryHandle = AsyncIterable<Record<string, JsonLike>> & {
-  interrupt?: () => Promise<void>;
-  stopTask?: (taskId: string) => Promise<void>;
-};
-
 export type JsonLike =
   | string
   | number
@@ -52,51 +46,14 @@ export type JsonLike =
   | JsonLike[]
   | { [key: string]: JsonLike };
 
-/** Result the SDK expects from `canUseTool` (matches the Agent SDK's PermissionResult). */
-type SdkPermissionResult =
-  | { behavior: "allow"; updatedInput: Record<string, JsonLike> }
-  | { behavior: "deny"; message: string };
-
-/** The `canUseTool` permission callback passed to `query()`. */
-export type SdkCanUseTool = (
-  toolName: string,
-  input: Record<string, JsonLike>,
-  options: { signal: AbortSignal; toolUseID?: string },
-) => Promise<SdkPermissionResult>;
-
-export type SdkOptions = {
-  cwd: string;
-  model: string;
-  pathToClaudeCodeExecutable: string;
-  systemPrompt:
-    | { type: "preset"; preset: "claude_code"; append?: string }
-    | string;
-  permissionMode: string;
-  allowDangerouslySkipPermissions: boolean;
-  allowedTools?: string[];
-  env: Record<string, string | undefined>;
-  sessionId?: string;
-  resume?: string;
-  extraArgs?: Record<string, string>;
-  includePartialMessages?: boolean;
-  effort?: "low" | "medium" | "high" | "xhigh" | "max";
-  /** Per-tool permission gate. Set only when blocking questions are enabled. */
-  canUseTool?: SdkCanUseTool;
-};
-
-export type SdkUserMessage = {
-  type: "user";
-  message: { role: "user"; content: string };
-  parent_tool_use_id: string | null;
-  session_id: string;
-};
-
-export type SdkModule = {
-  query: (args: {
-    prompt: string | AsyncIterable<SdkUserMessage>;
-    options: SdkOptions;
-  }) => SdkQueryHandle;
-};
+/** Official SDK types are erased from the standalone callback bundle. */
+export type SdkCanUseTool = CanUseTool;
+export type SdkOptions = Options;
+export type SdkUserMessage = SDKUserMessage;
+export type SdkModule = Pick<
+  typeof import("@anthropic-ai/claude-agent-sdk"),
+  "query"
+>;
 
 /** Resolves the sandbox's global npm root once (e.g. /usr/lib/node_modules). */
 export function globalNpmRoot(): string {
@@ -193,11 +150,10 @@ function buildSdkOptionsFromParts(
   // `bypassPermissions`. When enabled we switch to `default` mode and let the
   // gate auto-allow every tool except AskUserQuestion (which waits for the user).
   // Otherwise keep the original bypass behaviour (no per-tool gating).
-  const permissionOption: {
-    permissionMode: string;
-    allowDangerouslySkipPermissions: boolean;
-    canUseTool?: SdkCanUseTool;
-  } =
+  const permissionOption: Pick<
+    SdkOptions,
+    "permissionMode" | "allowDangerouslySkipPermissions" | "canUseTool"
+  > =
     tools === "agent" && BLOCKING_QUESTIONS_ENABLED
       ? {
           permissionMode: "default",
@@ -233,7 +189,7 @@ function buildSdkOptionsFromParts(
     delete env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
   }
 
-  const effortOption: { effort?: "low" | "medium" | "high" | "xhigh" | "max" } =
+  const effortOption: Pick<SdkOptions, "effort"> =
     claudeEffort === "low" ||
     claudeEffort === "medium" ||
     claudeEffort === "high" ||

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -36,7 +36,7 @@ const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 /**
  * The subset of the Agent SDK `query()` surface this runner uses. The SDK is
  * dynamically imported from the sandbox's global npm root (it is installed in
- * the base Image alongside the claude CLI), so these local types stand in for
+ * the seed snapshot alongside the Claude CLI), so these local types stand in for
  * the SDK's own — kept intentionally narrow.
  */
 type SdkQueryHandle = AsyncIterable<Record<string, JsonLike>> & {

--- a/packages/backend/callback-src/providers/cursorSdk.ts
+++ b/packages/backend/callback-src/providers/cursorSdk.ts
@@ -1,5 +1,15 @@
 import { execSync } from "child_process";
 import { existsSync, mkdirSync, readFileSync } from "fs";
+import type {
+  AgentOptions,
+  McpServerConfig,
+  ModelListItem,
+  ModelParameterValue,
+  ModelSelection,
+  Run,
+  SDKAgent,
+  TokenUsage,
+} from "@cursor/sdk";
 import {
   CURSOR_SDK_STORE_DIR,
   MAX_TOTAL_RUNTIME_MS,
@@ -38,28 +48,10 @@ const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 /** User-writable fallback install location (persists in home across resumes). */
 const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk";
 
-/**
- * Narrow structural types for the subset of the Cursor SDK this runner uses.
- * The SDK is dynamically imported from the sandbox's global npm root (installed
- * in the seed snapshot), so these stand in for the SDK's own types.
- */
-export type SdkMcpServerConfig = {
-  type: "http";
-  url: string;
-  headers?: Record<string, string>;
-};
-
-/** Opaque store handle — constructed, passed back to the SDK, never inspected. */
-type SdkLocalAgentStore = {
-  readonly agents?: object;
-};
-
-type SdkModelParameterValue = { id: string; value: string };
-
-type SdkModelSelection = {
-  id: string;
-  params?: SdkModelParameterValue[];
-};
+/** Official SDK types are erased from the standalone callback bundle. */
+export type SdkMcpServerConfig = McpServerConfig;
+type SdkModelParameterValue = ModelParameterValue;
+type SdkModelSelection = ModelSelection;
 
 export function cursorModeParams(
   model: string,
@@ -76,21 +68,7 @@ export function cursorModeParams(
   return params;
 }
 
-type SdkModelParameterDefinition = {
-  id?: string;
-  values?: Array<{ value?: string }>;
-};
-
-type SdkModelVariant = {
-  params?: SdkModelParameterValue[];
-  displayName?: string;
-};
-
-type SdkModel = {
-  id?: string;
-  parameters?: SdkModelParameterDefinition[];
-  variants?: SdkModelVariant[];
-};
+type SdkModel = ModelListItem;
 
 /**
  * The `fast`/`context` parameter ids are not documented, so never trust them
@@ -123,54 +101,15 @@ export function filterModeParamsByModel(
   );
 }
 
-type SdkAgentOptions = {
-  apiKey: string;
-  model: SdkModelSelection;
-  local: { cwd: string; store: SdkLocalAgentStore };
-  mcpServers?: Record<string, SdkMcpServerConfig>;
-};
+type SdkAgentOptions = AgentOptions;
+type SdkTokenUsage = TokenUsage;
+type SdkRun = Run;
+type SdkAgent = SDKAgent;
 
-type SdkTokenUsage = {
-  inputTokens?: number;
-  outputTokens?: number;
-  cacheReadTokens?: number;
-  cacheWriteTokens?: number;
-};
-
-type SdkRunResult = {
-  status?: string;
-  result?: string;
-  error?: { message?: string; code?: string };
-  durationMs?: number;
-  usage?: SdkTokenUsage;
-};
-
-type SdkRun = {
-  stream: () => AsyncIterable<Record<string, JsonLike>>;
-  wait: () => Promise<SdkRunResult>;
-  cancel: () => Promise<void>;
-};
-
-type SdkSendOptions = { local?: { force?: boolean } };
-
-type SdkAgent = {
-  agentId: string;
-  send: (message: string, options?: SdkSendOptions) => Promise<SdkRun>;
-  close: () => void;
-};
-
-export type CursorSdkModule = {
-  Agent: {
-    create: (options: SdkAgentOptions) => Promise<SdkAgent>;
-    resume: (agentId: string, options: SdkAgentOptions) => Promise<SdkAgent>;
-  };
-  JsonlLocalAgentStore: new (rootDir: string) => SdkLocalAgentStore;
-  Cursor?: {
-    models?: {
-      list?: () => Promise<SdkModel[]>;
-    };
-  };
-};
+export type CursorSdkModule = Pick<
+  typeof import("@cursor/sdk"),
+  "Agent" | "Cursor" | "JsonlLocalAgentStore"
+>;
 
 /**
  * Imports the Cursor SDK, preferring the base Image's global install (seeded in
@@ -423,12 +362,11 @@ function readUsageTokens(
   value: JsonLike | SdkTokenUsage | undefined,
 ): UsageTokens | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const usage: SdkTokenUsage = value;
   return {
-    inputTokens: readNum(usage.inputTokens),
-    outputTokens: readNum(usage.outputTokens),
-    cacheReadTokens: readNum(usage.cacheReadTokens),
-    cacheWriteTokens: readNum(usage.cacheWriteTokens),
+    inputTokens: readNum(value.inputTokens),
+    outputTokens: readNum(value.outputTokens),
+    cacheReadTokens: readNum(value.cacheReadTokens),
+    cacheWriteTokens: readNum(value.cacheWriteTokens),
   };
 }
 

--- a/packages/backend/convex/snapshotActions.ts
+++ b/packages/backend/convex/snapshotActions.ts
@@ -322,7 +322,7 @@ export const launchSeedRun = internalAction({
       "sudo mkdir -p /opt/git/etc",
       'sudo /usr/local/bin/git-lfs install --system || { echo "SEEDRUN-FAILED:git-lfs-filters"; exit 1; }',
       'sudo env GIT_CONFIG_SYSTEM=/etc/gitconfig /usr/local/bin/git-lfs install --system || { echo "SEEDRUN-FAILED:git-lfs-filters"; exit 1; }',
-      'command -v claude >/dev/null 2>&1 && command -v codex >/dev/null 2>&1 && command -v opencode >/dev/null 2>&1 && [ -d "$(npm root -g)/@cursor/sdk" ] || sudo npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai agent-browser convex agentation-mcp@1.2.0 @cursor/sdk@1.0.26 || { echo "SEEDRUN-FAILED:agent-clis"; exit 1; }',
+      'command -v claude >/dev/null 2>&1 && command -v codex >/dev/null 2>&1 && command -v opencode >/dev/null 2>&1 && [ -d "$(npm root -g)/@anthropic-ai/claude-agent-sdk" ] && [ -d "$(npm root -g)/@cursor/sdk" ] || sudo npm install -g @anthropic-ai/claude-code @anthropic-ai/claude-agent-sdk@0.3.201 @openai/codex opencode-ai agent-browser convex agentation-mcp@1.2.0 @cursor/sdk@1.0.26 || { echo "SEEDRUN-FAILED:agent-clis"; exit 1; }',
       'command -v code-server >/dev/null 2>&1 || curl -fsSL https://code-server.dev/install.sh | sh || { echo "SEEDRUN-FAILED:code-server"; exit 1; }',
       'command -v websockify >/dev/null 2>&1 || python3 -m pip install --user --break-system-packages websockify >/tmp/websockify-pip.log 2>&1 || python3 -m pip install --user websockify >/tmp/websockify-pip.log 2>&1 || { echo "SEEDRUN-FAILED:websockify"; exit 1; }',
       "sudo ln -sf $(python3 -m site --user-base)/bin/websockify /usr/local/bin/websockify 2>/dev/null || true",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,7 @@
   "description": "",
   "dependencies": {
     "@ai-sdk/gateway": "^4.0.28",
+    "@anthropic-ai/claude-agent-sdk": "0.3.201",
     "@clerk/backend": "^2.33.3",
     "@convex-dev/action-cache": "^0.3.1",
     "@convex-dev/crons": "^0.2.0",
@@ -34,6 +35,7 @@
     "@convex-dev/presence": "^0.3.0",
     "@convex-dev/prosemirror-sync": "^0.2.1",
     "@convex-dev/workflow": "^0.3.4",
+    "@cursor/sdk": "1.0.26",
     "@eva/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@octokit/auth-app": "^8.1.2",

--- a/packages/backend/tests/providerSdkDependenciesContract.test.ts
+++ b/packages/backend/tests/providerSdkDependenciesContract.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const testsDir = dirname(fileURLToPath(import.meta.url));
+
+const backendPackage = readFileSync(join(testsDir, "../package.json"), "utf8");
+const claudeLoader = readFileSync(
+  join(testsDir, "../callback-src/providers/claudeSdk.ts"),
+  "utf8",
+);
+const cursorLoader = readFileSync(
+  join(testsDir, "../callback-src/providers/cursorSdk.ts"),
+  "utf8",
+);
+const snapshotActions = readFileSync(
+  join(testsDir, "../convex/snapshotActions.ts"),
+  "utf8",
+);
+
+const sdkVersions = [
+  {
+    packageName: "@anthropic-ai/claude-agent-sdk",
+    version: "0.3.201",
+    loader: claudeLoader,
+  },
+  {
+    packageName: "@cursor/sdk",
+    version: "1.0.26",
+    loader: cursorLoader,
+  },
+];
+
+test("provider SDK dependencies match the callback loader versions", () => {
+  for (const sdk of sdkVersions) {
+    expect(backendPackage).toContain(
+      `"${sdk.packageName}": "${sdk.version}"`,
+    );
+    expect(sdk.loader).toContain(`const SDK_PACKAGE = "${sdk.packageName}"`);
+    expect(sdk.loader).toContain(`const SDK_VERSION = "${sdk.version}"`);
+  }
+});
+
+test("new snapshots preinstall both provider SDKs at the loader versions", () => {
+  for (const sdk of sdkVersions) {
+    expect(snapshotActions).toContain(
+      `[ -d "$(npm root -g)/${sdk.packageName}" ]`,
+    );
+    expect(snapshotActions).toContain(`${sdk.packageName}@${sdk.version}`);
+  }
+});
+
+test("older snapshots retain the user-local SDK fallback", () => {
+  for (const sdk of sdkVersions) {
+    expect(sdk.loader).toContain(
+      'const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk"',
+    );
+    expect(sdk.loader).toContain("npm install --prefix");
+  }
+});

--- a/packages/backend/tests/providerSdkDependenciesContract.test.ts
+++ b/packages/backend/tests/providerSdkDependenciesContract.test.ts
@@ -42,6 +42,17 @@ test("provider SDK dependencies match the callback loader versions", () => {
   }
 });
 
+test("provider boundaries use official SDK declarations", () => {
+  expect(claudeLoader).toContain(
+    'from "@anthropic-ai/claude-agent-sdk"',
+  );
+  expect(claudeLoader).toContain(
+    'typeof import("@anthropic-ai/claude-agent-sdk")',
+  );
+  expect(cursorLoader).toContain('from "@cursor/sdk"');
+  expect(cursorLoader).toContain('typeof import("@cursor/sdk")');
+});
+
 test("new snapshots preinstall both provider SDKs at the loader versions", () => {
   for (const sdk of sdkVersions) {
     expect(snapshotActions).toContain(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       '@ai-sdk/gateway':
         specifier: ^4.0.28
         version: 4.0.30(zod@3.25.76)
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 0.3.201
+        version: 0.3.201(@anthropic-ai/sdk@0.115.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)
       '@clerk/backend':
         specifier: ^2.33.3
         version: 2.33.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5)
@@ -521,6 +524,9 @@ importers:
       '@convex-dev/workflow':
         specifier: ^0.3.4
         version: 0.3.10(@convex-dev/workpool@0.4.6(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(hono@4.12.25)(react@19.2.5)(typescript@7.0.1-rc)(zod@3.25.76))(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(hono@4.12.25)(react@19.2.5)(typescript@7.0.1-rc)(zod@3.25.76))(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))
+      '@cursor/sdk':
+        specifier: 1.0.26
+        version: 1.0.26
       '@eva/shared':
         specifier: workspace:*
         version: link:../shared
@@ -817,6 +823,67 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201':
+    resolution: {integrity: sha512-8Mcb3BDyKUGfJWFFTWwt+at37lbDH3ZwVtUNPWGG1toZ75RDCJry5U4kXRvQ2xokvJQlA0E+eNp6keWe5ZH22Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.201':
+    resolution: {integrity: sha512-TFR2bu0+ml3RHoMrtsgD0qDK5Oknw8kYGBV7qpQHn+IWmE96gnHhogG1LpJwpHtni08XkJIjfWk1DdlsUYtRkQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.201':
+    resolution: {integrity: sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.201':
+    resolution: {integrity: sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.201':
+    resolution: {integrity: sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.201':
+    resolution: {integrity: sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.201':
+    resolution: {integrity: sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.201':
+    resolution: {integrity: sha512-PhalN/0cWcqDfbx7iwoLNR2gurjTiqhBk1G6K+NRScxEcQjWuu5xKXCcdbX8ePVpT+nbEMmFEFpn2y+8V8hIdA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.201':
+    resolution: {integrity: sha512-InT1XLmf2QpldWdtznKDWEoGJT4p+sXh24yxbeBQ++lMJCzMrI0W27MEmmmDWx0otpa+ubdHCF5YQ6oiNt7cmg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.115.0':
+    resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1508,6 +1575,9 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bufbuild/protobuf@1.10.0':
+    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
   '@chevrotain/cst-dts-gen@12.0.0':
     resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
 
@@ -1571,6 +1641,24 @@ packages:
   '@coinbase/wallet-sdk@4.3.0':
     resolution: {integrity: sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw==}
 
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect-web@1.7.0':
+    resolution: {integrity: sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect@1.7.0':
+    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+
   '@convex-dev/action-cache@0.3.1':
     resolution: {integrity: sha512-HTN/GXyX4t89xxsMXeacMDtQi2jEzQrrlLTtTV1L87Odxz7N8EQHIuI9HOug0dIsz6Gd1VybYbjT1Buv8jarLw==}
     peerDependencies:
@@ -1633,6 +1721,40 @@ packages:
     peerDependencies:
       convex: ^1.31.7
       convex-helpers: 0.1.114
+
+  '@cursor/sdk-darwin-arm64@1.0.26':
+    resolution: {integrity: sha512-PPWtq/8ax4w3/5vh45lMbFpwnXsyvYMl3eR9uW4C2SXScgrtE2V2LfhEU66f1zAt9RKHi2BTTjkuZEnxKJEz+Q==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@cursor/sdk-darwin-x64@1.0.26':
+    resolution: {integrity: sha512-3WJGk1SV0tYTAQY2+PWSzNui6jGp9F7sLUm257EI3bhc7g6h6xCzrLY7wIpD03IEaNdM7emcgVySEN1D0QWsHg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@cursor/sdk-linux-arm64@1.0.26':
+    resolution: {integrity: sha512-DF+zZTn4mszX5q9J3rj9xk7rDu8/JEMfpdDA/UBp3CyaeLo1sPfB/vyoe4GUo1F3I1ZRAgUO8KdBizoHxfBEeQ==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@cursor/sdk-linux-x64@1.0.26':
+    resolution: {integrity: sha512-NnBvOzgGFXJpKygIdk6XzAcstBSdLjtKZyzLg2jLM0d7KkEDs3br94XsyNAvbVqnWhT18KPwHzrgP62ZEHEFxg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@cursor/sdk-win32-x64@1.0.26':
+    resolution: {integrity: sha512-C2PyFwmQNJH9qlqYF+Zhpdyh50500cNm2ortmrtzjqgGSFQ+t4WvzMKqSc/UadCT0oNGWFGyiyMnUpO3sLa0nA==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@cursor/sdk@1.0.26':
+    resolution: {integrity: sha512-dU3WpJwrxv8yoMjs0DxBgZr5btAJEO+NrvFutl08b6l2+jcuemfFWUlSPBQ2xZAH7zIZun+sqfHvjT5NxW8woQ==}
+    engines: {node: '>=22.13'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -3981,6 +4103,12 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@statsig/client-core@3.31.0':
+    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
+
+  '@statsig/js-client@3.31.0':
+    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
 
   '@streamdown/cjk@1.0.3':
     resolution: {integrity: sha512-WRg8HR/gHbBoTgsMd91OKFUClIoDcEFVofJvluvEAyjx3KpU0aGgD9tGDqHkHj14ShoMSkX0IYetWGegTcwIJw==}
@@ -6665,6 +6793,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -8475,6 +8607,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -9096,6 +9231,52 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.201(@anthropic-ai/sdk@0.115.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.115.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      zod: 3.25.76
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.201
+
+  '@anthropic-ai/sdk@0.115.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 3.25.76
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -9978,6 +10159,8 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bufbuild/protobuf@1.10.0': {}
+
   '@chevrotain/cst-dts-gen@12.0.0':
     dependencies:
       '@chevrotain/gast': 12.0.0
@@ -10137,6 +10320,21 @@ snapshots:
       eventemitter3: 5.0.4
       preact: 10.29.1
 
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      undici: 7.29.0
+
+  '@connectrpc/connect-web@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+
+  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
   '@convex-dev/action-cache@0.3.1(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))':
     dependencies:
       convex: 1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)
@@ -10192,6 +10390,36 @@ snapshots:
     dependencies:
       convex: 1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)
       convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(hono@4.12.25)(react@19.2.5)(typescript@7.0.1-rc)(zod@3.25.76)
+
+  '@cursor/sdk-darwin-arm64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-darwin-x64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-linux-arm64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-linux-x64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-win32-x64@1.0.26':
+    optional: true
+
+  '@cursor/sdk@1.0.26':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@connectrpc/connect-web': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@statsig/js-client': 3.31.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@cursor/sdk-darwin-arm64': 1.0.26
+      '@cursor/sdk-darwin-x64': 1.0.26
+      '@cursor/sdk-linux-arm64': 1.0.26
+      '@cursor/sdk-linux-x64': 1.0.26
+      '@cursor/sdk-win32-x64': 1.0.26
 
   '@date-fns/tz@1.4.1': {}
 
@@ -12315,6 +12543,12 @@ snapshots:
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@statsig/client-core@3.31.0': {}
+
+  '@statsig/js-client@3.31.0':
+    dependencies:
+      '@statsig/client-core': 3.31.0
 
   '@streamdown/cjk@1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.1)(unified@11.0.5)':
     dependencies:
@@ -15150,6 +15384,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -17460,6 +17699,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-dedent@2.2.0: {}
 


### PR DESCRIPTION
Summary: Adds exact backend dependencies for the Claude Agent SDK and Cursor SDK; replaces duplicated provider boundary definitions with the packages' official query, permission, agent, run, model, store, MCP, and usage types; preinstalls both SDKs in new sandbox snapshots while retaining the user-local fallback for older snapshots; and adds a contract test keeping dependency, loader, snapshot, and type-import alignment intact. Runtime loading remains dynamic because Cursor's published ESM graph cannot be bundled into the standalone callback. Verification: all 100 backend test files passed (675 tests) before the refactor; focused provider tests pass (4 files, 21 tests); callback typecheck passes; backend typecheck passes.