### PR TITLE
Keep MCP auth in callback memory

### DIFF
--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## MCP auth stays in callback memory - 2026-08-12
+
+Eva's bearer token previously lived in `/tmp/eva-mcp.json`, so reused sandboxes could retain stale authorization and filesystem snapshots captured a live credential. Launches now deliver the token through reserved environment variables, the callback immediately converts and scrubs them, and both Claude and Cursor receive one shared typed MCP descriptor directly through their SDK options. The one-time runner also removes legacy MCP files and unlinks its credential-bearing launch script before the long-lived callback starts.
+
 ## Repo default model includes traits - 2026-08-12
 
 The repository default model on settings/config only stored the model id, so new tasks and sessions always used each model's own reasoning/Fast defaults. The picker now has the same traits menu as composers, and those values persist on the repo and apply when a task or session is created without an override.

--- a/internal/plans/implemented/mcp-auth-env-var.md
+++ b/internal/plans/implemented/mcp-auth-env-var.md
@@ -1,6 +1,8 @@
 # MCP rework: token via EVA_MCP_AUTH env var (no eva-mcp.json)
 
-**Status:** todo
+**Status:** implemented (2026-08-12)
+
+Implementation note: Cursor had migrated from ACP to `@cursor/sdk` before this landed, so the final change centralizes both SDK shapes in `callback-src/evaMcp.ts`. It also scrubs the transport variables from `process.env` and unlinks the credential-bearing launch script before spawning the callback.
 
 ## Context
 

--- a/internal/plans/todo/custom-mcp-servers.md
+++ b/internal/plans/todo/custom-mcp-servers.md
@@ -4,10 +4,10 @@ Goal: let a repo register external MCP servers (Linear, Figma, PostHog, …) tha
 
 ## Current state (anchors)
 
-- Single MCP config written at launch: [launch.ts:172-187](../../packages/backend/convex/_daytona/launch.ts) — hardcoded `mcpServers: { eva: { type: "http", url, headers } }` → `/tmp/eva-mcp.json`.
-- All providers consume that one file: claude sdk (`--mcp-config /tmp/eva-mcp.json`, [claudeSdk.ts:34](../../packages/backend/callback-src/providers/claudeSdk.ts)), claude one-shot ([config.ts:252](../../packages/backend/callback-src/config.ts)), cursor (translates file → `~/.cursor/mcp.json` + `--approve-mcps`, [cursorSession.ts:35-77](../../packages/backend/callback-src/session/cursorSession.ts)).
+- Eva MCP auth reaches the callback through reserved launch environment variables; [evaMcp.ts](../../packages/backend/callback-src/evaMcp.ts) consumes them into one typed in-memory server record and removes them before agent tools spawn.
+- Claude and Cursor pass that record directly through their SDK `mcpServers` options; no MCP JSON file is written.
 - Secrets already resolvable per repo/team: `resolveAllEnvVars(ctx, repoId)` ([envVarResolver.ts](../../packages/backend/convex/envVarResolver.ts)).
-- `signAndLaunchScript` ([helpers.ts](../../packages/backend/convex/_daytona/helpers.ts)) has `ctx` + `repoId`; `launchScript` does not — custom servers must resolve there and pass through opts.
+- `signAndLaunchScript` ([helpers.ts](../../packages/backend/convex/_sandbox_runtime/helpers.ts)) has `ctx` + `repoId`; `launchScript` does not — custom servers must resolve there and pass through opts.
 
 ## Design
 
