### PR TITLE
Configure non-interactive Axiom MCP

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,26 @@
 {
+  "permissions": {
+    "allow": [
+      "mcp__axiom__listDatasets",
+      "mcp__axiom__getDatasetSchema",
+      "mcp__axiom__queryApl",
+      "mcp__axiom__getSavedQueries",
+      "mcp__axiom__checkMonitors",
+      "mcp__axiom__getMonitorHistory"
+    ],
+    "deny": [
+      "mcp__axiom__createDashboard",
+      "mcp__axiom__createMonitor",
+      "mcp__axiom__createNotifier",
+      "mcp__axiom__deleteDashboard",
+      "mcp__axiom__deleteMonitor",
+      "mcp__axiom__deleteNotifier",
+      "mcp__axiom__updateDashboard",
+      "mcp__axiom__updateDashboardChart",
+      "mcp__axiom__updateMonitor",
+      "mcp__axiom__updateNotifier"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -23,3 +23,18 @@ env_vars = ["FIGMA_API_KEY"]
 [mcp_servers.linear]
 url = "https://mcp.linear.app/mcp"
 bearer_token_env_var = "LINEAR_API_KEY"
+
+[mcp_servers.axiom]
+url = "https://mcp.axiom.co/mcp"
+bearer_token_env_var = "AXIOM_MCP_PAT"
+env_http_headers = { "x-axiom-org-id" = "AXIOM_ORG_ID" }
+required = false
+default_tools_approval_mode = "approve"
+enabled_tools = [
+    "listDatasets",
+    "getDatasetSchema",
+    "queryApl",
+    "getSavedQueries",
+    "checkMonitors",
+    "getMonitorHistory",
+]

--- a/.mcp.json
+++ b/.mcp.json
@@ -31,6 +31,14 @@
         "--header",
         "Authorization:Bearer ${POSTHOG_API_KEY}"
       ]
+    },
+    "axiom": {
+      "type": "http",
+      "url": "https://mcp.axiom.co/mcp",
+      "headers": {
+        "Authorization": "Bearer ${AXIOM_MCP_PAT}",
+        "x-axiom-org-id": "${AXIOM_ORG_ID}"
+      }
     }
   }
 }

--- a/internal/mcp-setup-report.md
+++ b/internal/mcp-setup-report.md
@@ -74,6 +74,33 @@ Get key: **PostHog > Settings > Personal API Keys** (use "MCP Server" preset)
 
 **Note:** Does not work on PostHog EU cloud (`eu.posthog.com`).
 
+## Axiom
+
+Official hosted MCP over Streamable HTTP, configured non-interactively with a
+dedicated user's personal access token and organization ID. Codex exposes only
+the log investigation tools; Claude Code automatically permits those tools and
+denies Axiom's dashboard, monitor, and notifier mutation tools.
+
+### Required setup
+
+1. Create a dedicated Axiom user for Eva agents and assign Axiom's **Read-only**
+   role, restricted to the Convex log datasets where your plan supports it.
+2. While signed in as that user, create a personal access token under
+   **Axiom > Settings > Profile > Personal tokens**.
+3. Copy the organization ID from **Axiom > Settings > General**.
+4. In Eva, open this repo's **Settings > Environment Variables** and add:
+   - `AXIOM_MCP_PAT` — the dedicated read-only user's personal access token.
+   - `AXIOM_ORG_ID` — the Axiom organization ID.
+5. Leave **Exclude from sandboxes** disabled for both variables. The MCP clients
+   read these values from the sandbox environment; excluding them prevents the
+   non-interactive connection from authenticating.
+
+Never commit either value. Axiom personal access tokens inherit the owning
+user's access, which is why the dedicated read-only user is required. Axiom's
+hosted MCP routes query results through its US infrastructure.
+
+Server URL: `https://mcp.axiom.co/mcp`
+
 ## Headless Mode (`-p`)
 
 MCP servers configured via `claude mcp add` persist in `~/.claude.json` and are available in `-p` mode automatically. No extra flags needed.


### PR DESCRIPTION
## What changed

- Added Axiom's hosted Streamable HTTP MCP server to the project-scoped Codex and Claude configurations.
- Configured non-interactive header authentication through `AXIOM_MCP_PAT` and `AXIOM_ORG_ID` environment variables.
- Limited Codex to Axiom's log investigation tools and automatically approved only that allowlist.
- Allowed the equivalent read/query tools in Claude Code and denied dashboard, monitor, and notifier mutation tools.
- Added durable setup and security guidance to `internal/mcp-setup-report.md`.

## Why

Future Eva agents need unattended access to the Convex logs stored in Axiom so they can investigate failures and production behavior without an interactive OAuth login.

## Action required from you

1. Create a dedicated Axiom user for Eva agents.
2. Assign that user Axiom's **Read-only** role and restrict it to the Convex log datasets where possible.
3. Sign in as that user and create a personal access token under **Axiom → Settings → Profile → Personal tokens**.
4. Copy the organization ID from **Axiom → Settings → General**.
5. In Eva, open this repo's **Settings → Environment Variables** and add:
   - `AXIOM_MCP_PAT` — the dedicated user's PAT.
   - `AXIOM_ORG_ID` — the organization ID.
6. Leave **Exclude from sandboxes** disabled for both variables so unattended agents receive them.

Do not paste either value into this PR or commit them. The hosted MCP requires a PAT for non-interactive header authentication, so the dedicated read-only user is the principal security boundary.

## Validation

- Parsed `.codex/config.toml` with Python `tomllib`.
- Parsed `.mcp.json` and `.claude/settings.json` with PowerShell `ConvertFrom-Json`.
- Ran `git diff --check`.
- Confirmed `codex mcp list` recognizes `axiom` as an enabled bearer-token server.
- Scanned the changed files for token-like values.

A live Axiom query was not run because the two required secrets are intentionally not present in the repository.
