### PR TITLE
Reduce Convex hot-query database I/O

### DIFF
--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Convex hot lists stop rereading heavyweight documents - 2026-08-12
+
+Nine days of production traffic consumed 125 GB of Convex database I/O, led by `sessions.list`, `sessionWorkflow.claimPendingTurn`, `mentions.listData`, `agentTasks.getAllTasks`, and `repoSkills.listByRepo`. Their return values were already fairly small, but Convex charges for the source documents a function reads: projecting a few fields after `collect()` did not avoid loading session terminal state, task run logs, document bodies, or complete SKILL.md files.
+
+The 50 ms session daemon poll now reads a small `sessionDaemonStates` row containing only the staged turn and interrupt/setup signals. Existing sessions create that row on their first poll, and every signal writer mirrors the old session fields during the rollout, so in-flight daemons and rollback-safe code keep the same claim, cancellation, attachment, stop-agent, and setup-gate behavior. This also removes the hot poll from the large session document's contention set.
+
+Task lists now read one compact latest-run summary set per repo instead of joining every task to its newest full `agentRuns` document, whose logs and result data grow throughout execution. Every task and run creation path maintains the summary, while a per-task live-read fallback preserves exact results until the online backfill reaches that row. Repo skill metadata similarly keeps new SKILL.md bodies in `repoSkillContents`; the content viewer falls back to legacy inline content while the migration moves old bodies, so `listByRepo` stops paying for bodies it never returns.
+
+Session, mention, and task list predicates now use compound indexes that include archive/status and soft-delete state. This moves exclusion into Convex's index range instead of scanning documents and filtering afterward, while retaining the existing caps, ordering, authorization, return validators, archived-session semantics, and open-task mention set.
+
 ## Component data survives a sync to a local backend - 2026-08-12
 
 `sync:prod-to-local` imported the snapshot zip whole, and a zip that holds component tables cannot be imported that way. The import failed with "New table `X` in '\<component\>' has IDs that conflict with existing system table", because the CLI addresses a component namespace by name through `--component`, not by the `_components/` directories inside the zip. Every namespace also numbers its user tables from 10001, so a single whole-zip import puts two namespaces on the same numbers.
@@ -158,7 +168,7 @@ Also on that header: the head ref chip no longer truncates at `max-w-56` while t
 
 ## Persistent review header, checks pill, and a button for merge conflicts - 2026-08-11
 
-Everything that says what a pull request *is* lived inside the Overview tab: lifecycle pill, author, a prose sentence ("X wants to merge 3 commits into main from eva/foo"), and — at the foot of a long scroll — the merge box with CI and mergeability. From Diffs or Recap there was no way to tell a mergeable pull request from a conflicted one, and the sentence wrapped to three lines in a session pane.
+Everything that says what a pull request _is_ lived inside the Overview tab: lifecycle pill, author, a prose sentence ("X wants to merge 3 commits into main from eva/foo"), and — at the foot of a long scroll — the merge box with CI and mergeability. From Diffs or Recap there was no way to tell a mergeable pull request from a conflicted one, and the sentence wrapped to three lines in a session pane.
 
 `ReviewTabsPanel` now reads `usePrOverview` itself and renders a shared `ReviewHeader` above the tab row, so both review surfaces (`/reviews/$prNumber`, sandbox Review tab) get one header from one query: status pill, author and last-updated, `base ← head` as monospace chips, commits/files/±diffstat, and a blocker badge. The prose sentence and `PrOverviewHeader` are deleted; `ReviewOverviewPanel` takes the payload as props instead of fetching a second time, and the standalone page's title block became the header's first row (`headerOwnsRefresh` still keeps Refresh to one control).
 
@@ -191,11 +201,13 @@ Tailwind v4’s preflight switched buttons to `cursor: default` (browser UA). In
 OpenAI shipped GPT-5.6 coding tiers (Sol / Terra / Luna) while Eva’s Codex picker still only offered GPT-5.5. Added `codex:gpt-5.6-sol`, `codex:gpt-5.6-terra`, and `codex:gpt-5.6-luna` (CLI slugs `gpt-5.6-*`), kept GPT-5.5, aliased bare `codex:gpt-5.6` → Sol, exposed `max` reasoning for 5.6, and updated Codex token pricing.
 
 ## One sandbox owner contract for sessions, tasks, and projects - 2026-08-10
+
 ## Mouse wheel dead-zones from blanket overscroll contain - 2026-08-08
 
 Putting `overscroll-behavior: contain` on `@utility scrollbar` made every `overflow:auto` pane a contain target, including ones with no overflow and horizontal boards with `overflow-y-hidden`. Chrome treats those as scroll containers at their boundary, so the wheel was swallowed while dragging the ancestor scrollbar still worked. Removed contain from the utility; restored `overscroll-y-contain` / `overscroll-contain` on the kanban column and mention picker that had opted in before.
 
 ## Anonymous landing no longer waits for Clerk - 2026-08-08
+
 ## Anonymous landing no longer waits for Clerk - 2026-08-08
 
 Boot held first paint on Clerk's `isLoaded` for everyone. For a returning signed-in user that is correct — protected routes need the restored session and the alternative is a landing-page flash. For an anonymous visitor it means a blank screen while ~210 kB of clerk-js downloads from Clerk's CDN and completes a handshake, to restore a session that does not exist. Measured on production: clerk-js is 30% of the 700 kB cold landing payload, and FCP (~500 ms) was gated on it.

--- a/packages/backend/convex/_agentTasks/drafts.ts
+++ b/packages/backend/convex/_agentTasks/drafts.ts
@@ -21,6 +21,7 @@ import {
   assertProviderAccountUsableBy,
   resolveDefaultProviderAccountId,
 } from "../_userProviderAccounts/defaults";