@@ -26,14 +26,13 @@ New table `repoMcpServers` (fields in `_validators/tableFields.ts` per conventio
 1. CRUD in new `convex/repoMcpServers.ts`: `listByRepo` (authQuery, repo access check), `upsert`, `remove` (authMutations). Mask nothing — header values are templates, not secrets.
 2. Internal `resolveForLaunch(repoId)` internalQuery: enabled servers for repo.
 3. `signAndLaunchScript`: when `opts.enableMcp !== false`, fetch servers + `resolveAllEnvVars`, substitute `${VAR}` in header values (missing var → skip server + console.warn, do not fail launch), pass `customMcpServers` through to `launchScript` opts.
-4. `launchScript` (launch.ts:172): merge into the JSON — `mcpServers: { eva: {...}, ...custom }`. Written only when mcp enabled (keep current gate).
+4. Merge future servers into the callback's in-memory `mcpServers` record for each SDK, not a JSON file.
 5. Prompt: append one line to session/task/project chat prompts listing connected server names ("Connected MCP servers: eva, linear, figma") so agents discover them. Optional v1.
 
-### Callback (verify, likely zero changes)
+### Callback
 
-- claude: `--mcp-config` passes whole file — works as-is.
-- cursor: confirm cursorSession.ts translation copies ALL entries (it parses the file; check it doesn't cherry-pick `eva`). `--approve-mcps` already auto-approves.
-- codex/opencode: check whether they consume `/tmp/eva-mcp.json` at all; if not, note gap in tool descriptions (out of scope to add).
+- Extend the shared in-memory MCP boundary so Claude and Cursor receive every resolved server in their SDK-native shapes.
+- Codex/OpenCode do not consume Eva MCP today; adding them remains out of scope.
 - If any callback change needed → rebuild `callbackScript.generated.ts` (`node scripts/build-callback-script.mjs`).
 
 ### Web UI
@@ -43,7 +42,7 @@ New table `repoMcpServers` (fields in `_validators/tableFields.ts` per conventio
 
 ### Security notes
 
-- Substituted secrets land in `/tmp/eva-mcp.json` inside the sandbox — same trust level as existing provider keys/mcpToken already in sandbox env. Acceptable.
+- Substituted secrets must remain in callback memory and be removed from inherited child-process environments after consumption.
 - OAuth-flow MCP servers (e.g. Linear's hosted OAuth mode) NOT supported v1 — header/API-key auth only. Document in UI hint.
 - Data minimisation: header templates in Convex, real values only in team/repo env vars.
 

--- a/packages/backend/callback-src/config.ts
+++ b/packages/backend/callback-src/config.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "fs";
+import { hasEvaMcpConfig } from "./evaMcp.js";
 
 export const CONVEX_URL = process.env.CONVEX_URL;
 export const CONVEX_SITE_URL = process.env.CONVEX_SITE_URL || CONVEX_URL;
@@ -238,8 +239,8 @@ function buildSettingsJson(): string {
 }
 
 export const settingsJson = buildSettingsJson();
-/** True when the sandbox MCP config file is present (used for startup logging). */
-export const hasMcpConfig = existsSync("/tmp/eva-mcp.json");
+/** True when Eva MCP auth was supplied at callback startup. */
+export const hasMcpConfig = hasEvaMcpConfig;
 const claudeModelBase = MODEL.startsWith("claude:")
   ? MODEL.slice("claude:".length)
   : MODEL;

--- a/packages/backend/callback-src/evaMcp.ts
+++ b/packages/backend/callback-src/evaMcp.ts
@@ -1,0 +1,47 @@
+export type HttpMcpServerConfig = {
+  type: "http";
+  url: string;
+  headers: Record<string, string>;
+};
+
+export type HttpMcpServers = Record<string, HttpMcpServerConfig>;
+
+type EvaMcpEnvironment = {
+  EVA_MCP_AUTH?: string;
+  EVA_MCP_BASE_URL?: string;
+};
+
+export function buildEvaMcpServers({
+  auth,
+  baseUrl,
+}: {
+  auth?: string;
+  baseUrl?: string;
+}): HttpMcpServers {
+  if (!auth || !baseUrl) return {};
+  return {
+    eva: {
+      type: "http",
+      url: `${baseUrl}/mcp`,
+      headers: { Authorization: `Bearer ${auth}` },
+    },
+  };
+}
+
+export function consumeEvaMcpEnvironment(
+  env: EvaMcpEnvironment,
+): HttpMcpServers {
+  const servers = buildEvaMcpServers({
+    auth: env.EVA_MCP_AUTH,
+    baseUrl: env.EVA_MCP_BASE_URL,
+  });
+  // The callback keeps the MCP descriptor in memory. Removing the transport
+  // variables stops agent tools and unrelated child processes inheriting the
+  // bearer token through their environment.
+  delete env.EVA_MCP_AUTH;
+  delete env.EVA_MCP_BASE_URL;
+  return servers;
+}
+
+export const evaMcpServers = consumeEvaMcpEnvironment(process.env);
+export const hasEvaMcpConfig = Object.keys(evaMcpServers).length > 0;

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -15,6 +15,7 @@ import {
   normalizedClaudeModel,
   settingsJson,
 } from "../config.js";
+import { evaMcpServers, type HttpMcpServers } from "../evaMcp.js";
 import { buildClaudeStartupStep } from "../session/claudeSession.js";
 import { processRealtimeStdoutChunk } from "../parse/streamRouter.js";
 import { updateThinkingStep } from "../parse/canonical.js";
@@ -31,7 +32,6 @@ import { log } from "../utils.js";
 
 const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 const SDK_VERSION = "0.3.201";
-const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 
 /**
  * The subset of the Agent SDK `query()` surface this runner uses. The SDK is
@@ -80,6 +80,7 @@ export type SdkOptions = {
   extraArgs?: Record<string, string>;
   includePartialMessages?: boolean;
   effort?: "low" | "medium" | "high" | "xhigh" | "max";
+  mcpServers?: HttpMcpServers;
   /** Per-tool permission gate. Set only when blocking questions are enabled. */
   canUseTool?: SdkCanUseTool;
 };
@@ -170,9 +171,6 @@ export function buildSdkOptions(sessionMode: SessionMode): SdkOptions {
   // allowed tools, MCP, permissions, session resume). Formerly mirrored
   // Claude CLI flags; those builders are gone.
   const extraArgs: Record<string, string> = { settings: settingsJson };
-  if (existsSync(MCP_CONFIG_PATH)) {
-    extraArgs["mcp-config"] = MCP_CONFIG_PATH;
-  }
   return buildSdkOptionsFromParts(sessionMode, extraArgs);
 }
 
@@ -270,6 +268,9 @@ function buildSdkOptionsFromParts(
       ? { resume: sessionMode.sessionId }
       : {}),
     extraArgs,
+    ...(Object.keys(evaMcpServers).length > 0
+      ? { mcpServers: evaMcpServers }
+      : {}),
     ...effortOption,
   };
 }

--- a/packages/backend/callback-src/providers/cursorSdk.ts
+++ b/packages/backend/callback-src/providers/cursorSdk.ts
@@ -12,6 +12,7 @@ import {
   cursorUse1mContext,
   normalizedCursorModel,
 } from "../config.js";
+import { evaMcpServers, type HttpMcpServers } from "../evaMcp.js";
 import { updateThinkingStep } from "../parse/canonical.js";
 import { processRealtimeStdoutChunk } from "../parse/streamRouter.js";
 import {
@@ -26,14 +27,13 @@ import {
   writeCursorSessionState,
 } from "../session/cursorSession.js";
 import type { CliAttemptResult, JsonValue, SessionMode } from "../types.js";
-import { log, tryParseJson } from "../utils.js";
+import { log } from "../utils.js";
 import { globalNpmRoot, type JsonLike } from "./claudeSdk.js";
 
 const SDK_PACKAGE = "@cursor/sdk";
 const SDK_VERSION = "1.0.26";
 /** ESM entry inside the package (its exports map's `import` target). */
 const SDK_ENTRY_RELPATH = "/dist/esm/index.js";
-const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 
 /** User-writable fallback install location (persists in home across resumes). */
 const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk";
@@ -43,12 +43,6 @@ const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk";
  * The SDK is dynamically imported from the sandbox's global npm root (installed
  * in the seed snapshot), so these stand in for the SDK's own types.
  */
-export type SdkMcpServerConfig = {
-  type: "http";
-  url: string;
-  headers?: Record<string, string>;
-};
-
 /** Opaque store handle — constructed, passed back to the SDK, never inspected. */
 type SdkLocalAgentStore = {
   readonly agents?: object;
@@ -131,7 +125,7 @@ type SdkAgentOptions = {
   apiKey: string;
   model: SdkModelSelection;
   local: { cwd: string; store: SdkLocalAgentStore };
-  mcpServers?: Record<string, SdkMcpServerConfig>;
+  mcpServers?: HttpMcpServers;
 };
 
 type SdkTokenUsage = {
@@ -214,64 +208,6 @@ export async function loadCursorSdk(): Promise<CursorSdkModule> {
   }
   const mod: CursorSdkModule = await import(localEntry);
   return mod;
-}
-
-/**
- * Parses Eva's generated HTTP MCP descriptors into the SDK's inline mcpServers
- * shape (remote HTTP servers only, matching the old .cursor/mcp.json
- * translation). Header values are forwarded but never logged.
- */
-export function parseCursorSdkMcpServers(
-  raw: string,
-): Record<string, SdkMcpServerConfig> {
-  const servers: Record<string, SdkMcpServerConfig> = {};
-  const parsed = tryParseJson(raw);
-  if (
-    !parsed ||
-    typeof parsed !== "object" ||
-    Array.isArray(parsed) ||
-    !parsed.mcpServers ||
-    typeof parsed.mcpServers !== "object" ||
-    Array.isArray(parsed.mcpServers)
-  ) {
-    return servers;
-  }
-  for (const [name, server] of Object.entries(parsed.mcpServers)) {
-    if (
-      !server ||
-      typeof server !== "object" ||
-      Array.isArray(server) ||
-      typeof server.url !== "string" ||
-      !server.url.trim()
-    ) {
-      continue;
-    }
-    const entry: SdkMcpServerConfig = { type: "http", url: server.url };
-    if (
-      server.headers &&
-      typeof server.headers === "object" &&
-      !Array.isArray(server.headers)
-    ) {
-      const headers: Record<string, string> = {};
-      for (const [headerName, headerValue] of Object.entries(server.headers)) {
-        if (typeof headerValue === "string") {
-          headers[headerName] = headerValue;
-        }
-      }
-      if (Object.keys(headers).length > 0) entry.headers = headers;
-    }
-    servers[name] = entry;
-  }
-  return servers;
-}
-
-function readCursorSdkMcpServers(): Record<string, SdkMcpServerConfig> {
-  if (!existsSync(MCP_CONFIG_PATH)) return {};
-  try {
-    return parseCursorSdkMcpServers(readFileSync(MCP_CONFIG_PATH, "utf8"));
-  } catch {
-    return {};
-  }
 }
 
 function readPromptText(): string {
@@ -480,12 +416,13 @@ export async function runCursorSdkAttempt(
   const sdk = await loadCursorSdk();
   mkdirSync(CURSOR_SDK_STORE_DIR, { recursive: true });
   const store = new sdk.JsonlLocalAgentStore(CURSOR_SDK_STORE_DIR);
-  const mcpServers = readCursorSdkMcpServers();
   const options: SdkAgentOptions = {
     apiKey: (process.env.CURSOR_API_KEY || "").trim(),
     model: await resolveCursorModelSelection(sdk),
     local: { cwd: WORK_DIR, store },
-    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+    ...(Object.keys(evaMcpServers).length > 0
+      ? { mcpServers: evaMcpServers }
+      : {}),
   };
 
   const persistAgentId = (agentId: string): void => {

--- a/packages/backend/callback-src/session/cursorSession.ts
+++ b/packages/backend/callback-src/session/cursorSession.ts
@@ -28,8 +28,8 @@ export function syncCursorStateToPersist(): void {
 }
 
 function hydratePersistedCursorState(): void {
-  // MCP config is no longer written to WORK_DIR/.cursor/mcp.json — the SDK
-  // runner passes /tmp/eva-mcp.json servers inline (readCursorSdkMcpServers).
+  // MCP configuration is supplied directly to the Cursor SDK; no workspace
+  // file participates in session hydration.
   store.hydratePersistedState("hydratePersistedCursorState");
 }
 

--- a/packages/backend/callback-src/tests/cursorSdk.test.ts
+++ b/packages/backend/callback-src/tests/cursorSdk.test.ts
@@ -5,7 +5,6 @@ import { probeCursorSdkToolResult } from "../providers/cursor.js";
 import {
   cursorModeParams,
   filterModeParamsByModel,
-  parseCursorSdkMcpServers,
 } from "../providers/cursorSdk.js";
 
 test("splitCursorModel separates base id and reasoning level", () => {
@@ -120,32 +119,6 @@ test("filterModeParamsByModel without a model entry keeps only opted-in params",
 function opted(fastMode: boolean, use1mContext: boolean) {
   return { fastMode, use1mContext };
 }
-
-test("parseCursorSdkMcpServers maps eva-mcp.json to inline SDK config", () => {
-  const raw = JSON.stringify({
-    mcpServers: {
-      eva: {
-        url: "https://example.convex.site/mcp",
-        headers: { Authorization: "Bearer abc", "X-Num": 5 },
-      },
-      broken: { command: "npx" },
-      empty: { url: "   " },
-    },
-  });
-  const servers = parseCursorSdkMcpServers(raw);
-  expect(Object.keys(servers)).toEqual(["eva"]);
-  expect(servers.eva).toEqual({
-    type: "http",
-    url: "https://example.convex.site/mcp",
-    headers: { Authorization: "Bearer abc" },
-  });
-});
-
-test("parseCursorSdkMcpServers tolerates malformed input", () => {
-  expect(parseCursorSdkMcpServers("not json")).toEqual({});
-  expect(parseCursorSdkMcpServers("[]")).toEqual({});
-  expect(parseCursorSdkMcpServers('{"mcpServers":[]}')).toEqual({});
-});
 
 test("cursorSdkToolToStep maps known SDK tool kinds", () => {
   const read = cursorSdkToolToStep("read", { path: "/tmp/repo/src/a.ts" });

--- a/packages/backend/callback-src/tests/evaMcp.test.ts
+++ b/packages/backend/callback-src/tests/evaMcp.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+import {
+  buildEvaMcpServers,
+  consumeEvaMcpEnvironment,
+} from "../evaMcp.js";
+
+test("buildEvaMcpServers creates the authenticated HTTP descriptor", () => {
+  expect(
+    buildEvaMcpServers({
+      auth: "token-123",
+      baseUrl: "https://example.convex.site",
+    }),
+  ).toEqual({
+    eva: {
+      type: "http",
+      url: "https://example.convex.site/mcp",
+      headers: { Authorization: "Bearer token-123" },
+    },
+  });
+});
+
+test("buildEvaMcpServers requires both environment values", () => {
+  expect(buildEvaMcpServers({ auth: "token-123" })).toEqual({});
+  expect(
+    buildEvaMcpServers({ baseUrl: "https://example.convex.site" }),
+  ).toEqual({});
+  expect(buildEvaMcpServers({})).toEqual({});
+});
+
+test("consumeEvaMcpEnvironment removes credentials after reading them", () => {
+  const env = {
+    EVA_MCP_AUTH: "token-123",
+    EVA_MCP_BASE_URL: "https://example.convex.site",
+  };
+  const servers = consumeEvaMcpEnvironment(env);
+
+  expect(Object.keys(servers)).toEqual(["eva"]);
+  expect(env).toEqual({});
+});

--- a/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
+++ b/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
@@ -1,6 +1,6 @@
 "use node";
 
-export const CALLBACK_SCRIPT = `// callback-src/index.ts
+export const CALLBACK_SCRIPT = `// packages/backend/callback-src/index.ts
 import {
   existsSync as existsSync9,
   mkdirSync as mkdirSync8,
@@ -9,8 +9,36 @@ import {
   writeFileSync as writeFileSync11
 } from "fs";
 
-// callback-src/config.ts
+// packages/backend/callback-src/config.ts
 import { existsSync } from "fs";
+
+// packages/backend/callback-src/evaMcp.ts
+function buildEvaMcpServers({
+  auth,
+  baseUrl
+}) {
+  if (!auth || !baseUrl) return {};
+  return {
+    eva: {
+      type: "http",
+      url: \`\${baseUrl}/mcp\`,
+      headers: { Authorization: \`Bearer \${auth}\` }
+    }
+  };
+}
+function consumeEvaMcpEnvironment(env) {
+  const servers = buildEvaMcpServers({
+    auth: env.EVA_MCP_AUTH,
+    baseUrl: env.EVA_MCP_BASE_URL
+  });
+  delete env.EVA_MCP_AUTH;
+  delete env.EVA_MCP_BASE_URL;
+  return servers;
+}
+var evaMcpServers = consumeEvaMcpEnvironment(process.env);
+var hasEvaMcpConfig = Object.keys(evaMcpServers).length > 0;
+
+// packages/backend/callback-src/config.ts
 var CONVEX_URL = process.env.CONVEX_URL;
 var CONVEX_SITE_URL = process.env.CONVEX_SITE_URL || CONVEX_URL;
 var CONVEX_TOKEN = process.env.CONVEX_TOKEN;
@@ -166,7 +194,7 @@ function buildSettingsJson() {
   return JSON.stringify(settings);
 }
 var settingsJson = buildSettingsJson();
-var hasMcpConfig = existsSync("/tmp/eva-mcp.json");
+var hasMcpConfig = hasEvaMcpConfig;
 var claudeModelBase = MODEL.startsWith("claude:") ? MODEL.slice("claude:".length) : MODEL;
 var normalizedClaudeModel = PROVIDER === "claude" && AI_CONTEXT_1M === "1" ? \`\${claudeModelBase}[1m]\` : claudeModelBase;
 var normalizedCodexModel = MODEL.startsWith("codex:") ? MODEL.slice("codex:".length) : MODEL;
@@ -261,10 +289,10 @@ var completedLabels = {
   "Asking a question...": "Asked a question"
 };
 
-// callback-src/providers/claudeSdkDaemon.ts
+// packages/backend/callback-src/providers/claudeSdkDaemon.ts
 import { unlinkSync as unlinkSync2, writeFileSync as writeFileSync9, readFileSync as readFileSync6 } from "fs";
 
-// callback-src/providers/daemonPaths.ts
+// packages/backend/callback-src/providers/daemonPaths.ts
 var LEGACY_DAEMON_PID = "/tmp/eva-daemon.pid";
 var LEGACY_DAEMON_ENTITY = "/tmp/eva-daemon.entity";
 var LEGACY_DAEMON_OPTS = "/tmp/eva-daemon.opts";
@@ -286,7 +314,7 @@ function resolveLegacySessionDaemonPaths() {
   };
 }
 
-// callback-src/utils.ts
+// packages/backend/callback-src/utils.ts
 import { spawnSync } from "child_process";
 import {
   cpSync,
@@ -298,7 +326,7 @@ import {
   writeFileSync
 } from "fs";
 
-// callback-src/runtime/state.ts
+// packages/backend/callback-src/runtime/state.ts
 function parsePriorStep(value) {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
@@ -468,7 +496,7 @@ function assignRawLogStream(stream) {
   callbackState.rawLogStream = stream;
 }
 
-// callback-src/utils.ts
+// packages/backend/callback-src/utils.ts
 function narrowJsonValue(value) {
   if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     return value;
@@ -639,7 +667,7 @@ function elapsedAttemptMs() {
   return attemptElapsedMs();
 }
 
-// callback-src/http/convexClient.ts
+// packages/backend/callback-src/http/convexClient.ts
 async function fetchWithTimeout(url, options, timeoutMs = CALLBACK_HTTP_TIMEOUT_MS) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -788,7 +816,7 @@ async function callStreamingHeartbeatTouch(entityId) {
   }
 }
 
-// callback-src/parse/stepBudget.ts
+// packages/backend/callback-src/parse/stepBudget.ts
 var STEP_FIELD_CAPS = {
   command: 600,
   output: 1200,
@@ -852,7 +880,7 @@ function serializeSteps(steps) {
   return JSON.stringify(enforceStepBudget(steps));
 }
 
-// callback-src/parse/toolResultCapture.ts
+// packages/backend/callback-src/parse/toolResultCapture.ts
 function capCommand(command) {
   return headCap(command, STEP_FIELD_CAPS.command).text;
 }
@@ -1035,7 +1063,7 @@ function probeOpencodeStateResult(state) {
   };
 }
 
-// callback-src/parse/toolSteps.ts
+// packages/backend/callback-src/parse/toolSteps.ts
 function opencodeToolToStep(part) {
   const tool = typeof part.tool === "string" ? part.tool : "tool";
   const stateObj = part.state && typeof part.state === "object" && !Array.isArray(part.state) ? part.state : null;
@@ -1677,7 +1705,7 @@ function codexItemToStep(item) {
   });
 }
 
-// callback-src/runtime/sandboxMedia.ts
+// packages/backend/callback-src/runtime/sandboxMedia.ts
 function mediaCandidateRoots(workDir, rootDirectory) {
   const roots = [workDir];
   const trimmed = rootDirectory?.trim() ?? "";
@@ -1697,7 +1725,7 @@ function mediaSearchDirs(workDir, rootDirectory) {
   };
 }
 
-// callback-src/runtime/completion.ts
+// packages/backend/callback-src/runtime/completion.ts
 import {
   existsSync as existsSync3,
   readFileSync as readFileSync2,
@@ -2150,7 +2178,7 @@ function hasToolActivity() {
   return callbackState.accumulatedSteps.some((step) => TOOL_STEP_TYPES.has(step.type));
 }
 
-// callback-src/session/claudeSession.ts
+// packages/backend/callback-src/session/claudeSession.ts
 import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync3 } from "fs";
 function buildClaudeStartupStep() {
   if (callbackState.waitingForFirstAssistantEvent && callbackState.claudeInitAt > 0) {
@@ -2355,7 +2383,7 @@ function prepareClaudeSessionState() {
   return sessionMode;
 }
 
-// callback-src/runtime/backgroundShells.ts
+// packages/backend/callback-src/runtime/backgroundShells.ts
 var PENDING_CAP = 200;
 var QUEUE_CAP = 20;
 var FLUSH_FAILURE_COOLDOWN_MS = 1e4;
@@ -2468,7 +2496,7 @@ async function flushBackgroundShellQueue() {
   }
 }
 
-// callback-src/parse/sdkTaxonomy.ts
+// packages/backend/callback-src/parse/sdkTaxonomy.ts
 var loggedUnknownKinds = /* @__PURE__ */ new Set();
 var knownBackgroundTaskIds = /* @__PURE__ */ new Set();
 function readString(value) {
@@ -2751,7 +2779,7 @@ function completeStatusOnNonStatusMessage(event) {
   completeActiveStatusStep();
 }
 
-// callback-src/providers/claude.ts
+// packages/backend/callback-src/providers/claude.ts
 function claudeToolCompleteResult(resultText, isError) {
   const output = buildStepOutput(resultText);
   if (!output && !isError) {
@@ -2974,10 +3002,10 @@ var claudeAdapter = {
   }
 };
 
-// callback-src/session/codexSession.ts
+// packages/backend/callback-src/session/codexSession.ts
 import { mkdirSync as mkdirSync4, writeFileSync as writeFileSync5 } from "fs";
 
-// callback-src/session/createSessionStore.ts
+// packages/backend/callback-src/session/createSessionStore.ts
 import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync4 } from "fs";
 function createSessionStore(config) {
   const readSessionState = () => {
@@ -3051,7 +3079,7 @@ function createSessionStore(config) {
   };
 }
 
-// callback-src/session/codexSession.ts
+// packages/backend/callback-src/session/codexSession.ts
 var store = createSessionStore({
   runtimeHomeDir: CODEX_RUNTIME_HOME_DIR,
   persistDir: CODEX_PERSIST_DIR,
@@ -3139,7 +3167,7 @@ function prepareCodexSessionState() {
   return persistedState && persistedState.resumeThreadId ? { mode: "resume", sessionId: persistedState.resumeThreadId } : { mode: "none", sessionId: null };
 }
 
-// callback-src/providers/codex.ts
+// packages/backend/callback-src/providers/codex.ts
 function codexParseLine(event) {
   const events = [];
   const threadId = getCodexThreadId(event);
@@ -3241,7 +3269,7 @@ var codexAdapter = {
   onStdoutText: inspectCodexStdout
 };
 
-// callback-src/session/cursorSession.ts
+// packages/backend/callback-src/session/cursorSession.ts
 var store2 = createSessionStore({
   runtimeHomeDir: CURSOR_RUNTIME_HOME_DIR,
   persistDir: CURSOR_PERSIST_DIR,
@@ -3279,7 +3307,7 @@ function prepareCursorSessionState() {
   return { mode: "none", sessionId: null };
 }
 
-// callback-src/providers/cursor.ts
+// packages/backend/callback-src/providers/cursor.ts
 function probeCursorSdkToolResult(status, result) {
   const eventIsError = status === "error";
   if (result === void 0 || result === null) {
@@ -3432,7 +3460,7 @@ var cursorAdapter = {
   }
 };
 
-// callback-src/session/opencodeSession.ts
+// packages/backend/callback-src/session/opencodeSession.ts
 import { mkdirSync as mkdirSync5, writeFileSync as writeFileSync6 } from "fs";
 var store3 = createSessionStore({
   runtimeHomeDir: OPENCODE_RUNTIME_HOME_DIR,
@@ -3493,7 +3521,7 @@ function prepareOpencodeSessionState() {
   return { mode: "none", sessionId: null };
 }
 
-// callback-src/providers/opencode.ts
+// packages/backend/callback-src/providers/opencode.ts
 function opencodeParseLine(event) {
   const events = [];
   if (event.type === "reasoning" && event.part && typeof event.part === "object" && !Array.isArray(event.part) && typeof event.part.text === "string" && event.part.text) {
@@ -3572,7 +3600,7 @@ var opencodeAdapter = {
   }
 };
 
-// callback-src/parse/canonical.ts
+// packages/backend/callback-src/parse/canonical.ts
 var stepStartedAt = /* @__PURE__ */ new WeakMap();
 function mergeToolResult(step, result) {
   if (result.output) {
@@ -3764,10 +3792,10 @@ function appendStreamedContent(text, isBlockBoundary = false) {
   callbackState.currentStreamedContent += nextText;
 }
 
-// callback-src/runtime/heartbeats.ts
+// packages/backend/callback-src/runtime/heartbeats.ts
 import { writeFileSync as writeFileSync7 } from "fs";
 
-// callback-src/runtime/processControl.ts
+// packages/backend/callback-src/runtime/processControl.ts
 import { spawnSync as spawnSync2 } from "child_process";
 function terminateAttemptProcess(child) {
   try {
@@ -3795,7 +3823,7 @@ function isChildZombie(pid) {
   }
 }
 
-// callback-src/runtime/heartbeats.ts
+// packages/backend/callback-src/runtime/heartbeats.ts
 var flushInterval = null;
 var heartbeatInterval = null;
 function buildStreamingPayload() {
@@ -3996,7 +4024,7 @@ async function runPreflightHeartbeat() {
   }
 }
 
-// callback-src/providers/index.ts
+// packages/backend/callback-src/providers/index.ts
 function getProviderAdapter(provider = PROVIDER) {
   if (provider === "codex") return codexAdapter;
   if (provider === "opencode") return opencodeAdapter;
@@ -4004,7 +4032,7 @@ function getProviderAdapter(provider = PROVIDER) {
   return claudeAdapter;
 }
 
-// callback-src/parse/streamRouter.ts
+// packages/backend/callback-src/parse/streamRouter.ts
 function processRealtimeStdoutChunk(text) {
   callbackState.realtimeOutputBuffer += text;
   while (true) {
@@ -4032,7 +4060,7 @@ function handleRealtimeStreamLine(line) {
   }
 }
 
-// callback-src/runtime/buffers.ts
+// packages/backend/callback-src/runtime/buffers.ts
 import { createWriteStream } from "fs";
 function trimBufferHead(buf) {
   if (buf.length <= OUTPUT_BUFFER_MAX_BYTES) return buf;
@@ -4070,11 +4098,11 @@ function appendToRawLogFile(text) {
   }
 }
 
-// callback-src/providers/claudeSdk.ts
+// packages/backend/callback-src/providers/claudeSdk.ts
 import { execSync } from "child_process";
 import { existsSync as existsSync6, readFileSync as readFileSync5 } from "fs";
 
-// callback-src/runtime/cliAttempt.ts
+// packages/backend/callback-src/runtime/cliAttempt.ts
 import { spawn } from "child_process";
 import { writeFileSync as writeFileSync8 } from "fs";
 function evaluateAttemptHealth(input) {
@@ -4254,7 +4282,7 @@ async function runCliAttempt(options) {
   });
 }
 
-// callback-src/runtime/pendingQuestion.ts
+// packages/backend/callback-src/runtime/pendingQuestion.ts
 var POLL_INTERVAL_MS = 300;
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -4328,10 +4356,9 @@ function buildCanUseTool() {
   };
 }
 
-// callback-src/providers/claudeSdk.ts
+// packages/backend/callback-src/providers/claudeSdk.ts
 var SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 var SDK_VERSION = "0.3.201";
-var MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 function globalNpmRoot() {
   return execSync("npm root -g", { encoding: "utf8" }).trim();
 }
@@ -4368,9 +4395,6 @@ function readPromptText() {
 }
 function buildSdkOptions(sessionMode) {
   const extraArgs = { settings: settingsJson };
-  if (existsSync6(MCP_CONFIG_PATH)) {
-    extraArgs["mcp-config"] = MCP_CONFIG_PATH;
-  }
   return buildSdkOptionsFromParts(sessionMode, extraArgs);
 }
 var EVA_SDK_SYSTEM_APPEND = "You are running inside Eva, a platform that runs coding agents in remote sandboxes against GitHub repos. Treat the workspace as the active repo checkout.";
@@ -4423,6 +4447,7 @@ function buildSdkOptionsFromParts(sessionMode, extraArgs, tools = "agent") {
     ...sessionMode.mode === "session" && sessionMode.sessionId ? { sessionId: sessionMode.sessionId } : {},
     ...sessionMode.mode === "resume" && sessionMode.sessionId ? { resume: sessionMode.sessionId } : {},
     extraArgs,
+    ...Object.keys(evaMcpServers).length > 0 ? { mcpServers: evaMcpServers } : {},
     ...effortOption
   };
 }
@@ -4536,7 +4561,7 @@ async function runClaudeSdkAttempt(sessionMode) {
   };
 }
 
-// callback-src/runtime/turnPersist.ts
+// packages/backend/callback-src/runtime/turnPersist.ts
 import { spawnSync as spawnSync3 } from "child_process";
 var GIT_STEP_TIMEOUT_MS = 2e4;
 var PUSH_TIMEOUT_MS = 6e4;
@@ -4686,7 +4711,7 @@ function persistTurnWork() {
   }
 }
 
-// callback-src/providers/claimPendingTurnParse.ts
+// packages/backend/callback-src/providers/claimPendingTurnParse.ts
 function readStopTaskToolUseIds(result) {
   if (typeof result !== "object" || result === null || Array.isArray(result)) {
     return [];
@@ -4708,7 +4733,7 @@ function readCancelRequested(result) {
   return payload.cancelRequested === true;
 }
 
-// callback-src/providers/claudeSdkDaemon.ts
+// packages/backend/callback-src/providers/claudeSdkDaemon.ts
 function sleep2(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -5735,7 +5760,7 @@ async function runSdkDaemon() {
   process.exit(0);
 }
 
-// callback-src/runtime/systemSkills.ts
+// packages/backend/callback-src/runtime/systemSkills.ts
 import {
   existsSync as existsSync7,
   mkdirSync as mkdirSync6,
@@ -5876,13 +5901,12 @@ function materializeSystemSkills() {
   }
 }
 
-// callback-src/providers/cursorSdk.ts
+// packages/backend/callback-src/providers/cursorSdk.ts
 import { execSync as execSync2 } from "child_process";
 import { existsSync as existsSync8, mkdirSync as mkdirSync7, readFileSync as readFileSync8 } from "fs";
 var SDK_PACKAGE2 = "@cursor/sdk";
 var SDK_VERSION2 = "1.0.26";
 var SDK_ENTRY_RELPATH = "/dist/esm/index.js";
-var MCP_CONFIG_PATH2 = "/tmp/eva-mcp.json";
 var SDK_LOCAL_PREFIX2 = "/home/eva/.eva-agent-sdk";
 function cursorModeParams(model, fastMode, use1mContext) {
   const params = [];
@@ -5927,38 +5951,6 @@ async function loadCursorSdk() {
   }
   const mod = await import(localEntry);
   return mod;
-}
-function parseCursorSdkMcpServers(raw) {
-  const servers = {};
-  const parsed = tryParseJson(raw);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !parsed.mcpServers || typeof parsed.mcpServers !== "object" || Array.isArray(parsed.mcpServers)) {
-    return servers;
-  }
-  for (const [name, server] of Object.entries(parsed.mcpServers)) {
-    if (!server || typeof server !== "object" || Array.isArray(server) || typeof server.url !== "string" || !server.url.trim()) {
-      continue;
-    }
-    const entry = { type: "http", url: server.url };
-    if (server.headers && typeof server.headers === "object" && !Array.isArray(server.headers)) {
-      const headers = {};
-      for (const [headerName, headerValue] of Object.entries(server.headers)) {
-        if (typeof headerValue === "string") {
-          headers[headerName] = headerValue;
-        }
-      }
-      if (Object.keys(headers).length > 0) entry.headers = headers;
-    }
-    servers[name] = entry;
-  }
-  return servers;
-}
-function readCursorSdkMcpServers() {
-  if (!existsSync8(MCP_CONFIG_PATH2)) return {};
-  try {
-    return parseCursorSdkMcpServers(readFileSync8(MCP_CONFIG_PATH2, "utf8"));
-  } catch {
-    return {};
-  }
 }
 function readPromptText2() {
   return readFileSync8("/tmp/design-prompt.txt", "utf8");
@@ -6080,12 +6072,11 @@ async function runCursorSdkAttempt(sessionMode) {
   const sdk = await loadCursorSdk();
   mkdirSync7(CURSOR_SDK_STORE_DIR, { recursive: true });
   const store4 = new sdk.JsonlLocalAgentStore(CURSOR_SDK_STORE_DIR);
-  const mcpServers = readCursorSdkMcpServers();
   const options = {
     apiKey: (process.env.CURSOR_API_KEY || "").trim(),
     model: await resolveCursorModelSelection(sdk),
     local: { cwd: WORK_DIR, store: store4 },
-    ...Object.keys(mcpServers).length > 0 ? { mcpServers } : {}
+    ...Object.keys(evaMcpServers).length > 0 ? { mcpServers: evaMcpServers } : {}
   };
   const persistAgentId = (agentId) => {
     callbackState.activeCursorSessionId = agentId;
@@ -6227,7 +6218,7 @@ async function runCursorSdkAttempt(sessionMode) {
   };
 }
 
-// callback-src/providers/attempts.ts
+// packages/backend/callback-src/providers/attempts.ts
 function prepareProviderSessionState() {
   if (PROVIDER === "codex") return prepareCodexSessionState();
   if (PROVIDER === "opencode") return prepareOpencodeSessionState();
@@ -6296,7 +6287,7 @@ async function runProviderAttempt(sessionMode) {
   return await runClaudeAttempt(sessionMode);
 }
 
-// callback-src/index.ts
+// packages/backend/callback-src/index.ts
 process.on("exit", (code) => {
   writeDoneFile("unexpected-exit", {
     exitCode: typeof code === "number" ? code : null

--- a/packages/backend/convex/_sandbox_runtime/launch.ts
+++ b/packages/backend/convex/_sandbox_runtime/launch.ts
@@ -167,23 +167,6 @@ export async function launchScript(
     ),
   ];
 
-  if (opts.mcpBaseUrl && opts.mcpToken) {
-    const mcpConfig = JSON.stringify({
-      mcpServers: {
-        eva: {
-          type: "http",
-          url: `${opts.mcpBaseUrl}/mcp`,
-          headers: {
-            Authorization: `Bearer ${opts.mcpToken}`,
-          },
-        },
-      },
-    });
-    uploadTasks.push(
-      uploadWithTiming("/tmp/eva-mcp.json", mcpConfig, "MCP config"),
-    );
-  }
-
   // Written on every launch, empty list included: the file persists on a reused
   // sandbox, so an unconditional write is what lets the callback prune stubs
   // for skills that have since been uninstalled.
@@ -266,6 +249,12 @@ export async function launchScript(
       envParts.push(`${key}=${quote([val])}`);
     }
   }
+  // Reserved Eva values are appended after repo/user env so they cannot be
+  // shadowed. The callback consumes and removes them before agent tools spawn.
+  if (opts.mcpBaseUrl && opts.mcpToken) {
+    envParts.push(`EVA_MCP_AUTH=${quote([opts.mcpToken])}`);
+    envParts.push(`EVA_MCP_BASE_URL=${quote([opts.mcpBaseUrl])}`);
+  }
   envParts.push(`CALLBACK_SCRIPT_FP=${quote([CALLBACK_SCRIPT_FINGERPRINT])}`);
   const exportLines = envParts.map((part) => `export ${part}`);
   // Kernel-enforced single-runner-per-entity: spawn under an exclusive flock
@@ -281,8 +270,11 @@ export async function launchScript(
     "#!/usr/bin/env bash",
     "set -euo pipefail",
     `[ -f ${EVA_ENV_FILE} ] && . ${EVA_ENV_FILE}`,
-    "rm -f /tmp/run-design.pid /tmp/run-design.ready",
+    "rm -f /tmp/run-design.pid /tmp/run-design.ready /tmp/eva-mcp.json",
     ...exportLines,
+    // The script carries per-launch credentials, so unlink it once this shell
+    // has loaded the exports and before the long-lived callback is spawned.
+    'rm -f "$0"',
     "if command -v flock >/dev/null 2>&1; then",
     `  nohup flock -n -E 217 ${runnerLockPath} node /tmp/run-design.mjs >> /tmp/design.log 2>&1 &`,
     "else",

--- a/packages/backend/docs/ARCHITECTURE.md
+++ b/packages/backend/docs/ARCHITECTURE.md
@@ -67,10 +67,11 @@ The callback owns seven core capabilities:
 
 ### 5. MCP-Config Injection
 
-- `/tmp/eva-mcp.json` written at launch (contains Convex-native HTTP MCP endpoint + auth token)
-- Passed to the Agent SDK via `extraArgs["mcp-config"]` as a `--mcp-config` CLI flag
-- Used because eva's MCP server is HTTP-based and requires authentication
-- **File:** `callback-src/index.ts:100`, `convex/_daytona/launch.ts:98`
+- The launcher exports `EVA_MCP_AUTH` and `EVA_MCP_BASE_URL` only to the callback process
+- The callback converts them into one typed in-memory HTTP server descriptor, then removes the variables before agent tools spawn
+- Claude and Cursor receive the same descriptor through their SDK `mcpServers` options; no MCP config file is written
+- The credential-bearing launch script unlinks itself before spawning the long-lived callback
+- **Files:** `callback-src/evaMcp.ts`, `callback-src/providers/claudeSdk.ts`, `callback-src/providers/cursorSdk.ts`, `convex/_sandbox_runtime/launch.ts`
 
 ### 6. Background-Task Disabling
 


### PR DESCRIPTION
## Summary

- replace the sandbox `/tmp/eva-mcp.json` token file with reserved launch environment variables
- consume those variables once into a shared typed in-memory HTTP MCP descriptor, then remove them from `process.env`
- pass the descriptor directly through both Claude and Cursor SDK `mcpServers` options
- remove legacy MCP files on launch and unlink the credential-bearing runner script before spawning the callback
- refresh architecture/custom-MCP documentation and move the completed implementation plan out of todo

## Why

The generated MCP file left a live bearer token on the sandbox filesystem and could survive sandbox reuse. The old file gate could therefore expose stale Eva MCP authorization to a later callback. Keeping the descriptor in callback memory removes that durable config file, while scrubbing the transport variables prevents agent tools and unrelated child processes from inheriting the bearer token.

## Validation

- `node packages/backend/scripts/build-callback-script.mjs`
- `corepack pnpm --filter @eva/backend exec vitest run callback-src/tests/evaMcp.test.ts callback-src/tests/cursorSdk.test.ts` — 13 tests passed
- `corepack pnpm --filter @eva/backend typecheck`
- `git diff --check`

No shared dev deployment was performed.
