### PR TITLE
chore(mcp): add read-only Inngest Dev Server MCP

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,27 @@
 {
+  "permissions": {
+    "allow": [
+      "mcp__inngest-dev__get_app",
+      "mcp__inngest-dev__get_apps",
+      "mcp__inngest-dev__get_event_runs",
+      "mcp__inngest-dev__get_function",
+      "mcp__inngest-dev__get_run",
+      "mcp__inngest-dev__get_run_trace",
+      "mcp__inngest-dev__health",
+      "mcp__inngest-dev__list_function_runs",
+      "mcp__inngest-dev__list_functions",
+      "mcp__inngest-dev__list_runs",
+      "mcp__inngest-dev__grep_docs",
+      "mcp__inngest-dev__list_docs",
+      "mcp__inngest-dev__read_doc"
+    ],
+    "deny": [
+      "mcp__inngest-dev__cancel_run",
+      "mcp__inngest-dev__invoke_function",
+      "mcp__inngest-dev__rerun",
+      "mcp__inngest-dev__send_event"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -23,3 +23,23 @@ env_vars = ["FIGMA_API_KEY"]
 [mcp_servers.linear]
 url = "https://mcp.linear.app/mcp"
 bearer_token_env_var = "LINEAR_API_KEY"
+
+[mcp_servers.inngest-dev]
+url = "http://127.0.0.1:8288/mcp"
+required = false
+default_tools_approval_mode = "approve"
+enabled_tools = [
+    "get_app",
+    "get_apps",
+    "get_event_runs",
+    "get_function",
+    "get_run",
+    "get_run_trace",
+    "health",
+    "list_function_runs",
+    "list_functions",
+    "list_runs",
+    "grep_docs",
+    "list_docs",
+    "read_doc",
+]

--- a/.mcp.json
+++ b/.mcp.json
@@ -31,6 +31,10 @@
         "--header",
         "Authorization:Bearer ${POSTHOG_API_KEY}"
       ]
+    },
+    "inngest-dev": {
+      "type": "http",
+      "url": "http://127.0.0.1:8288/mcp"
     }
   }
 }


### PR DESCRIPTION
Adds the local Inngest Dev Server MCP (`http://127.0.0.1:8288/mcp`) to the shared editor MCP configs, enforced **read-only**.

## Changes
- **Claude** (`.mcp.json`): add `inngest-dev` http server.
- **Claude** (`.claude/settings.json`): allow the 13 read tools, deny the 4 mutating tools (`cancel_run`, `invoke_function`, `rerun`, `send_event`).
- **Codex** (`.codex/config.toml`): add `[mcp_servers.inngest-dev]` with an `enabled_tools` allowlist of read tools only.

## Read-only note
The Inngest MCP server has **no server-side read-only mode**. Read-only is enforced client-side via allow/deny lists. Cursor's `mcp.json` is gitignored (not in this PR) and has no per-tool filtering, so the Cursor entry was applied locally and cannot be restricted to read-only in config.

## To use
Requires the Inngest dev server running locally: `inngest dev` (endpoint `http://127.0.0.1:8288/mcp`, no auth). Restart the editor/MCP client after merge.