+import { createTaskRunSummary } from "./runSummary";
 
 /** Lists all draft tasks for the current user in a given repo, sorted by most recently updated. */
 export const listDrafts = authQuery({
@@ -110,6 +111,7 @@ export const saveDraft = authMutation({
       projectId: args.projectId,
       numId: await allocateNumId(ctx.db, args.repoId, "agentTasks"),
     });
+    await createTaskRunSummary(ctx, draftId, args.repoId);
     await ensureSubscribed(ctx, draftId, ctx.userId);
     return draftId;
   },

--- a/packages/backend/convex/_agentTasks/execution.ts
+++ b/packages/backend/convex/_agentTasks/execution.ts
@@ -15,6 +15,7 @@ import { workflow } from "../workflowManager";
 import { buildProjectBranchName } from "../_projects/helpers";
 import { resolveTaskWorkflowBaseBranch } from "../_taskWorkflow/resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
+import { setTaskLastRunStartedAt } from "./runSummary";
 
 /** Starts task execution by creating a run and launching the workflow. */
 export const startExecution = authMutation({
@@ -109,11 +110,12 @@ export const startExecution = authMutation({
       project ?? undefined,
     );
 
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.id,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       mode: args.mode,
       triggeredBy: ctx.userId,
       // Explicit comment (quick-task "Make changes") wins; otherwise consume any
@@ -127,6 +129,7 @@ export const startExecution = authMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.id, task.repoId, startedAt);
     await ctx.db.patch(args.id, {
       status: "in_progress",
       updatedAt: Date.now(),

--- a/packages/backend/convex/_agentTasks/mutations.ts
+++ b/packages/backend/convex/_agentTasks/mutations.ts
@@ -32,6 +32,7 @@ import {
   reconcileProviderAccountForModel,
   resolveDefaultProviderAccountId,
 } from "../_userProviderAccounts/defaults";
+import { createTaskRunSummary, moveTaskRunSummary } from "./runSummary";
 
 /** Extracts the PR number from a GitHub PR URL. */
 function extractPrNumber(prUrl: string): number | null {
@@ -148,6 +149,9 @@ export const update = authMutation({
     if (args.priority !== undefined)
       updates.priority = args.priority ?? undefined;
     await ctx.db.patch(args.id, updates);
+    if (args.repoId !== undefined && args.repoId !== task.repoId) {
+      await moveTaskRunSummary(ctx, args.id, args.repoId);
+    }
 
     if (args.title !== undefined && args.title !== task.title) {
       await logTaskActivity(
@@ -552,6 +556,7 @@ export const createQuickTask = authMutation({
       attachmentStorageIds: args.attachmentStorageIds,
       numId,
     });
+    await createTaskRunSummary(ctx, taskId, args.repoId);
     await ensureSubscribed(ctx, taskId, ctx.userId);
     await ctx.scheduler.runAfter(0, internal.textGen.generateTaskTags, {
       taskId,
@@ -613,6 +618,7 @@ export const createQuickTasksBatch = authMutation({
         model: repo.defaultModel,
         numId,
       });
+      await createTaskRunSummary(ctx, taskId, args.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
       taskIds.push(taskId);
     }
@@ -712,6 +718,7 @@ export const createBatchWithDependencies = authMutation({
         model,
         numId,
       });
+      await createTaskRunSummary(ctx, taskId, args.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
       taskIds.push(taskId);
     }

--- a/packages/backend/convex/_agentTasks/queries.ts
+++ b/packages/backend/convex/_agentTasks/queries.ts
@@ -17,8 +17,32 @@ async function enrichTasksWithLastRun(
   db: QueryCtx["db"],
   tasks: Array<Doc<"agentTasks">>,
 ) {
+  const repoIds = new Set<Id<"githubRepos">>();
+  for (const task of tasks) {
+    if (task.repoId) repoIds.add(task.repoId);
+  }
+  const summaryGroups = await Promise.all(
+    [...repoIds].map((repoId) =>
+      db
+        .query("agentTaskRunSummaries")
+        .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+        .collect(),
+    ),
+  );
+  const summariesByTask = new Map(
+    summaryGroups.flat().map((summary) => [String(summary.taskId), summary]),
+  );
+
   return Promise.all(
     tasks.map(async (task) => {
+      const summary = summariesByTask.get(String(task._id));
+      if (summary) {
+        return {
+          ...task,
+          lastRunStartedAt: summary.lastRunStartedAt,
+        };
+      }
+      // Migration-safe fallback for tasks whose summary row is not backfilled.
       const latestRun = await db
         .query("agentRuns")
         .withIndex("by_task", (q) => q.eq("taskId", task._id))
@@ -195,15 +219,16 @@ export const getAllTasks = authQuery({
       nonDraftStatuses.map((status) =>
         ctx.db
           .query("agentTasks")
-          .withIndex("by_repo_and_status", (q) =>
-            q.eq("repoId", args.repoId).eq("status", status),
+          .withIndex("by_repo_status_and_deleted", (q) =>
+            q
+              .eq("repoId", args.repoId)
+              .eq("status", status)
+              .eq("deletedAt", undefined),
           )
           .collect(),
       ),
     );
-    const tasks = filterActiveEntities(taskArrays.flat()).sort(
-      (a, b) => a.createdAt - b.createdAt,
-    );
+    const tasks = taskArrays.flat().sort((a, b) => a.createdAt - b.createdAt);
     return enrichTasksWithLastRun(ctx.db, tasks);
   },
 });

--- a/packages/backend/convex/_agentTasks/runSummary.ts
+++ b/packages/backend/convex/_agentTasks/runSummary.ts
@@ -1,0 +1,48 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+/** Inserts the no-runs sentinel row for a newly created task. */
+export async function createTaskRunSummary(
+  ctx: MutationCtx,
+  taskId: Id<"agentTasks">,
+  repoId: Id<"githubRepos">,
+): Promise<void> {
+  await ctx.db.insert("agentTaskRunSummaries", { taskId, repoId });
+}
+
+/** Upserts the small latest-run row used by task list queries. */
+export async function setTaskLastRunStartedAt(
+  ctx: MutationCtx,
+  taskId: Id<"agentTasks">,
+  repoId: Id<"githubRepos">,
+  lastRunStartedAt: number,
+): Promise<void> {
+  const summary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (summary) {
+    await ctx.db.patch(summary._id, { repoId, lastRunStartedAt });
+    return;
+  }
+  await ctx.db.insert("agentTaskRunSummaries", {
+    taskId,
+    repoId,
+    lastRunStartedAt,
+  });
+}
+
+/** Keeps the summary's repo key correct when a task moves between repos. */
+export async function moveTaskRunSummary(
+  ctx: MutationCtx,
+  taskId: Id<"agentTasks">,
+  repoId: Id<"githubRepos">,
+): Promise<void> {
+  const summary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (summary) {
+    await ctx.db.patch(summary._id, { repoId });
+  }
+}

--- a/packages/backend/convex/_automations/findings.ts
+++ b/packages/backend/convex/_automations/findings.ts
@@ -10,6 +10,10 @@ import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
 import { resolveTaskWorkflowBaseBranchForTask } from "../_taskWorkflow/resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
 import { normalizeAIModel } from "../validators";
+import {
+  createTaskRunSummary,
+  setTaskLastRunStartedAt,
+} from "../_agentTasks/runSummary";
 
 /** Creates agent tasks from selected automation findings and optionally auto-starts them. */
 export const createTasksFromFindings = authMutation({
@@ -62,6 +66,7 @@ export const createTasksFromFindings = authMutation({
         model: automation.model ?? repo.defaultModel,
         numId: await allocateNumId(ctx.db, automation.repoId, "agentTasks"),
       });
+      await createTaskRunSummary(ctx, taskId, automation.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
 
       updatedFindings[i] = { ...finding, taskId };
@@ -108,11 +113,12 @@ export const autoStartTask = internalMutation({
       return null;
     }
 
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.taskId,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
         task.providerAccountId,
@@ -120,6 +126,7 @@ export const autoStartTask = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, startedAt);
 
     await ctx.db.patch(args.taskId, {
       status: "in_progress",

--- a/packages/backend/convex/_chat/surfaceAdapters.ts
+++ b/packages/backend/convex/_chat/surfaceAdapters.ts
@@ -12,6 +12,7 @@ import {
   startNextQueuedTaskChatMessage,
 } from "../_queues/helpers";
 import type { WorkflowId } from "@convex-dev/workflow";
+import { syncSessionDaemonState } from "../_sessions/daemonState";
 
 /** Streaming entityId prefix for project chat workflows. */
 export const PROJECT_CHAT_STREAM_PREFIX = "project-chat-";
@@ -127,7 +128,9 @@ const sessionChatAdapter: ChatSurfaceAdapter<
   repoId: (session) => session.repoId,
   interrupt: async (ctx, session) => {
     if (getAIModelProvider(normalizeAIModel(session.lastModel)) === "claude") {
-      await ctx.db.patch(session._id, { cancelRequestedAt: Date.now() });
+      const cancelRequestedAt = Date.now();
+      await ctx.db.patch(session._id, { cancelRequestedAt });
+      await syncSessionDaemonState(ctx, session, { cancelRequestedAt });
     } else if (session.sandboxId) {
       await ctx.scheduler.runAfter(0, internal.sandbox.killSandboxProcess, {
         sandboxId: session.sandboxId,

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as _agentTasks_helpers from "../_agentTasks/helpers.js";
 import type * as _agentTasks_internal from "../_agentTasks/internal.js";
 import type * as _agentTasks_mutations from "../_agentTasks/mutations.js";
 import type * as _agentTasks_queries from "../_agentTasks/queries.js";
+import type * as _agentTasks_runSummary from "../_agentTasks/runSummary.js";
 import type * as _agentTasks_sandbox from "../_agentTasks/sandbox.js";
 import type * as _auth_currentUser from "../_auth/currentUser.js";
 import type * as _auth_experimentalFlags from "../_auth/experimentalFlags.js";
@@ -112,6 +113,7 @@ import type * as _pty_launchDevServerInVercelConsole from "../_pty/launchDevServ
 import type * as _pty_owners from "../_pty/owners.js";
 import type * as _pty_vercel from "../_pty/vercel.js";
 import type * as _queues_helpers from "../_queues/helpers.js";
+import type * as _repoSkills_content from "../_repoSkills/content.js";
 import type * as _repoSkills_decodeGitHubContent from "../_repoSkills/decodeGitHubContent.js";
 import type * as _repoSkills_skillMarkdown from "../_repoSkills/skillMarkdown.js";
 import type * as _repoSkills_sync from "../_repoSkills/sync.js";
@@ -157,6 +159,7 @@ import type * as _sandbox_runtime_swap from "../_sandbox_runtime/swap.js";
 import type * as _sandbox_runtime_vercelAppPorts from "../_sandbox_runtime/vercelAppPorts.js";
 import type * as _sessions_backgroundAgents from "../_sessions/backgroundAgents.js";
 import type * as _sessions_baseBranch from "../_sessions/baseBranch.js";
+import type * as _sessions_daemonState from "../_sessions/daemonState.js";
 import type * as _sessions_execution from "../_sessions/execution.js";
 import type * as _sessions_helpers from "../_sessions/helpers.js";
 import type * as _sessions_internal from "../_sessions/internal.js";
@@ -340,6 +343,7 @@ declare const fullApi: ApiFromModules<{
   "_agentTasks/internal": typeof _agentTasks_internal;
   "_agentTasks/mutations": typeof _agentTasks_mutations;
   "_agentTasks/queries": typeof _agentTasks_queries;
+  "_agentTasks/runSummary": typeof _agentTasks_runSummary;
   "_agentTasks/sandbox": typeof _agentTasks_sandbox;
   "_auth/currentUser": typeof _auth_currentUser;
   "_auth/experimentalFlags": typeof _auth_experimentalFlags;
@@ -435,6 +439,7 @@ declare const fullApi: ApiFromModules<{
   "_pty/owners": typeof _pty_owners;
   "_pty/vercel": typeof _pty_vercel;
   "_queues/helpers": typeof _queues_helpers;
+  "_repoSkills/content": typeof _repoSkills_content;
   "_repoSkills/decodeGitHubContent": typeof _repoSkills_decodeGitHubContent;
   "_repoSkills/skillMarkdown": typeof _repoSkills_skillMarkdown;
   "_repoSkills/sync": typeof _repoSkills_sync;
@@ -480,6 +485,7 @@ declare const fullApi: ApiFromModules<{
   "_sandbox_runtime/vercelAppPorts": typeof _sandbox_runtime_vercelAppPorts;
   "_sessions/backgroundAgents": typeof _sessions_backgroundAgents;
   "_sessions/baseBranch": typeof _sessions_baseBranch;
+  "_sessions/daemonState": typeof _sessions_daemonState;
   "_sessions/execution": typeof _sessions_execution;
   "_sessions/helpers": typeof _sessions_helpers;
   "_sessions/internal": typeof _sessions_internal;

--- a/packages/backend/convex/_mentions/listData.ts
+++ b/packages/backend/convex/_mentions/listData.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { authQuery, hasRepoAccess } from "../functions";
-import { entityVisible, filterActiveEntities, isEntityDeleted } from "../numId";
+import { entityVisible } from "../numId";
 import {
   DATA_MENTION_BADGE,
   DATA_MENTION_KINDS,
@@ -70,11 +70,12 @@ export const listData = authQuery({
 
     const docs = await ctx.db
       .query("docs")
-      .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
+      .withIndex("by_repo_and_deleted", (q) =>
+        q.eq("repoId", args.repoId).eq("deletedAt", undefined),
+      )
       .order("desc")
       .take(MENTION_LIST_CAP);
     for (const doc of docs) {
-      if (isEntityDeleted(doc)) continue;
       // Prefer stored description — avoid pulling the whole body into the
       // picker payload even though the document read already paid for it.
       const description = doc.description?.trim()
@@ -91,13 +92,13 @@ export const listData = authQuery({
     }
 
     // Include archived sessions — soft-deleted only are excluded below.
-    const sessions = filterActiveEntities(
-      await ctx.db
-        .query("sessions")
-        .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
-        .order("desc")
-        .take(MENTION_LIST_CAP),
-    );
+    const sessions = await ctx.db
+      .query("sessions")
+      .withIndex("by_repo_and_deleted", (q) =>
+        q.eq("repoId", args.repoId).eq("deletedAt", undefined),
+      )
+      .order("desc")
+      .take(MENTION_LIST_CAP);
     for (const session of sessions) {
       items.push({
         kind: "session",
@@ -108,13 +109,13 @@ export const listData = authQuery({
       });
     }
 
-    const projects = filterActiveEntities(
-      await ctx.db
-        .query("projects")
-        .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
-        .order("desc")
-        .take(MENTION_LIST_CAP),
-    );
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_repo_and_deleted", (q) =>
+        q.eq("repoId", args.repoId).eq("deletedAt", undefined),
+      )
+      .order("desc")
+      .take(MENTION_LIST_CAP);
     for (const project of projects) {
       const description = project.description?.trim();
       items.push({
@@ -135,13 +136,16 @@ export const listData = authQuery({
       taskStatuses.map((status) =>
         ctx.db
           .query("agentTasks")
-          .withIndex("by_repo_and_status", (q) =>
-            q.eq("repoId", args.repoId).eq("status", status),
+          .withIndex("by_repo_status_and_deleted", (q) =>
+            q
+              .eq("repoId", args.repoId)
+              .eq("status", status)
+              .eq("deletedAt", undefined),
           )
           .take(MENTION_LIST_CAP),
       ),
     );
-    for (const task of filterActiveEntities(taskArrays.flat())) {
+    for (const task of taskArrays.flat()) {
       const description = task.description?.trim();
       items.push({
         kind: "quickTask",

--- a/packages/backend/convex/_migrations/deleteRepos.ts
+++ b/packages/backend/convex/_migrations/deleteRepos.ts
@@ -131,6 +131,14 @@ export const deleteRepoStep = internalMutation({
       }
 
       case "tasks": {
+        const summaries = await ctx.db
+          .query("agentTaskRunSummaries")
+          .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+          .collect();
+        for (const summary of summaries) {
+          await ctx.db.delete(summary._id);
+          deleted++;
+        }
         const tasks = await ctx.db
           .query("agentTasks")
           .withIndex("by_repo", (q) => q.eq("repoId", repoId))
@@ -148,6 +156,14 @@ export const deleteRepoStep = internalMutation({
           .withIndex("by_repo", (q) => q.eq("repoId", repoId))
           .collect();
         for (const session of sessions) {
+          const daemonState = await ctx.db
+            .query("sessionDaemonStates")
+            .withIndex("by_session", (q) => q.eq("sessionId", session._id))
+            .unique();
+          if (daemonState) {
+            await ctx.db.delete(daemonState._id);
+            deleted++;
+          }
           const messages = await ctx.db
             .query("messages")
             .withIndex("by_parent", (q) => q.eq("parentId", session._id))
@@ -228,6 +244,20 @@ export const deleteRepoStep = internalMutation({
       }
 
       case "flatTables": {
+        const repoSkills = await ctx.db
+          .query("repoSkills")
+          .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+          .collect();
+        for (const skill of repoSkills) {
+          const content = await ctx.db
+            .query("repoSkillContents")
+            .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+            .unique();
+          if (content) {
+            await ctx.db.delete(content._id);
+            deleted++;
+          }
+        }
         const tables = [
           "designPersonas",
           "repoSkills",

--- a/packages/backend/convex/_projects/development.ts
+++ b/packages/backend/convex/_projects/development.ts
@@ -10,6 +10,7 @@ import {
   buildProjectBranchName,
 } from "./helpers";
 import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
+import { createTaskRunSummary } from "../_agentTasks/runSummary";
 
 /** Converts a finalized project spec into tasks with dependencies and sets the project to business_review. */
 export const startDevelopment = authMutation({
@@ -54,6 +55,7 @@ export const startDevelopment = authMutation({
         baseBranch: projectBaseBranch,
         numId,
       });
+      await createTaskRunSummary(ctx, taskId, project.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
       taskIdMap.set(taskNumber, taskId);
     }

--- a/packages/backend/convex/_projects/sandbox.ts
+++ b/packages/backend/convex/_projects/sandbox.ts
@@ -12,6 +12,7 @@ import {
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
 import { clearPendingQuestionsForEntity } from "../pendingQuestions";
 import { normalizeAIModel } from "../validators";
+import { setTaskLastRunStartedAt } from "../_agentTasks/runSummary";
 
 const PREVIEW_ALLOWED_PHASES = [
   "in_progress",
@@ -244,11 +245,12 @@ export const resolveProjectConflicts = authMutation({
       project.baseBranch ?? repo.defaultBaseBranch ?? FALLBACK_GIT_BASE_BRANCH;
 
     const previousStatus = carrier.status;
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: carrier._id,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       mode: "resolve_conflicts",
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
@@ -257,6 +259,7 @@ export const resolveProjectConflicts = authMutation({
       ),
       model: normalizeAIModel(carrier.model),
     });
+    await setTaskLastRunStartedAt(ctx, carrier._id, project.repoId, startedAt);
     await ctx.db.patch(carrier._id, {
       status: "in_progress",
       updatedAt: Date.now(),

--- a/packages/backend/convex/_repoSkills/content.ts
+++ b/packages/backend/convex/_repoSkills/content.ts
@@ -1,0 +1,21 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+/** Stores a SKILL.md body outside the metadata row used by list subscriptions. */
+export async function upsertRepoSkillContent(
+  ctx: MutationCtx,
+  skillId: Id<"repoSkills">,
+  content: string,
+): Promise<void> {
+  const existing = await ctx.db
+    .query("repoSkillContents")
+    .withIndex("by_skill", (q) => q.eq("skillId", skillId))
+    .unique();
+  if (existing) {
+    if (existing.content !== content) {
+      await ctx.db.patch(existing._id, { content });
+    }
+    return;
+  }
+  await ctx.db.insert("repoSkillContents", { skillId, content });
+}

--- a/packages/backend/convex/_sessions/daemonState.ts
+++ b/packages/backend/convex/_sessions/daemonState.ts
@@ -1,0 +1,53 @@
+import type { Doc } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+export type SessionDaemonPatch = Pick<
+  Doc<"sessions">,
+  | "pendingTurn"
+  | "pendingTaskStops"
+  | "cancelRequestedAt"
+  | "sandboxSetupPending"
+>;
+
+/** Mirrors daemon-only session fields into the small row polled by warm agents. */
+export async function syncSessionDaemonState(
+  ctx: MutationCtx,
+  session: Doc<"sessions">,
+  patch: Partial<SessionDaemonPatch>,
+): Promise<void> {
+  const state = await ctx.db
+    .query("sessionDaemonStates")
+    .withIndex("by_session", (q) => q.eq("sessionId", session._id))
+    .unique();
+
+  if (state) {
+    await ctx.db.patch(state._id, patch);
+    return;
+  }
+
+  await ctx.db.insert("sessionDaemonStates", {
+    sessionId: session._id,
+    repoId: session.repoId,
+    userId: session.userId,
+    pendingTurn: Object.hasOwn(patch, "pendingTurn")
+      ? patch.pendingTurn
+      : session.pendingTurn,
+    pendingTaskStops: Object.hasOwn(patch, "pendingTaskStops")
+      ? patch.pendingTaskStops
+      : session.pendingTaskStops,
+    cancelRequestedAt: Object.hasOwn(patch, "cancelRequestedAt")
+      ? patch.cancelRequestedAt
+      : session.cancelRequestedAt,
+    sandboxSetupPending: Object.hasOwn(patch, "sandboxSetupPending")
+      ? patch.sandboxSetupPending
+      : session.sandboxSetupPending,
+  });
+}
+
+/** Creates the small daemon row lazily for sessions predating this split. */
+export async function ensureSessionDaemonState(
+  ctx: MutationCtx,
+  session: Doc<"sessions">,
+): Promise<void> {
+  await syncSessionDaemonState(ctx, session, {});
+}

--- a/packages/backend/convex/_sessions/execution.ts
+++ b/packages/backend/convex/_sessions/execution.ts
@@ -13,6 +13,7 @@ import {
 import { trackSessionWorkflow } from "../workflowWatchdog";
 import { clearStreamingActivity } from "../_taskWorkflow/helpers";
 import { finalizeCancelledAssistantMessage } from "../streaming";
+import { syncSessionDaemonState } from "./daemonState";
 import { startNextQueuedSessionMessage } from "../_queues/helpers";
 import { buildSessionPrompt, MODE_TOOLS, resolveToolMode } from "./workflow";
 import {
@@ -145,17 +146,16 @@ export const startExecute = authMutation({
     // leftover Claude daemon mismatch-spam while launchOnExistingSandbox runs.
     const normalizedModel = normalizeAIModel(args.model);
     const usesDaemonPull = getAIModelProvider(normalizedModel) === "claude";
+    const pendingTurn = usesDaemonPull
+      ? {
+          prompt,
+          requestedAt: Date.now(),
+          attachmentStorageIds: args.attachmentStorageIds,
+          model: normalizedModel,
+        }
+      : undefined;
     await ctx.db.patch(args.sessionId, {
-      ...(usesDaemonPull
-        ? {
-            pendingTurn: {
-              prompt,
-              requestedAt: Date.now(),
-              attachmentStorageIds: args.attachmentStorageIds,
-              model: normalizedModel,
-            },
-          }
-        : { pendingTurn: undefined }),
+      pendingTurn,
       // Deliberately no cancelRequestedAt clear here: staging must never wipe
       // an undrained cancel for a still-running turn (the daemon drains the
       // flag via claimPendingTurn, and ignores it when no turn is active, so a
@@ -176,6 +176,7 @@ export const startExecute = authMutation({
       ...(args.fastMode !== undefined ? { lastFastMode: args.fastMode } : {}),
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, { pendingTurn });
 
     // Ensure a Claude daemon exists to claim the staged prompt. Skip for
     // one-shot providers (prewarmSessionDaemon already no-ops, but scheduling
@@ -375,7 +376,9 @@ export const cancelExecution = authMutation({
     await cancelTrackedWorkflow(ctx, workflowIdToCancel);
 
     if (getAIModelProvider(normalizeAIModel(session.lastModel)) === "claude") {
-      await ctx.db.patch(args.sessionId, { cancelRequestedAt: Date.now() });
+      const cancelRequestedAt = Date.now();
+      await ctx.db.patch(args.sessionId, { cancelRequestedAt });
+      await syncSessionDaemonState(ctx, session, { cancelRequestedAt });
     } else if (session.sandboxId) {
       await ctx.scheduler.runAfter(0, internal.sandbox.killSandboxProcess, {
         sandboxId: session.sandboxId,
@@ -435,10 +438,10 @@ export const cancelExecution = authMutation({
     ) {
       sessionPatch.activeWorkflowId = undefined;
     }
-    if (
+    const clearsPendingTurn =
       pendingRequestedAt !== undefined &&
-      latest.pendingTurn?.requestedAt === pendingRequestedAt
-    ) {
+      latest.pendingTurn?.requestedAt === pendingRequestedAt;
+    if (clearsPendingTurn) {
       sessionPatch.pendingTurn = undefined;
     }
     if (!newerTurnStaged && !newerWorkflowTracked) {
@@ -446,6 +449,9 @@ export const cancelExecution = authMutation({
     }
 
     await ctx.db.patch(args.sessionId, sessionPatch);
+    if (clearsPendingTurn) {
+      await syncSessionDaemonState(ctx, latest, { pendingTurn: undefined });
+    }
 
     await startNextQueuedSessionMessage(ctx, args.sessionId);
 

--- a/packages/backend/convex/_sessions/queries.ts
+++ b/packages/backend/convex/_sessions/queries.ts
@@ -101,13 +101,20 @@ export const list = authQuery({
   returns: v.array(sessionListItemValidator),
   handler: async (ctx, args) => {
     if (!(await hasRepoAccess(ctx.db, args.repoId, ctx.userId))) return [];
-    const sessions = filterActiveEntities(
-      await ctx.db
-        .query("sessions")
-        .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
-        .filter((q) => q.neq(q.field("archived"), true))
-        .collect(),
+    const sessionGroups = await Promise.all(
+      [undefined, false].map((archived) =>
+        ctx.db
+          .query("sessions")
+          .withIndex("by_repo_archived_and_deleted", (q) =>
+            q
+              .eq("repoId", args.repoId)
+              .eq("archived", archived)
+              .eq("deletedAt", undefined),
+          )
+          .collect(),
+      ),
     );
+    const sessions = sessionGroups.flat();
     return sessions.sort(byMostRecentlyUpdated).map(toSessionListItem);
   },
 });
@@ -118,14 +125,15 @@ export const listArchived = authQuery({
   returns: v.array(sessionListItemValidator),
   handler: async (ctx, args) => {
     if (!(await hasRepoAccess(ctx.db, args.repoId, ctx.userId))) return [];
-    const sessions = filterActiveEntities(
-      await ctx.db
-        .query("sessions")
-        .withIndex("by_repo_and_archived", (q) =>
-          q.eq("repoId", args.repoId).eq("archived", true),
-        )
-        .collect(),
-    );
+    const sessions = await ctx.db
+      .query("sessions")
+      .withIndex("by_repo_archived_and_deleted", (q) =>
+        q
+          .eq("repoId", args.repoId)
+          .eq("archived", true)
+          .eq("deletedAt", undefined),
+      )
+      .collect();
     return sessions.sort(byMostRecentlyUpdated).map(toSessionListItem);
   },
 });

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -18,6 +18,7 @@ import { clearStreamingActivity } from "../_taskWorkflow/helpers";
 import { finalizeCancelledAssistantMessage } from "../streaming";
 import { clearPendingQuestionsForEntity } from "../pendingQuestions";
 import { startNextQueuedSessionMessage } from "../_queues/helpers";
+import { syncSessionDaemonState } from "./daemonState";
 
 /** How long to wait before re-issuing stop if finalize died with a Convex transient error. */
 const STUCK_STOPPING_RECOVER_MS = 20_000;
@@ -414,6 +415,11 @@ export const sandboxReady = internalMutation({
       ...(args.devCommand !== undefined ? { devCommand: args.devCommand } : {}),
       ...(args.markSetupPending ? { sandboxSetupPending: true } : {}),
     });
+    if (args.markSetupPending) {
+      await syncSessionDaemonState(ctx, session, {
+        sandboxSetupPending: true,
+      });
+    }
     // Drain first-message (and any other) queued turns now that chat can run.
     // Early + final ready both call this; second no-ops while activeWorkflowId is set.
     await startNextQueuedSessionMessage(ctx, args.sessionId);
@@ -434,6 +440,9 @@ export const clearSandboxSetupPending = internalMutation({
     const session = await ctx.db.get(args.sessionId);
     if (!session || session.sandboxSetupPending !== true) return null;
     await ctx.db.patch(args.sessionId, { sandboxSetupPending: undefined });
+    await syncSessionDaemonState(ctx, session, {
+      sandboxSetupPending: undefined,
+    });
     return null;
   },
 });

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -36,6 +36,10 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { finalizeCancelledAssistantMessage } from "../streaming";
 import { backgroundAgentEntryValidator } from "../_validators/tableFields";
 import { mergeBackgroundAgents } from "./backgroundAgents";
+import {
+  ensureSessionDaemonState,
+  syncSessionDaemonState,
+} from "./daemonState";
 
 // --- Completion event ---
 
@@ -558,7 +562,6 @@ export const sessionExecuteWorkflow = workflow.define({
         }
       }
     }
-
   },
 });
 
@@ -659,6 +662,9 @@ export const clearStuckWorkingState = internalMutation({
       syntheticTurnMessageId: undefined,
       updatedAt: Date.now(),
     });
+    if (session) {
+      await syncSessionDaemonState(ctx, session, { pendingTurn: undefined });
+    }
     return { deletedPlaceholders, clearedStreaming: true };
   },
 });
@@ -965,12 +971,24 @@ export const claimPendingTurn = authMutation({
       stopTaskToolUseIds: string[];
       cancelRequested: boolean;
     };
-    const session = await ctx.db.get(args.sessionId);
-    if (!session) return emptyClaim;
-    // Daemon polls this ~20×/s; skip the repo+membership join when the token
-    // is already the session owner (the normal sandbox CONVEX_TOKEN case).
-    if (session.userId !== ctx.userId) {
-      if (!(await hasRepoAccess(ctx.db, session.repoId, ctx.userId)))
+    let daemonState = await ctx.db
+      .query("sessionDaemonStates")
+      .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
+      .unique();
+    if (!daemonState) {
+      const session = await ctx.db.get(args.sessionId);
+      if (!session) return emptyClaim;
+      await ensureSessionDaemonState(ctx, session);
+      daemonState = await ctx.db
+        .query("sessionDaemonStates")
+        .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
+        .unique();
+      if (!daemonState) return emptyClaim;
+    }
+    // The normal owner path now reads only this small row, not the session's
+    // plan, terminal history, panes, and other UI state on every 50ms poll.
+    if (daemonState.userId !== ctx.userId) {
+      if (!(await hasRepoAccess(ctx.db, daemonState.repoId, ctx.userId)))
         throw new Error("Not authorized");
     }
 
@@ -979,28 +997,30 @@ export const claimPendingTurn = authMutation({
     // cleared when setup finishes). Returning an empty claim leaves pendingTurn
     // intact; the daemon keeps polling (45m idle budget) and claims the moment
     // the gate clears, so the agent never executes against a stale checkout.
-    if (session.sandboxSetupPending === true) {
+    if (daemonState.sandboxSetupPending === true) {
       return emptyClaim;
     }
 
-    const stopTaskToolUseIds = session.pendingTaskStops ?? [];
+    const stopTaskToolUseIds = daemonState.pendingTaskStops ?? [];
     if (stopTaskToolUseIds.length > 0) {
+      await ctx.db.patch(daemonState._id, { pendingTaskStops: undefined });
       await ctx.db.patch(args.sessionId, { pendingTaskStops: undefined });
     }
 
     // Cancel must drain the same way as stopTaskToolUseIds above: the daemon
     // polls this mutation continuously, including mid-turn, specifically to
     // notice an interrupt — gating the drain on pendingTurn would strand it.
-    const cancelRequested = session.cancelRequestedAt !== undefined;
+    const cancelRequested = daemonState.cancelRequestedAt !== undefined;
     if (cancelRequested) {
+      await ctx.db.patch(daemonState._id, { cancelRequestedAt: undefined });
       await ctx.db.patch(args.sessionId, { cancelRequestedAt: undefined });
     }
 
-    if (!session.pendingTurn) {
+    if (!daemonState.pendingTurn) {
       return { ...emptyClaim, stopTaskToolUseIds, cancelRequested };
     }
 
-    const pendingModel = session.pendingTurn.model;
+    const pendingModel = daemonState.pendingTurn.model;
     if (pendingModel !== undefined) {
       const claimModel = normalizeAIModel(args.model);
       if (normalizeAIModel(pendingModel) !== claimModel) {
@@ -1011,16 +1031,17 @@ export const claimPendingTurn = authMutation({
       }
     }
 
-    const prompt = session.pendingTurn.prompt;
-    const claimWaitMs = Date.now() - session.pendingTurn.requestedAt;
+    const prompt = daemonState.pendingTurn.prompt;
+    const claimWaitMs = Date.now() - daemonState.pendingTurn.requestedAt;
     const resolvedUrls = await Promise.all(
-      (session.pendingTurn.attachmentStorageIds ?? []).map((id) =>
+      (daemonState.pendingTurn.attachmentStorageIds ?? []).map((id) =>
         ctx.storage.getUrl(id),
       ),
     );
     const attachmentUrls = resolvedUrls.filter(
       (url): url is string => url !== null,
     );
+    await ctx.db.patch(daemonState._id, { pendingTurn: undefined });
     await ctx.db.patch(args.sessionId, { pendingTurn: undefined });
     console.log(
       `[sessionWorkflow] claimPendingTurn sessionId=${args.sessionId} claimWaitMs=${claimWaitMs} attachments=${attachmentUrls.length}`,
@@ -1074,6 +1095,9 @@ export const requestStopBackgroundAgent = authMutation({
       pendingTaskStops: [...pending, args.toolUseId],
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, {
+      pendingTaskStops: [...pending, args.toolUseId],
+    });
     return null;
   },
 });
@@ -1117,17 +1141,19 @@ export const ensurePendingTurn = internalMutation({
       return null;
     }
 
+    const pendingTurn = {
+      prompt: args.prompt,
+      requestedAt: Date.now(),
+      attachmentStorageIds: args.attachmentStorageIds,
+      ...(args.model !== undefined
+        ? { model: normalizeAIModel(args.model) }
+        : {}),
+    };
     await ctx.db.patch(args.sessionId, {
-      pendingTurn: {
-        prompt: args.prompt,
-        requestedAt: Date.now(),
-        attachmentStorageIds: args.attachmentStorageIds,
-        ...(args.model !== undefined
-          ? { model: normalizeAIModel(args.model) }
-          : {}),
-      },
+      pendingTurn,
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, { pendingTurn });
     console.log(
       `[sessionWorkflow] ensurePendingTurn restaged sessionId=${args.sessionId}`,
     );
@@ -1213,17 +1239,17 @@ export const restageOpenTurn = internalMutation({
       personaId: lastUser.personaId,
     });
 
+    const pendingTurn = {
+      prompt,
+      requestedAt: Date.now(),
+      attachmentStorageIds: lastUser.attachmentStorageIds,
+      ...(session.lastModel !== undefined ? { model: session.lastModel } : {}),
+    };
     await ctx.db.patch(args.sessionId, {
-      pendingTurn: {
-        prompt,
-        requestedAt: Date.now(),
-        attachmentStorageIds: lastUser.attachmentStorageIds,
-        ...(session.lastModel !== undefined
-          ? { model: session.lastModel }
-          : {}),
-      },
+      pendingTurn,
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, { pendingTurn });
     console.log(
       `[sessionWorkflow] restageOpenTurn sessionId=${args.sessionId}`,
     );
@@ -1400,6 +1426,7 @@ export const handleCompletion = authMutation({
     // clear any leftover staged prompt here. Claude already cleared on claim.
     if (session.pendingTurn !== undefined) {
       await ctx.db.patch(args.sessionId, { pendingTurn: undefined });
+      await syncSessionDaemonState(ctx, session, { pendingTurn: undefined });
     }
 
     await sendCompletionEvent(

--- a/packages/backend/convex/_taskWorkflow/scheduling.ts
+++ b/packages/backend/convex/_taskWorkflow/scheduling.ts
@@ -8,6 +8,7 @@ import { buildProjectBranchName } from "../_projects/helpers";
 import { resolveTaskWorkflowBaseBranchForTask } from "./resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
 import { normalizeAIModel } from "../validators";
+import { setTaskLastRunStartedAt } from "../_agentTasks/runSummary";
 
 /** Schedules an automatic retry for a failed quick task if the failure looks transient. */
 export const maybeScheduleQuickTaskRetry = internalMutation({
@@ -148,6 +149,7 @@ export const executeScheduledTask = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, now);
 
     await ctx.db.patch(args.taskId, {
       ...clearSchedule,

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -173,6 +173,17 @@ export const pendingTurnFields = {
 
 export const pendingTurnValidator = v.optional(v.object(pendingTurnFields));
 
+/** Small daemon-poll row kept separate from heavyweight session documents. */
+export const sessionDaemonStateFields = {
+  sessionId: v.id("sessions"),
+  repoId: v.id("githubRepos"),
+  userId: v.id("users"),
+  pendingTurn: pendingTurnValidator,
+  pendingTaskStops: v.optional(v.array(v.string())),
+  cancelRequestedAt: v.optional(v.number()),
+  sandboxSetupPending: v.optional(v.boolean()),
+};
+
 export const chatDaemonEntityFields = {
   pendingTurn: pendingTurnValidator,
   syntheticTurnMessageId: v.optional(v.id("messages")),
@@ -394,6 +405,12 @@ export const repoSkillFields = {
   unavailableSince: v.optional(v.number()),
   prompt: v.optional(v.string()),
   createdAt: v.number(),
+};
+
+/** Large SKILL.md body split from repoSkills so list queries read metadata only. */
+export const repoSkillContentFields = {
+  skillId: v.id("repoSkills"),
+  content: v.string(),
 };
 
 /**

--- a/packages/backend/convex/buildWorkflow.ts
+++ b/packages/backend/convex/buildWorkflow.ts
@@ -13,6 +13,7 @@ import { buildProjectBranchName } from "./_projects/helpers";
 import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
 import { resolveCredentialSourceLabel } from "./_userProviderAccounts/credentialSource";
 import { normalizeAIModel } from "./validators";
+import { setTaskLastRunStartedAt } from "./_agentTasks/runSummary";
 
 // --- Workflow ---
 
@@ -145,11 +146,12 @@ export const startTaskForBuild = internalMutation({
     // Create the run. When this build picks up a task a reviewer sent back via
     // "Make changes", link the parked change-request comment so the timeline
     // labels this run "made changes" rather than a bare "success".
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.taskId,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       triggeringCommentId: task.pendingChangeRequestCommentId,
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
@@ -158,6 +160,7 @@ export const startTaskForBuild = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, startedAt);
 
     await ctx.db.patch(args.taskId, {
       status: "in_progress",

--- a/packages/backend/convex/dataMigrations.ts
+++ b/packages/backend/convex/dataMigrations.ts
@@ -43,3 +43,50 @@ export const dataMigrations = new Migrations<DataModel, typeof schema>(
 
 /** Generic runner: `npx convex run dataMigrations:run '{fn:"dataMigrations:…"}'`. */
 export const run = dataMigrations.runner();
+
+/** Backfills compact task latest-run rows so list queries stop reading run logs. */
+export const backfillAgentTaskRunSummaries = dataMigrations.define({
+  table: "agentTasks",
+  migrateOne: async (ctx, task) => {
+    if (!task.repoId) return;
+    const existing = await ctx.db
+      .query("agentTaskRunSummaries")
+      .withIndex("by_task", (q) => q.eq("taskId", task._id))
+      .unique();
+    if (existing) return;
+
+    const latestRun = await ctx.db
+      .query("agentRuns")
+      .withIndex("by_task", (q) => q.eq("taskId", task._id))
+      .order("desc")
+      .first();
+    await ctx.db.insert("agentTaskRunSummaries", {
+      taskId: task._id,
+      repoId: task.repoId,
+      lastRunStartedAt: latestRun?.startedAt,
+    });
+  },
+});
+
+/** Moves large SKILL.md bodies out of rows read by repoSkills.listByRepo. */
+export const splitRepoSkillContent = dataMigrations.define({
+  table: "repoSkills",
+  migrateOne: async (ctx, skill) => {
+    if (!skill.content) return;
+    const existing = await ctx.db
+      .query("repoSkillContents")
+      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+      .unique();
+    if (existing) {
+      if (existing.content !== skill.content) {
+        await ctx.db.patch(existing._id, { content: skill.content });
+      }
+    } else {
+      await ctx.db.insert("repoSkillContents", {
+        skillId: skill._id,
+        content: skill.content,
+      });
+    }
+    await ctx.db.patch(skill._id, { content: undefined });
+  },
+});

--- a/packages/backend/convex/evaluationReports.ts
+++ b/packages/backend/convex/evaluationReports.ts
@@ -10,6 +10,10 @@ import { workflow } from "./workflowManager";
 import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
 import { resolveTaskWorkflowBaseBranchForTask } from "./_taskWorkflow/resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "./_userProviderAccounts/credentialSource";
+import {
+  createTaskRunSummary,
+  setTaskLastRunStartedAt,
+} from "./_agentTasks/runSummary";
 
 const reportValidator = v.object({
   _id: v.id("evaluationReports"),
@@ -83,6 +87,7 @@ export const createTasksFromIssues = authMutation({
         model: repo.defaultModel,
         numId: await allocateNumId(ctx.db, report.repoId, "agentTasks"),
       });
+      await createTaskRunSummary(ctx, taskId, report.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
 
       updatedIssues[i] = { ...issue, taskId };
@@ -130,11 +135,12 @@ export const autoStartTask = internalMutation({
       return null;
     }
 
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.taskId,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
         task.providerAccountId,
@@ -142,6 +148,7 @@ export const autoStartTask = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, startedAt);
 
     await ctx.db.patch(args.taskId, {
       status: "in_progress",

--- a/packages/backend/convex/functions.ts
+++ b/packages/backend/convex/functions.ts
@@ -406,6 +406,13 @@ export async function deleteTaskRelatedData(
   for (const event of activityEvents) {
     await ctx.db.delete(event._id);
   }
+  const runSummary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (runSummary) {
+    await ctx.db.delete(runSummary._id);
+  }
   await ctx.db.delete(taskId);
 }
 
@@ -430,6 +437,13 @@ export async function softDeleteAgentTask(
       sandboxId: task.sandboxId,
       repoId: task.repoId,
     });
+  }
+  const runSummary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (runSummary) {
+    await ctx.db.delete(runSummary._id);
   }
   await ctx.db.patch(taskId, { deletedAt: Date.now() });
 }

--- a/packages/backend/convex/repoSkills.ts
+++ b/packages/backend/convex/repoSkills.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { internalMutation, internalQuery } from "./_generated/server";
 import { authQuery, hasRepoAccess } from "./functions";
 import { resolveCanonicalRepoId } from "./_githubRepos/helpers";
+import { upsertRepoSkillContent } from "./_repoSkills/content";
 
 export { syncFromGithub } from "./_repoSkills/sync";
 
@@ -79,12 +80,17 @@ export const getContentById = authQuery({
     if (!(await hasRepoAccess(ctx.db, skill.repoId, ctx.userId))) {
       return null;
     }
-    if (!skill.content) return null;
+    const splitContent = await ctx.db
+      .query("repoSkillContents")
+      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+      .unique();
+    const content = splitContent?.content ?? skill.content;
+    if (!content) return null;
 
     return {
       title: skill.title,
       sourcePath: skill.sourcePath,
-      content: skill.content,
+      content,
     };
   },
 });
@@ -211,10 +217,11 @@ export const applyGithubSync = internalMutation({
       syncedPaths.add(skill.sourcePath);
       const existingSkill = existingBySourcePath.get(skill.sourcePath);
       if (existingSkill) {
+        await upsertRepoSkillContent(ctx, existingSkill._id, skill.content);
         await ctx.db.patch(existingSkill._id, {
           title: skill.title,
           description: skill.description,
-          content: skill.content,
+          content: undefined,
           sourceSha: skill.sourceSha,
           available: true,
           lastSyncedAt: args.syncedAt,
@@ -222,17 +229,17 @@ export const applyGithubSync = internalMutation({
           prompt: undefined,
         });
       } else {
-        await ctx.db.insert("repoSkills", {
+        const skillId = await ctx.db.insert("repoSkills", {
           repoId: args.repoId,
           title: skill.title,
           description: skill.description,
-          content: skill.content,
           sourcePath: skill.sourcePath,
           sourceSha: skill.sourceSha,
           available: true,
           lastSyncedAt: args.syncedAt,
           createdAt: args.syncedAt,
         });
+        await upsertRepoSkillContent(ctx, skillId, skill.content);
       }
     }
 

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -24,6 +24,7 @@ import {
   taskReactionFields,
   taskSubscriberFields,
   repoSkillFields,
+  repoSkillContentFields,
   repoSystemSkillFields,
   sandboxGitCredentialsFields,
   appSettingsFields,
@@ -44,6 +45,7 @@ import {
   appTabFields,
   backgroundProcessFields,
   snapshotBuildFields,
+  sessionDaemonStateFields,
 } from "./validators";
 
 const schema = defineSchema({
@@ -57,6 +59,7 @@ const schema = defineSchema({
 
   projects: defineTable(projectFields)
     .index("by_repo", ["repoId"])
+    .index("by_repo_and_deleted", ["repoId", "deletedAt"])
     .index("by_user", ["userId"])
     .index("by_repo_and_phase", ["repoId", "phase"])
     .index("by_pr_url", ["prUrl"])
@@ -74,6 +77,7 @@ const schema = defineSchema({
   agentTasks: defineTable(agentTaskFields)
     .index("by_repo", ["repoId"])
     .index("by_repo_and_status", ["repoId", "status"])
+    .index("by_repo_status_and_deleted", ["repoId", "status", "deletedAt"])
     .index("by_repo_and_updatedAt", ["repoId", "updatedAt"])
     .index("by_project", ["projectId"])
     .index("by_project_and_status", ["projectId", "status"])
@@ -86,6 +90,14 @@ const schema = defineSchema({
     .index("by_task_and_status", ["taskId", "status"])
     .index("by_status", ["status"])
     .index("by_pr_url", ["prUrl"]),
+
+  agentTaskRunSummaries: defineTable({
+    taskId: v.id("agentTasks"),
+    repoId: v.id("githubRepos"),
+    lastRunStartedAt: v.optional(v.number()),
+  })
+    .index("by_task", ["taskId"])
+    .index("by_repo", ["repoId"]),
 
   agentRunActivityLogs: defineTable({
     runId: v.id("agentRuns"),
@@ -135,12 +147,18 @@ const schema = defineSchema({
     .index("by_parent_and_order", ["parentId", "order"]),
   sessions: defineTable(sessionFields)
     .index("by_repo", ["repoId"])
+    .index("by_repo_and_deleted", ["repoId", "deletedAt"])
     .index("by_user", ["userId"])
     .index("by_repo_and_status", ["repoId", "status"])
     .index("by_repo_and_archived", ["repoId", "archived"])
+    .index("by_repo_archived_and_deleted", ["repoId", "archived", "deletedAt"])
     .index("by_pr_url", ["prUrl"])
     .index("by_repo_and_numId", ["repoId", "numId"])
     .index("by_sandbox", ["sandboxId"]),
+  sessionDaemonStates: defineTable(sessionDaemonStateFields).index(
+    "by_session",
+    ["sessionId"],
+  ),
   backgroundProcesses: defineTable(backgroundProcessFields)
     .index("by_session_and_status", ["sessionId", "status"])
     .index("by_session_and_key", ["sessionId", "key"]),
@@ -184,6 +202,7 @@ const schema = defineSchema({
     .index("by_entity_tool", ["entityId", "toolUseId"]),
   docs: defineTable(docFields)
     .index("by_repo", ["repoId"])
+    .index("by_repo_and_deleted", ["repoId", "deletedAt"])
     .index("by_session", ["sessionId"])
     .index("by_repo_and_pr_url", ["repoId", "prUrl"])
     .index("by_repo_and_numId", ["repoId", "numId"]),
@@ -219,6 +238,9 @@ const schema = defineSchema({
   repoSkills: defineTable(repoSkillFields)
     .index("by_repo", ["repoId"])
     .index("by_repo_and_source_path", ["repoId", "sourcePath"]),
+  repoSkillContents: defineTable(repoSkillContentFields).index("by_skill", [
+    "skillId",
+  ]),
   repoSystemSkills: defineTable(repoSystemSkillFields)
     .index("by_repo", ["repoId"])
     .index("by_repo_and_name", ["repoId", "name"]),

--- a/packages/backend/tests/convexHotPathIoContract.test.ts
+++ b/packages/backend/tests/convexHotPathIoContract.test.ts
@@ -1,0 +1,82 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const convexDir = join(dirname(fileURLToPath(import.meta.url)), "../convex");
+
+function source(path: string): string {
+  return readFileSync(join(convexDir, path), "utf8").replaceAll("\r\n", "\n");
+}
+
+function definitionBody(path: string, name: string): string {
+  const text = source(path);
+  const start = text.indexOf(`export const ${name} =`);
+  expect(start, `${path}:${name} moved or was renamed`).toBeGreaterThan(-1);
+  const end = text.indexOf("\n});", start);
+  return text.slice(start, end < 0 ? undefined : end);
+}
+
+describe("measured Convex I/O hot paths stay on compact reads", () => {
+  test("claimPendingTurn polls the compact daemon row", () => {
+    const body = definitionBody("_sessions/workflow.ts", "claimPendingTurn");
+    expect(body).toContain('.query("sessionDaemonStates")');
+    expect(body).toContain('withIndex("by_session"');
+    expect(body).toContain("daemonState.pendingTurn");
+    expect(body).not.toContain("session.pendingTurn");
+  });
+
+  test("every session daemon signal writer mirrors the compact row", () => {
+    for (const path of [
+      "_sessions/execution.ts",
+      "_sessions/sandbox.ts",
+      "_sessions/workflow.ts",
+      "_chat/surfaceAdapters.ts",
+    ]) {
+      expect(source(path), path).toContain("syncSessionDaemonState");
+    }
+  });
+
+  test("task lists use summaries and every run creator updates them", () => {
+    const list = definitionBody("_agentTasks/queries.ts", "getAllTasks");
+    expect(source("_agentTasks/queries.ts")).toContain(
+      '.query("agentTaskRunSummaries")',
+    );
+    expect(list).toContain('withIndex("by_repo_status_and_deleted"');
+
+    const runCreators = convexFiles().filter((path) =>
+      source(path).includes('insert("agentRuns"'),
+    );
+    expect(runCreators.length).toBeGreaterThan(0);
+    for (const path of runCreators) {
+      expect(source(path), path).toContain("setTaskLastRunStartedAt");
+    }
+  });
+
+  test("list filters are index ranges, not post-read filters", () => {
+    const sessions = definitionBody("_sessions/queries.ts", "list");
+    expect(sessions).toContain('withIndex("by_repo_archived_and_deleted"');
+    expect(sessions).not.toContain(".filter(");
+
+    const mentions = definitionBody("_mentions/listData.ts", "listData");
+    expect(mentions).toContain('withIndex("by_repo_and_deleted"');
+    expect(mentions).toContain('withIndex("by_repo_status_and_deleted"');
+    expect(mentions).not.toContain("filterActiveEntities");
+  });
+
+  test("skill list metadata no longer writes new SKILL.md bodies inline", () => {
+    const apply = definitionBody("repoSkills.ts", "applyGithubSync");
+    expect(apply).toContain("upsertRepoSkillContent");
+    expect(apply).toContain("content: undefined");
+    expect(source("repoSkills.ts")).toContain('.query("repoSkillContents")');
+    expect(source("dataMigrations.ts")).toContain("splitRepoSkillContent");
+  });
+});
+
+function convexFiles(): string[] {
+  return readdirSync(convexDir, { recursive: true })
+    .map((entry) => String(entry).replaceAll("\\", "/"))
+    .filter((path) => path.endsWith(".ts"))
+    .filter((path) => !path.includes("_generated"))
+    .filter((path) => !path.endsWith(".generated.ts"));
+}


### PR DESCRIPTION
## Summary

- move high-frequency session daemon signals into compact `sessionDaemonStates` rows while dual-writing the legacy session fields for rollback safety
- maintain compact latest-run summaries for task lists instead of rereading `agentRuns`
- split large repo skill content from list metadata so `repoSkills.listByRepo` reads lightweight rows
- add compound indexes that exclude soft-deleted rows inside `sessions.list`, `mentions.listData`, and `agentTasks.getAllTasks`
- preserve existing return shapes, ordering, authorization, archived-session behavior, and migration-safe fallbacks

## Why

Convex database I/O reached roughly 125 GB over nine days. The identified hot functions were repeatedly reading heavyweight documents or filtering deleted rows after storage reads, so unchanged subscriptions and daemon polling amplified bandwidth.

## Rollout

The new read paths fall back to legacy data until backfills complete. After deploying the schema/functions, run:

```sh
npx convex run dataMigrations:backfillAgentTaskRunSummaries '{"dryRun":true}' --prod
npx convex run dataMigrations:backfillAgentTaskRunSummaries --prod
npx convex run dataMigrations:splitRepoSkillContent '{"dryRun":true}' --prod
npx convex run dataMigrations:splitRepoSkillContent --prod
```

## Validation

- Convex codegen with typechecking enabled
- backend Vitest suite: 100 files, 677 tests passed
- dedicated hot-path I/O contract coverage
- `git diff --check`
