### PR TITLE
Integrate #578 + #577 + #583 + #581 for prod

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,26 @@
 {
+  "permissions": {
+    "allow": [
+      "mcp__axiom__listDatasets",
+      "mcp__axiom__getDatasetSchema",
+      "mcp__axiom__queryApl",
+      "mcp__axiom__getSavedQueries",
+      "mcp__axiom__checkMonitors",
+      "mcp__axiom__getMonitorHistory"
+    ],
+    "deny": [
+      "mcp__axiom__createDashboard",
+      "mcp__axiom__createMonitor",
+      "mcp__axiom__createNotifier",
+      "mcp__axiom__deleteDashboard",
+      "mcp__axiom__deleteMonitor",
+      "mcp__axiom__deleteNotifier",
+      "mcp__axiom__updateDashboard",
+      "mcp__axiom__updateDashboardChart",
+      "mcp__axiom__updateMonitor",
+      "mcp__axiom__updateNotifier"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -23,3 +23,18 @@ env_vars = ["FIGMA_API_KEY"]
 [mcp_servers.linear]
 url = "https://mcp.linear.app/mcp"
 bearer_token_env_var = "LINEAR_API_KEY"
+
+[mcp_servers.axiom]
+url = "https://mcp.axiom.co/mcp"
+bearer_token_env_var = "AXIOM_MCP_PAT"
+env_http_headers = { "x-axiom-org-id" = "AXIOM_ORG_ID" }
+required = false
+default_tools_approval_mode = "approve"
+enabled_tools = [
+    "listDatasets",
+    "getDatasetSchema",
+    "queryApl",
+    "getSavedQueries",
+    "checkMonitors",
+    "getMonitorHistory",
+]

--- a/.mcp.json
+++ b/.mcp.json
@@ -31,6 +31,14 @@
         "--header",
         "Authorization:Bearer ${POSTHOG_API_KEY}"
       ]
+    },
+    "axiom": {
+      "type": "http",
+      "url": "https://mcp.axiom.co/mcp",
+      "headers": {
+        "Authorization": "Bearer ${AXIOM_MCP_PAT}",
+        "x-axiom-org-id": "${AXIOM_ORG_ID}"
+      }
     }
   }
 }

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Convex hot lists stop rereading heavyweight documents - 2026-08-12
+
+Nine days of production traffic consumed 125 GB of Convex database I/O, led by `sessions.list`, `sessionWorkflow.claimPendingTurn`, `mentions.listData`, `agentTasks.getAllTasks`, and `repoSkills.listByRepo`. Their return values were already fairly small, but Convex charges for the source documents a function reads: projecting a few fields after `collect()` did not avoid loading session terminal state, task run logs, document bodies, or complete SKILL.md files.
+
+The 50 ms session daemon poll now reads a small `sessionDaemonStates` row containing only the staged turn and interrupt/setup signals. Existing sessions create that row on their first poll, and every signal writer mirrors the old session fields during the rollout, so in-flight daemons and rollback-safe code keep the same claim, cancellation, attachment, stop-agent, and setup-gate behavior. This also removes the hot poll from the large session document's contention set.
+
+Task lists now read one compact latest-run summary set per repo instead of joining every task to its newest full `agentRuns` document, whose logs and result data grow throughout execution. Every task and run creation path maintains the summary, while a per-task live-read fallback preserves exact results until the online backfill reaches that row. Repo skill metadata similarly keeps new SKILL.md bodies in `repoSkillContents`; the content viewer falls back to legacy inline content while the migration moves old bodies, so `listByRepo` stops paying for bodies it never returns.
+
+Session, mention, and task list predicates now use compound indexes that include archive/status and soft-delete state. This moves exclusion into Convex's index range instead of scanning documents and filtering afterward, while retaining the existing caps, ordering, authorization, return validators, archived-session semantics, and open-task mention set.
+
 ## Component data survives a sync to a local backend - 2026-08-12
 
 `sync:prod-to-local` imported the snapshot zip whole, and a zip that holds component tables cannot be imported that way. The import failed with "New table `X` in '\<component\>' has IDs that conflict with existing system table", because the CLI addresses a component namespace by name through `--component`, not by the `_components/` directories inside the zip. Every namespace also numbers its user tables from 10001, so a single whole-zip import puts two namespaces on the same numbers.
@@ -158,7 +168,7 @@ Also on that header: the head ref chip no longer truncates at `max-w-56` while t
 
 ## Persistent review header, checks pill, and a button for merge conflicts - 2026-08-11
 
-Everything that says what a pull request *is* lived inside the Overview tab: lifecycle pill, author, a prose sentence ("X wants to merge 3 commits into main from eva/foo"), and — at the foot of a long scroll — the merge box with CI and mergeability. From Diffs or Recap there was no way to tell a mergeable pull request from a conflicted one, and the sentence wrapped to three lines in a session pane.
+Everything that says what a pull request _is_ lived inside the Overview tab: lifecycle pill, author, a prose sentence ("X wants to merge 3 commits into main from eva/foo"), and — at the foot of a long scroll — the merge box with CI and mergeability. From Diffs or Recap there was no way to tell a mergeable pull request from a conflicted one, and the sentence wrapped to three lines in a session pane.
 
 `ReviewTabsPanel` now reads `usePrOverview` itself and renders a shared `ReviewHeader` above the tab row, so both review surfaces (`/reviews/$prNumber`, sandbox Review tab) get one header from one query: status pill, author and last-updated, `base ← head` as monospace chips, commits/files/±diffstat, and a blocker badge. The prose sentence and `PrOverviewHeader` are deleted; `ReviewOverviewPanel` takes the payload as props instead of fetching a second time, and the standalone page's title block became the header's first row (`headerOwnsRefresh` still keeps Refresh to one control).
 
@@ -191,11 +201,13 @@ Tailwind v4’s preflight switched buttons to `cursor: default` (browser UA). In
 OpenAI shipped GPT-5.6 coding tiers (Sol / Terra / Luna) while Eva’s Codex picker still only offered GPT-5.5. Added `codex:gpt-5.6-sol`, `codex:gpt-5.6-terra`, and `codex:gpt-5.6-luna` (CLI slugs `gpt-5.6-*`), kept GPT-5.5, aliased bare `codex:gpt-5.6` → Sol, exposed `max` reasoning for 5.6, and updated Codex token pricing.
 
 ## One sandbox owner contract for sessions, tasks, and projects - 2026-08-10
+
 ## Mouse wheel dead-zones from blanket overscroll contain - 2026-08-08
 
 Putting `overscroll-behavior: contain` on `@utility scrollbar` made every `overflow:auto` pane a contain target, including ones with no overflow and horizontal boards with `overflow-y-hidden`. Chrome treats those as scroll containers at their boundary, so the wheel was swallowed while dragging the ancestor scrollbar still worked. Removed contain from the utility; restored `overscroll-y-contain` / `overscroll-contain` on the kanban column and mention picker that had opted in before.
 
 ## Anonymous landing no longer waits for Clerk - 2026-08-08
+
 ## Anonymous landing no longer waits for Clerk - 2026-08-08
 
 Boot held first paint on Clerk's `isLoaded` for everyone. For a returning signed-in user that is correct — protected routes need the restored session and the alternative is a landing-page flash. For an anonymous visitor it means a blank screen while ~210 kB of clerk-js downloads from Clerk's CDN and completes a handshake, to restore a session that does not exist. Measured on production: clerk-js is 30% of the 700 kB cold landing payload, and FCP (~500 ms) was gated on it.

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## MCP auth stays in callback memory - 2026-08-12
+
+Eva's bearer token previously lived in `/tmp/eva-mcp.json`, so reused sandboxes could retain stale authorization and filesystem snapshots captured a live credential. Launches now deliver the token through reserved environment variables, the callback immediately converts and scrubs them, and both Claude and Cursor receive one shared typed MCP descriptor directly through their SDK options. The one-time runner also removes legacy MCP files and unlinks its credential-bearing launch script before the long-lived callback starts.
+
 ## Repo default model includes traits - 2026-08-12
 
 The repository default model on settings/config only stored the model id, so new tasks and sessions always used each model's own reasoning/Fast defaults. The picker now has the same traits menu as composers, and those values persist on the repo and apply when a task or session is created without an override.

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -4,7 +4,7 @@
 
 The Claude Agent SDK and Cursor SDK were loaded by exact version inside sandbox callbacks, but neither version was declared in the backend workspace. That left local installs without the official packages and allowed the handwritten callback boundary types to drift without an inspectable, locked SDK beside them. New snapshots also preinstalled only Cursor's SDK, so the first Claude SDK task paid for a user-local fallback install.
 
-Both SDKs are now exact backend dependencies and are locked at the same versions used by the callback loaders. Snapshot seeding preinstalls both packages and verifies both directories before skipping the agent-tool install. The user-local dynamic loader remains for older snapshots; Cursor's package cannot be safely folded into the standalone callback bundle because its published ESM graph includes Bun-only and declaration-map imports.
+Both SDKs are now exact backend dependencies and are locked at the same versions used by the callback loaders. The provider boundaries import their official query, permission, agent, run, model, store, MCP, and usage types instead of restating those public APIs. Snapshot seeding preinstalls both packages and verifies both directories before skipping the agent-tool install. The user-local dynamic loader remains for older snapshots; the imports are type-only because Cursor's package cannot be safely folded into the standalone callback bundle—its published ESM graph includes Bun-only and declaration-map imports.
 
 ## Component data survives a sync to a local backend - 2026-08-12
 

--- a/internal/changelog.md
+++ b/internal/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Claude and Cursor SDK versions now match their sandbox runtimes - 2026-08-12
+
+The Claude Agent SDK and Cursor SDK were loaded by exact version inside sandbox callbacks, but neither version was declared in the backend workspace. That left local installs without the official packages and allowed the handwritten callback boundary types to drift without an inspectable, locked SDK beside them. New snapshots also preinstalled only Cursor's SDK, so the first Claude SDK task paid for a user-local fallback install.
+
+Both SDKs are now exact backend dependencies and are locked at the same versions used by the callback loaders. Snapshot seeding preinstalls both packages and verifies both directories before skipping the agent-tool install. The user-local dynamic loader remains for older snapshots; Cursor's package cannot be safely folded into the standalone callback bundle because its published ESM graph includes Bun-only and declaration-map imports.
+
 ## Component data survives a sync to a local backend - 2026-08-12
 
 `sync:prod-to-local` imported the snapshot zip whole, and a zip that holds component tables cannot be imported that way. The import failed with "New table `X` in '\<component\>' has IDs that conflict with existing system table", because the CLI addresses a component namespace by name through `--component`, not by the `_components/` directories inside the zip. Every namespace also numbers its user tables from 10001, so a single whole-zip import puts two namespaces on the same numbers.

--- a/internal/mcp-setup-report.md
+++ b/internal/mcp-setup-report.md
@@ -74,6 +74,33 @@ Get key: **PostHog > Settings > Personal API Keys** (use "MCP Server" preset)
 
 **Note:** Does not work on PostHog EU cloud (`eu.posthog.com`).
 
+## Axiom
+
+Official hosted MCP over Streamable HTTP, configured non-interactively with a
+dedicated user's personal access token and organization ID. Codex exposes only
+the log investigation tools; Claude Code automatically permits those tools and
+denies Axiom's dashboard, monitor, and notifier mutation tools.
+
+### Required setup
+
+1. Create a dedicated Axiom user for Eva agents and assign Axiom's **Read-only**
+   role, restricted to the Convex log datasets where your plan supports it.
+2. While signed in as that user, create a personal access token under
+   **Axiom > Settings > Profile > Personal tokens**.
+3. Copy the organization ID from **Axiom > Settings > General**.
+4. In Eva, open this repo's **Settings > Environment Variables** and add:
+   - `AXIOM_MCP_PAT` — the dedicated read-only user's personal access token.
+   - `AXIOM_ORG_ID` — the Axiom organization ID.
+5. Leave **Exclude from sandboxes** disabled for both variables. The MCP clients
+   read these values from the sandbox environment; excluding them prevents the
+   non-interactive connection from authenticating.
+
+Never commit either value. Axiom personal access tokens inherit the owning
+user's access, which is why the dedicated read-only user is required. Axiom's
+hosted MCP routes query results through its US infrastructure.
+
+Server URL: `https://mcp.axiom.co/mcp`
+
 ## Headless Mode (`-p`)
 
 MCP servers configured via `claude mcp add` persist in `~/.claude.json` and are available in `-p` mode automatically. No extra flags needed.

--- a/internal/plans/implemented/mcp-auth-env-var.md
+++ b/internal/plans/implemented/mcp-auth-env-var.md
@@ -1,6 +1,8 @@
 # MCP rework: token via EVA_MCP_AUTH env var (no eva-mcp.json)
 
-**Status:** todo
+**Status:** implemented (2026-08-12)
+
+Implementation note: Cursor had migrated from ACP to `@cursor/sdk` before this landed, so the final change centralizes both SDK shapes in `callback-src/evaMcp.ts`. It also scrubs the transport variables from `process.env` and unlinks the credential-bearing launch script before spawning the callback.
 
 ## Context
 

--- a/internal/plans/todo/custom-mcp-servers.md
+++ b/internal/plans/todo/custom-mcp-servers.md
@@ -4,10 +4,10 @@ Goal: let a repo register external MCP servers (Linear, Figma, PostHog, …) tha
 
 ## Current state (anchors)
 
-- Single MCP config written at launch: [launch.ts:172-187](../../packages/backend/convex/_daytona/launch.ts) — hardcoded `mcpServers: { eva: { type: "http", url, headers } }` → `/tmp/eva-mcp.json`.
-- All providers consume that one file: claude sdk (`--mcp-config /tmp/eva-mcp.json`, [claudeSdk.ts:34](../../packages/backend/callback-src/providers/claudeSdk.ts)), claude one-shot ([config.ts:252](../../packages/backend/callback-src/config.ts)), cursor (translates file → `~/.cursor/mcp.json` + `--approve-mcps`, [cursorSession.ts:35-77](../../packages/backend/callback-src/session/cursorSession.ts)).
+- Eva MCP auth reaches the callback through reserved launch environment variables; [evaMcp.ts](../../packages/backend/callback-src/evaMcp.ts) consumes them into one typed in-memory server record and removes them before agent tools spawn.
+- Claude and Cursor pass that record directly through their SDK `mcpServers` options; no MCP JSON file is written.
 - Secrets already resolvable per repo/team: `resolveAllEnvVars(ctx, repoId)` ([envVarResolver.ts](../../packages/backend/convex/envVarResolver.ts)).
-- `signAndLaunchScript` ([helpers.ts](../../packages/backend/convex/_daytona/helpers.ts)) has `ctx` + `repoId`; `launchScript` does not — custom servers must resolve there and pass through opts.
+- `signAndLaunchScript` ([helpers.ts](../../packages/backend/convex/_sandbox_runtime/helpers.ts)) has `ctx` + `repoId`; `launchScript` does not — custom servers must resolve there and pass through opts.
 
 ## Design
 
@@ -26,14 +26,13 @@ New table `repoMcpServers` (fields in `_validators/tableFields.ts` per conventio
 1. CRUD in new `convex/repoMcpServers.ts`: `listByRepo` (authQuery, repo access check), `upsert`, `remove` (authMutations). Mask nothing — header values are templates, not secrets.
 2. Internal `resolveForLaunch(repoId)` internalQuery: enabled servers for repo.
 3. `signAndLaunchScript`: when `opts.enableMcp !== false`, fetch servers + `resolveAllEnvVars`, substitute `${VAR}` in header values (missing var → skip server + console.warn, do not fail launch), pass `customMcpServers` through to `launchScript` opts.
-4. `launchScript` (launch.ts:172): merge into the JSON — `mcpServers: { eva: {...}, ...custom }`. Written only when mcp enabled (keep current gate).
+4. Merge future servers into the callback's in-memory `mcpServers` record for each SDK, not a JSON file.
 5. Prompt: append one line to session/task/project chat prompts listing connected server names ("Connected MCP servers: eva, linear, figma") so agents discover them. Optional v1.
 
-### Callback (verify, likely zero changes)
+### Callback
 
-- claude: `--mcp-config` passes whole file — works as-is.
-- cursor: confirm cursorSession.ts translation copies ALL entries (it parses the file; check it doesn't cherry-pick `eva`). `--approve-mcps` already auto-approves.
-- codex/opencode: check whether they consume `/tmp/eva-mcp.json` at all; if not, note gap in tool descriptions (out of scope to add).
+- Extend the shared in-memory MCP boundary so Claude and Cursor receive every resolved server in their SDK-native shapes.
+- Codex/OpenCode do not consume Eva MCP today; adding them remains out of scope.
 - If any callback change needed → rebuild `callbackScript.generated.ts` (`node scripts/build-callback-script.mjs`).
 
 ### Web UI
@@ -43,7 +42,7 @@ New table `repoMcpServers` (fields in `_validators/tableFields.ts` per conventio
 
 ### Security notes
 
-- Substituted secrets land in `/tmp/eva-mcp.json` inside the sandbox — same trust level as existing provider keys/mcpToken already in sandbox env. Acceptable.
+- Substituted secrets must remain in callback memory and be removed from inherited child-process environments after consumption.
 - OAuth-flow MCP servers (e.g. Linear's hosted OAuth mode) NOT supported v1 — header/API-key auth only. Document in UI hint.
 - Data minimisation: header templates in Convex, real values only in team/repo env vars.
 

--- a/packages/backend/callback-src/config.ts
+++ b/packages/backend/callback-src/config.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "fs";
+import { hasEvaMcpConfig } from "./evaMcp.js";
 
 export const CONVEX_URL = process.env.CONVEX_URL;
 export const CONVEX_SITE_URL = process.env.CONVEX_SITE_URL || CONVEX_URL;
@@ -238,8 +239,8 @@ function buildSettingsJson(): string {
 }
 
 export const settingsJson = buildSettingsJson();
-/** True when the sandbox MCP config file is present (used for startup logging). */
-export const hasMcpConfig = existsSync("/tmp/eva-mcp.json");
+/** True when Eva MCP auth was supplied at callback startup. */
+export const hasMcpConfig = hasEvaMcpConfig;
 const claudeModelBase = MODEL.startsWith("claude:")
   ? MODEL.slice("claude:".length)
   : MODEL;

--- a/packages/backend/callback-src/evaMcp.ts
+++ b/packages/backend/callback-src/evaMcp.ts
@@ -1,0 +1,47 @@
+export type HttpMcpServerConfig = {
+  type: "http";
+  url: string;
+  headers: Record<string, string>;
+};
+
+export type HttpMcpServers = Record<string, HttpMcpServerConfig>;
+
+type EvaMcpEnvironment = {
+  EVA_MCP_AUTH?: string;
+  EVA_MCP_BASE_URL?: string;
+};
+
+export function buildEvaMcpServers({
+  auth,
+  baseUrl,
+}: {
+  auth?: string;
+  baseUrl?: string;
+}): HttpMcpServers {
+  if (!auth || !baseUrl) return {};
+  return {
+    eva: {
+      type: "http",
+      url: `${baseUrl}/mcp`,
+      headers: { Authorization: `Bearer ${auth}` },
+    },
+  };
+}
+
+export function consumeEvaMcpEnvironment(
+  env: EvaMcpEnvironment,
+): HttpMcpServers {
+  const servers = buildEvaMcpServers({
+    auth: env.EVA_MCP_AUTH,
+    baseUrl: env.EVA_MCP_BASE_URL,
+  });
+  // The callback keeps the MCP descriptor in memory. Removing the transport
+  // variables stops agent tools and unrelated child processes inheriting the
+  // bearer token through their environment.
+  delete env.EVA_MCP_AUTH;
+  delete env.EVA_MCP_BASE_URL;
+  return servers;
+}
+
+export const evaMcpServers = consumeEvaMcpEnvironment(process.env);
+export const hasEvaMcpConfig = Object.keys(evaMcpServers).length > 0;

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -1,5 +1,10 @@
 import { execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
+import type {
+  CanUseTool,
+  Options,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
 import {
   ALLOWED_TOOLS,
   BLOCKING_QUESTIONS_ENABLED,
@@ -33,17 +38,6 @@ const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 const SDK_VERSION = "0.3.201";
 const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 
-/**
- * The subset of the Agent SDK `query()` surface this runner uses. The SDK is
- * dynamically imported from the sandbox's global npm root (it is installed in
- * the seed snapshot alongside the Claude CLI), so these local types stand in for
- * the SDK's own — kept intentionally narrow.
- */
-type SdkQueryHandle = AsyncIterable<Record<string, JsonLike>> & {
-  interrupt?: () => Promise<void>;
-  stopTask?: (taskId: string) => Promise<void>;
-};
-
 export type JsonLike =
   | string
   | number
@@ -52,51 +46,14 @@ export type JsonLike =
   | JsonLike[]
   | { [key: string]: JsonLike };
 
-/** Result the SDK expects from `canUseTool` (matches the Agent SDK's PermissionResult). */
-type SdkPermissionResult =
-  | { behavior: "allow"; updatedInput: Record<string, JsonLike> }
-  | { behavior: "deny"; message: string };
-
-/** The `canUseTool` permission callback passed to `query()`. */
-export type SdkCanUseTool = (
-  toolName: string,
-  input: Record<string, JsonLike>,
-  options: { signal: AbortSignal; toolUseID?: string },
-) => Promise<SdkPermissionResult>;
-
-export type SdkOptions = {
-  cwd: string;
-  model: string;
-  pathToClaudeCodeExecutable: string;
-  systemPrompt:
-    | { type: "preset"; preset: "claude_code"; append?: string }
-    | string;
-  permissionMode: string;
-  allowDangerouslySkipPermissions: boolean;
-  allowedTools?: string[];
-  env: Record<string, string | undefined>;
-  sessionId?: string;
-  resume?: string;
-  extraArgs?: Record<string, string>;
-  includePartialMessages?: boolean;
-  effort?: "low" | "medium" | "high" | "xhigh" | "max";
-  /** Per-tool permission gate. Set only when blocking questions are enabled. */
-  canUseTool?: SdkCanUseTool;
-};
-
-export type SdkUserMessage = {
-  type: "user";
-  message: { role: "user"; content: string };
-  parent_tool_use_id: string | null;
-  session_id: string;
-};
-
-export type SdkModule = {
-  query: (args: {
-    prompt: string | AsyncIterable<SdkUserMessage>;
-    options: SdkOptions;
-  }) => SdkQueryHandle;
-};
+/** Official SDK types are erased from the standalone callback bundle. */
+export type SdkCanUseTool = CanUseTool;
+export type SdkOptions = Options;
+export type SdkUserMessage = SDKUserMessage;
+export type SdkModule = Pick<
+  typeof import("@anthropic-ai/claude-agent-sdk"),
+  "query"
+>;
 
 /** Resolves the sandbox's global npm root once (e.g. /usr/lib/node_modules). */
 export function globalNpmRoot(): string {
@@ -193,11 +150,10 @@ function buildSdkOptionsFromParts(
   // `bypassPermissions`. When enabled we switch to `default` mode and let the
   // gate auto-allow every tool except AskUserQuestion (which waits for the user).
   // Otherwise keep the original bypass behaviour (no per-tool gating).
-  const permissionOption: {
-    permissionMode: string;
-    allowDangerouslySkipPermissions: boolean;
-    canUseTool?: SdkCanUseTool;
-  } =
+  const permissionOption: Pick<
+    SdkOptions,
+    "permissionMode" | "allowDangerouslySkipPermissions" | "canUseTool"
+  > =
     tools === "agent" && BLOCKING_QUESTIONS_ENABLED
       ? {
           permissionMode: "default",
@@ -233,7 +189,7 @@ function buildSdkOptionsFromParts(
     delete env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
   }
 
-  const effortOption: { effort?: "low" | "medium" | "high" | "xhigh" | "max" } =
+  const effortOption: Pick<SdkOptions, "effort"> =
     claudeEffort === "low" ||
     claudeEffort === "medium" ||
     claudeEffort === "high" ||

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -15,6 +15,7 @@ import {
   normalizedClaudeModel,
   settingsJson,
 } from "../config.js";
+import { evaMcpServers, type HttpMcpServers } from "../evaMcp.js";
 import { buildClaudeStartupStep } from "../session/claudeSession.js";
 import { processRealtimeStdoutChunk } from "../parse/streamRouter.js";
 import { updateThinkingStep } from "../parse/canonical.js";
@@ -31,7 +32,6 @@ import { log } from "../utils.js";
 
 const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 const SDK_VERSION = "0.3.201";
-const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 
 /**
  * The subset of the Agent SDK `query()` surface this runner uses. The SDK is
@@ -80,6 +80,7 @@ export type SdkOptions = {
   extraArgs?: Record<string, string>;
   includePartialMessages?: boolean;
   effort?: "low" | "medium" | "high" | "xhigh" | "max";
+  mcpServers?: HttpMcpServers;
   /** Per-tool permission gate. Set only when blocking questions are enabled. */
   canUseTool?: SdkCanUseTool;
 };
@@ -170,9 +171,6 @@ export function buildSdkOptions(sessionMode: SessionMode): SdkOptions {
   // allowed tools, MCP, permissions, session resume). Formerly mirrored
   // Claude CLI flags; those builders are gone.
   const extraArgs: Record<string, string> = { settings: settingsJson };
-  if (existsSync(MCP_CONFIG_PATH)) {
-    extraArgs["mcp-config"] = MCP_CONFIG_PATH;
-  }
   return buildSdkOptionsFromParts(sessionMode, extraArgs);
 }
 
@@ -270,6 +268,9 @@ function buildSdkOptionsFromParts(
       ? { resume: sessionMode.sessionId }
       : {}),
     extraArgs,
+    ...(Object.keys(evaMcpServers).length > 0
+      ? { mcpServers: evaMcpServers }
+      : {}),
     ...effortOption,
   };
 }

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -4,6 +4,7 @@ import type {
   CanUseTool,
   Options,
   SDKUserMessage,
+  query,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
   ALLOWED_TOOLS,
@@ -50,10 +51,7 @@ export type JsonLike =
 export type SdkCanUseTool = CanUseTool;
 export type SdkOptions = Options;
 export type SdkUserMessage = SDKUserMessage;
-export type SdkModule = Pick<
-  typeof import("@anthropic-ai/claude-agent-sdk"),
-  "query"
->;
+export type SdkModule = { query: typeof query };
 
 /** Resolves the sandbox's global npm root once (e.g. /usr/lib/node_modules). */
 export function globalNpmRoot(): string {

--- a/packages/backend/callback-src/providers/claudeSdk.ts
+++ b/packages/backend/callback-src/providers/claudeSdk.ts
@@ -36,7 +36,7 @@ const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 /**
  * The subset of the Agent SDK `query()` surface this runner uses. The SDK is
  * dynamically imported from the sandbox's global npm root (it is installed in
- * the base Image alongside the claude CLI), so these local types stand in for
+ * the seed snapshot alongside the Claude CLI), so these local types stand in for
  * the SDK's own — kept intentionally narrow.
  */
 type SdkQueryHandle = AsyncIterable<Record<string, JsonLike>> & {

--- a/packages/backend/callback-src/providers/cursorSdk.ts
+++ b/packages/backend/callback-src/providers/cursorSdk.ts
@@ -1,5 +1,15 @@
 import { execSync } from "child_process";
 import { existsSync, mkdirSync, readFileSync } from "fs";
+import type {
+  AgentOptions,
+  McpServerConfig,
+  ModelListItem,
+  ModelParameterValue,
+  ModelSelection,
+  Run,
+  SDKAgent,
+  TokenUsage,
+} from "@cursor/sdk";
 import {
   CURSOR_SDK_STORE_DIR,
   MAX_TOTAL_RUNTIME_MS,
@@ -38,28 +48,10 @@ const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 /** User-writable fallback install location (persists in home across resumes). */
 const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk";
 
-/**
- * Narrow structural types for the subset of the Cursor SDK this runner uses.
- * The SDK is dynamically imported from the sandbox's global npm root (installed
- * in the seed snapshot), so these stand in for the SDK's own types.
- */
-export type SdkMcpServerConfig = {
-  type: "http";
-  url: string;
-  headers?: Record<string, string>;
-};
-
-/** Opaque store handle — constructed, passed back to the SDK, never inspected. */
-type SdkLocalAgentStore = {
-  readonly agents?: object;
-};
-
-type SdkModelParameterValue = { id: string; value: string };
-
-type SdkModelSelection = {
-  id: string;
-  params?: SdkModelParameterValue[];
-};
+/** Official SDK types are erased from the standalone callback bundle. */
+export type SdkMcpServerConfig = McpServerConfig;
+type SdkModelParameterValue = ModelParameterValue;
+type SdkModelSelection = ModelSelection;
 
 export function cursorModeParams(
   model: string,
@@ -76,21 +68,7 @@ export function cursorModeParams(
   return params;
 }
 
-type SdkModelParameterDefinition = {
-  id?: string;
-  values?: Array<{ value?: string }>;
-};
-
-type SdkModelVariant = {
-  params?: SdkModelParameterValue[];
-  displayName?: string;
-};
-
-type SdkModel = {
-  id?: string;
-  parameters?: SdkModelParameterDefinition[];
-  variants?: SdkModelVariant[];
-};
+type SdkModel = ModelListItem;
 
 /**
  * The `fast`/`context` parameter ids are not documented, so never trust them
@@ -123,54 +101,15 @@ export function filterModeParamsByModel(
   );
 }
 
-type SdkAgentOptions = {
-  apiKey: string;
-  model: SdkModelSelection;
-  local: { cwd: string; store: SdkLocalAgentStore };
-  mcpServers?: Record<string, SdkMcpServerConfig>;
-};
+type SdkAgentOptions = AgentOptions;
+type SdkTokenUsage = TokenUsage;
+type SdkRun = Run;
+type SdkAgent = SDKAgent;
 
-type SdkTokenUsage = {
-  inputTokens?: number;
-  outputTokens?: number;
-  cacheReadTokens?: number;
-  cacheWriteTokens?: number;
-};
-
-type SdkRunResult = {
-  status?: string;
-  result?: string;
-  error?: { message?: string; code?: string };
-  durationMs?: number;
-  usage?: SdkTokenUsage;
-};
-
-type SdkRun = {
-  stream: () => AsyncIterable<Record<string, JsonLike>>;
-  wait: () => Promise<SdkRunResult>;
-  cancel: () => Promise<void>;
-};
-
-type SdkSendOptions = { local?: { force?: boolean } };
-
-type SdkAgent = {
-  agentId: string;
-  send: (message: string, options?: SdkSendOptions) => Promise<SdkRun>;
-  close: () => void;
-};
-
-export type CursorSdkModule = {
-  Agent: {
-    create: (options: SdkAgentOptions) => Promise<SdkAgent>;
-    resume: (agentId: string, options: SdkAgentOptions) => Promise<SdkAgent>;
-  };
-  JsonlLocalAgentStore: new (rootDir: string) => SdkLocalAgentStore;
-  Cursor?: {
-    models?: {
-      list?: () => Promise<SdkModel[]>;
-    };
-  };
-};
+export type CursorSdkModule = Pick<
+  typeof import("@cursor/sdk"),
+  "Agent" | "Cursor" | "JsonlLocalAgentStore"
+>;
 
 /**
  * Imports the Cursor SDK, preferring the base Image's global install (seeded in
@@ -423,12 +362,11 @@ function readUsageTokens(
   value: JsonLike | SdkTokenUsage | undefined,
 ): UsageTokens | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const usage: SdkTokenUsage = value;
   return {
-    inputTokens: readNum(usage.inputTokens),
-    outputTokens: readNum(usage.outputTokens),
-    cacheReadTokens: readNum(usage.cacheReadTokens),
-    cacheWriteTokens: readNum(usage.cacheWriteTokens),
+    inputTokens: readNum(value.inputTokens),
+    outputTokens: readNum(value.outputTokens),
+    cacheReadTokens: readNum(value.cacheReadTokens),
+    cacheWriteTokens: readNum(value.cacheWriteTokens),
   };
 }
 

--- a/packages/backend/callback-src/providers/cursorSdk.ts
+++ b/packages/backend/callback-src/providers/cursorSdk.ts
@@ -12,6 +12,7 @@ import {
   cursorUse1mContext,
   normalizedCursorModel,
 } from "../config.js";
+import { evaMcpServers, type HttpMcpServers } from "../evaMcp.js";
 import { updateThinkingStep } from "../parse/canonical.js";
 import { processRealtimeStdoutChunk } from "../parse/streamRouter.js";
 import {
@@ -26,14 +27,13 @@ import {
   writeCursorSessionState,
 } from "../session/cursorSession.js";
 import type { CliAttemptResult, JsonValue, SessionMode } from "../types.js";
-import { log, tryParseJson } from "../utils.js";
+import { log } from "../utils.js";
 import { globalNpmRoot, type JsonLike } from "./claudeSdk.js";
 
 const SDK_PACKAGE = "@cursor/sdk";
 const SDK_VERSION = "1.0.26";
 /** ESM entry inside the package (its exports map's `import` target). */
 const SDK_ENTRY_RELPATH = "/dist/esm/index.js";
-const MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 
 /** User-writable fallback install location (persists in home across resumes). */
 const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk";
@@ -43,12 +43,6 @@ const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk";
  * The SDK is dynamically imported from the sandbox's global npm root (installed
  * in the seed snapshot), so these stand in for the SDK's own types.
  */
-export type SdkMcpServerConfig = {
-  type: "http";
-  url: string;
-  headers?: Record<string, string>;
-};
-
 /** Opaque store handle — constructed, passed back to the SDK, never inspected. */
 type SdkLocalAgentStore = {
   readonly agents?: object;
@@ -131,7 +125,7 @@ type SdkAgentOptions = {
   apiKey: string;
   model: SdkModelSelection;
   local: { cwd: string; store: SdkLocalAgentStore };
-  mcpServers?: Record<string, SdkMcpServerConfig>;
+  mcpServers?: HttpMcpServers;
 };
 
 type SdkTokenUsage = {
@@ -214,64 +208,6 @@ export async function loadCursorSdk(): Promise<CursorSdkModule> {
   }
   const mod: CursorSdkModule = await import(localEntry);
   return mod;
-}
-
-/**
- * Parses Eva's generated HTTP MCP descriptors into the SDK's inline mcpServers
- * shape (remote HTTP servers only, matching the old .cursor/mcp.json
- * translation). Header values are forwarded but never logged.
- */
-export function parseCursorSdkMcpServers(
-  raw: string,
-): Record<string, SdkMcpServerConfig> {
-  const servers: Record<string, SdkMcpServerConfig> = {};
-  const parsed = tryParseJson(raw);
-  if (
-    !parsed ||
-    typeof parsed !== "object" ||
-    Array.isArray(parsed) ||
-    !parsed.mcpServers ||
-    typeof parsed.mcpServers !== "object" ||
-    Array.isArray(parsed.mcpServers)
-  ) {
-    return servers;
-  }
-  for (const [name, server] of Object.entries(parsed.mcpServers)) {
-    if (
-      !server ||
-      typeof server !== "object" ||
-      Array.isArray(server) ||
-      typeof server.url !== "string" ||
-      !server.url.trim()
-    ) {
-      continue;
-    }
-    const entry: SdkMcpServerConfig = { type: "http", url: server.url };
-    if (
-      server.headers &&
-      typeof server.headers === "object" &&
-      !Array.isArray(server.headers)
-    ) {
-      const headers: Record<string, string> = {};
-      for (const [headerName, headerValue] of Object.entries(server.headers)) {
-        if (typeof headerValue === "string") {
-          headers[headerName] = headerValue;
-        }
-      }
-      if (Object.keys(headers).length > 0) entry.headers = headers;
-    }
-    servers[name] = entry;
-  }
-  return servers;
-}
-
-function readCursorSdkMcpServers(): Record<string, SdkMcpServerConfig> {
-  if (!existsSync(MCP_CONFIG_PATH)) return {};
-  try {
-    return parseCursorSdkMcpServers(readFileSync(MCP_CONFIG_PATH, "utf8"));
-  } catch {
-    return {};
-  }
 }
 
 function readPromptText(): string {
@@ -480,12 +416,13 @@ export async function runCursorSdkAttempt(
   const sdk = await loadCursorSdk();
   mkdirSync(CURSOR_SDK_STORE_DIR, { recursive: true });
   const store = new sdk.JsonlLocalAgentStore(CURSOR_SDK_STORE_DIR);
-  const mcpServers = readCursorSdkMcpServers();
   const options: SdkAgentOptions = {
     apiKey: (process.env.CURSOR_API_KEY || "").trim(),
     model: await resolveCursorModelSelection(sdk),
     local: { cwd: WORK_DIR, store },
-    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+    ...(Object.keys(evaMcpServers).length > 0
+      ? { mcpServers: evaMcpServers }
+      : {}),
   };
 
   const persistAgentId = (agentId: string): void => {

--- a/packages/backend/callback-src/providers/cursorSdk.ts
+++ b/packages/backend/callback-src/providers/cursorSdk.ts
@@ -1,7 +1,10 @@
 import { execSync } from "child_process";
 import { existsSync, mkdirSync, readFileSync } from "fs";
 import type {
+  Agent,
   AgentOptions,
+  Cursor,
+  JsonlLocalAgentStore,
   McpServerConfig,
   ModelListItem,
   ModelParameterValue,
@@ -110,10 +113,11 @@ type SdkTokenUsage = TokenUsage;
 type SdkRun = Run;
 type SdkAgent = SDKAgent;
 
-export type CursorSdkModule = Pick<
-  typeof import("@cursor/sdk"),
-  "Agent" | "Cursor" | "JsonlLocalAgentStore"
->;
+export type CursorSdkModule = {
+  Agent: typeof Agent;
+  Cursor: typeof Cursor;
+  JsonlLocalAgentStore: typeof JsonlLocalAgentStore;
+};
 
 /**
  * Imports the Cursor SDK, preferring the base Image's global install (seeded in

--- a/packages/backend/callback-src/session/cursorSession.ts
+++ b/packages/backend/callback-src/session/cursorSession.ts
@@ -28,8 +28,8 @@ export function syncCursorStateToPersist(): void {
 }
 
 function hydratePersistedCursorState(): void {
-  // MCP config is no longer written to WORK_DIR/.cursor/mcp.json — the SDK
-  // runner passes /tmp/eva-mcp.json servers inline (readCursorSdkMcpServers).
+  // MCP configuration is supplied directly to the Cursor SDK; no workspace
+  // file participates in session hydration.
   store.hydratePersistedState("hydratePersistedCursorState");
 }
 

--- a/packages/backend/callback-src/tests/cursorSdk.test.ts
+++ b/packages/backend/callback-src/tests/cursorSdk.test.ts
@@ -5,7 +5,6 @@ import { probeCursorSdkToolResult } from "../providers/cursor.js";
 import {
   cursorModeParams,
   filterModeParamsByModel,
-  parseCursorSdkMcpServers,
 } from "../providers/cursorSdk.js";
 
 test("splitCursorModel separates base id and reasoning level", () => {
@@ -120,32 +119,6 @@ test("filterModeParamsByModel without a model entry keeps only opted-in params",
 function opted(fastMode: boolean, use1mContext: boolean) {
   return { fastMode, use1mContext };
 }
-
-test("parseCursorSdkMcpServers maps eva-mcp.json to inline SDK config", () => {
-  const raw = JSON.stringify({
-    mcpServers: {
-      eva: {
-        url: "https://example.convex.site/mcp",
-        headers: { Authorization: "Bearer abc", "X-Num": 5 },
-      },
-      broken: { command: "npx" },
-      empty: { url: "   " },
-    },
-  });
-  const servers = parseCursorSdkMcpServers(raw);
-  expect(Object.keys(servers)).toEqual(["eva"]);
-  expect(servers.eva).toEqual({
-    type: "http",
-    url: "https://example.convex.site/mcp",
-    headers: { Authorization: "Bearer abc" },
-  });
-});
-
-test("parseCursorSdkMcpServers tolerates malformed input", () => {
-  expect(parseCursorSdkMcpServers("not json")).toEqual({});
-  expect(parseCursorSdkMcpServers("[]")).toEqual({});
-  expect(parseCursorSdkMcpServers('{"mcpServers":[]}')).toEqual({});
-});
 
 test("cursorSdkToolToStep maps known SDK tool kinds", () => {
   const read = cursorSdkToolToStep("read", { path: "/tmp/repo/src/a.ts" });

--- a/packages/backend/callback-src/tests/evaMcp.test.ts
+++ b/packages/backend/callback-src/tests/evaMcp.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+import {
+  buildEvaMcpServers,
+  consumeEvaMcpEnvironment,
+} from "../evaMcp.js";
+
+test("buildEvaMcpServers creates the authenticated HTTP descriptor", () => {
+  expect(
+    buildEvaMcpServers({
+      auth: "token-123",
+      baseUrl: "https://example.convex.site",
+    }),
+  ).toEqual({
+    eva: {
+      type: "http",
+      url: "https://example.convex.site/mcp",
+      headers: { Authorization: "Bearer token-123" },
+    },
+  });
+});
+
+test("buildEvaMcpServers requires both environment values", () => {
+  expect(buildEvaMcpServers({ auth: "token-123" })).toEqual({});
+  expect(
+    buildEvaMcpServers({ baseUrl: "https://example.convex.site" }),
+  ).toEqual({});
+  expect(buildEvaMcpServers({})).toEqual({});
+});
+
+test("consumeEvaMcpEnvironment removes credentials after reading them", () => {
+  const env = {
+    EVA_MCP_AUTH: "token-123",
+    EVA_MCP_BASE_URL: "https://example.convex.site",
+  };
+  const servers = consumeEvaMcpEnvironment(env);
+
+  expect(Object.keys(servers)).toEqual(["eva"]);
+  expect(env).toEqual({});
+});

--- a/packages/backend/convex/_agentTasks/drafts.ts
+++ b/packages/backend/convex/_agentTasks/drafts.ts
@@ -21,6 +21,7 @@ import {
   assertProviderAccountUsableBy,
   resolveDefaultProviderAccountId,
 } from "../_userProviderAccounts/defaults";
+import { createTaskRunSummary } from "./runSummary";
 
 /** Lists all draft tasks for the current user in a given repo, sorted by most recently updated. */
 export const listDrafts = authQuery({
@@ -110,6 +111,7 @@ export const saveDraft = authMutation({
       projectId: args.projectId,
       numId: await allocateNumId(ctx.db, args.repoId, "agentTasks"),
     });
+    await createTaskRunSummary(ctx, draftId, args.repoId);
     await ensureSubscribed(ctx, draftId, ctx.userId);
     return draftId;
   },

--- a/packages/backend/convex/_agentTasks/execution.ts
+++ b/packages/backend/convex/_agentTasks/execution.ts
@@ -15,6 +15,7 @@ import { workflow } from "../workflowManager";
 import { buildProjectBranchName } from "../_projects/helpers";
 import { resolveTaskWorkflowBaseBranch } from "../_taskWorkflow/resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
+import { setTaskLastRunStartedAt } from "./runSummary";
 
 /** Starts task execution by creating a run and launching the workflow. */
 export const startExecution = authMutation({
@@ -109,11 +110,12 @@ export const startExecution = authMutation({
       project ?? undefined,
     );
 
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.id,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       mode: args.mode,
       triggeredBy: ctx.userId,
       // Explicit comment (quick-task "Make changes") wins; otherwise consume any
@@ -127,6 +129,7 @@ export const startExecution = authMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.id, task.repoId, startedAt);
     await ctx.db.patch(args.id, {
       status: "in_progress",
       updatedAt: Date.now(),

--- a/packages/backend/convex/_agentTasks/mutations.ts
+++ b/packages/backend/convex/_agentTasks/mutations.ts
@@ -32,6 +32,7 @@ import {
   reconcileProviderAccountForModel,
   resolveDefaultProviderAccountId,
 } from "../_userProviderAccounts/defaults";
+import { createTaskRunSummary, moveTaskRunSummary } from "./runSummary";
 
 /** Extracts the PR number from a GitHub PR URL. */
 function extractPrNumber(prUrl: string): number | null {
@@ -148,6 +149,9 @@ export const update = authMutation({
     if (args.priority !== undefined)
       updates.priority = args.priority ?? undefined;
     await ctx.db.patch(args.id, updates);
+    if (args.repoId !== undefined && args.repoId !== task.repoId) {
+      await moveTaskRunSummary(ctx, args.id, args.repoId);
+    }
 
     if (args.title !== undefined && args.title !== task.title) {
       await logTaskActivity(
@@ -552,6 +556,7 @@ export const createQuickTask = authMutation({
       attachmentStorageIds: args.attachmentStorageIds,
       numId,
     });
+    await createTaskRunSummary(ctx, taskId, args.repoId);
     await ensureSubscribed(ctx, taskId, ctx.userId);
     await ctx.scheduler.runAfter(0, internal.textGen.generateTaskTags, {
       taskId,
@@ -613,6 +618,7 @@ export const createQuickTasksBatch = authMutation({
         model: repo.defaultModel,
         numId,
       });
+      await createTaskRunSummary(ctx, taskId, args.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
       taskIds.push(taskId);
     }
@@ -712,6 +718,7 @@ export const createBatchWithDependencies = authMutation({
         model,
         numId,
       });
+      await createTaskRunSummary(ctx, taskId, args.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
       taskIds.push(taskId);
     }

--- a/packages/backend/convex/_agentTasks/queries.ts
+++ b/packages/backend/convex/_agentTasks/queries.ts
@@ -17,8 +17,32 @@ async function enrichTasksWithLastRun(
   db: QueryCtx["db"],
   tasks: Array<Doc<"agentTasks">>,
 ) {
+  const repoIds = new Set<Id<"githubRepos">>();
+  for (const task of tasks) {
+    if (task.repoId) repoIds.add(task.repoId);
+  }
+  const summaryGroups = await Promise.all(
+    [...repoIds].map((repoId) =>
+      db
+        .query("agentTaskRunSummaries")
+        .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+        .collect(),
+    ),
+  );
+  const summariesByTask = new Map(
+    summaryGroups.flat().map((summary) => [String(summary.taskId), summary]),
+  );
+
   return Promise.all(
     tasks.map(async (task) => {
+      const summary = summariesByTask.get(String(task._id));
+      if (summary) {
+        return {
+          ...task,
+          lastRunStartedAt: summary.lastRunStartedAt,
+        };
+      }
+      // Migration-safe fallback for tasks whose summary row is not backfilled.
       const latestRun = await db
         .query("agentRuns")
         .withIndex("by_task", (q) => q.eq("taskId", task._id))
@@ -195,15 +219,16 @@ export const getAllTasks = authQuery({
       nonDraftStatuses.map((status) =>
         ctx.db
           .query("agentTasks")
-          .withIndex("by_repo_and_status", (q) =>
-            q.eq("repoId", args.repoId).eq("status", status),
+          .withIndex("by_repo_status_and_deleted", (q) =>
+            q
+              .eq("repoId", args.repoId)
+              .eq("status", status)
+              .eq("deletedAt", undefined),
           )
           .collect(),
       ),
     );
-    const tasks = filterActiveEntities(taskArrays.flat()).sort(
-      (a, b) => a.createdAt - b.createdAt,
-    );
+    const tasks = taskArrays.flat().sort((a, b) => a.createdAt - b.createdAt);
     return enrichTasksWithLastRun(ctx.db, tasks);
   },
 });

--- a/packages/backend/convex/_agentTasks/runSummary.ts
+++ b/packages/backend/convex/_agentTasks/runSummary.ts
@@ -1,0 +1,48 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+/** Inserts the no-runs sentinel row for a newly created task. */
+export async function createTaskRunSummary(
+  ctx: MutationCtx,
+  taskId: Id<"agentTasks">,
+  repoId: Id<"githubRepos">,
+): Promise<void> {
+  await ctx.db.insert("agentTaskRunSummaries", { taskId, repoId });
+}
+
+/** Upserts the small latest-run row used by task list queries. */
+export async function setTaskLastRunStartedAt(
+  ctx: MutationCtx,
+  taskId: Id<"agentTasks">,
+  repoId: Id<"githubRepos">,
+  lastRunStartedAt: number,
+): Promise<void> {
+  const summary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (summary) {
+    await ctx.db.patch(summary._id, { repoId, lastRunStartedAt });
+    return;
+  }
+  await ctx.db.insert("agentTaskRunSummaries", {
+    taskId,
+    repoId,
+    lastRunStartedAt,
+  });
+}
+
+/** Keeps the summary's repo key correct when a task moves between repos. */
+export async function moveTaskRunSummary(
+  ctx: MutationCtx,
+  taskId: Id<"agentTasks">,
+  repoId: Id<"githubRepos">,
+): Promise<void> {
+  const summary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (summary) {
+    await ctx.db.patch(summary._id, { repoId });
+  }
+}

--- a/packages/backend/convex/_automations/findings.ts
+++ b/packages/backend/convex/_automations/findings.ts
@@ -10,6 +10,10 @@ import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
 import { resolveTaskWorkflowBaseBranchForTask } from "../_taskWorkflow/resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
 import { normalizeAIModel } from "../validators";
+import {
+  createTaskRunSummary,
+  setTaskLastRunStartedAt,
+} from "../_agentTasks/runSummary";
 
 /** Creates agent tasks from selected automation findings and optionally auto-starts them. */
 export const createTasksFromFindings = authMutation({
@@ -62,6 +66,7 @@ export const createTasksFromFindings = authMutation({
         model: automation.model ?? repo.defaultModel,
         numId: await allocateNumId(ctx.db, automation.repoId, "agentTasks"),
       });
+      await createTaskRunSummary(ctx, taskId, automation.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
 
       updatedFindings[i] = { ...finding, taskId };
@@ -108,11 +113,12 @@ export const autoStartTask = internalMutation({
       return null;
     }
 
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.taskId,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
         task.providerAccountId,
@@ -120,6 +126,7 @@ export const autoStartTask = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, startedAt);
 
     await ctx.db.patch(args.taskId, {
       status: "in_progress",

--- a/packages/backend/convex/_chat/surfaceAdapters.ts
+++ b/packages/backend/convex/_chat/surfaceAdapters.ts
@@ -12,6 +12,7 @@ import {
   startNextQueuedTaskChatMessage,
 } from "../_queues/helpers";
 import type { WorkflowId } from "@convex-dev/workflow";
+import { syncSessionDaemonState } from "../_sessions/daemonState";
 
 /** Streaming entityId prefix for project chat workflows. */
 export const PROJECT_CHAT_STREAM_PREFIX = "project-chat-";
@@ -127,7 +128,9 @@ const sessionChatAdapter: ChatSurfaceAdapter<
   repoId: (session) => session.repoId,
   interrupt: async (ctx, session) => {
     if (getAIModelProvider(normalizeAIModel(session.lastModel)) === "claude") {
-      await ctx.db.patch(session._id, { cancelRequestedAt: Date.now() });
+      const cancelRequestedAt = Date.now();
+      await ctx.db.patch(session._id, { cancelRequestedAt });
+      await syncSessionDaemonState(ctx, session, { cancelRequestedAt });
     } else if (session.sandboxId) {
       await ctx.scheduler.runAfter(0, internal.sandbox.killSandboxProcess, {
         sandboxId: session.sandboxId,

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as _agentTasks_helpers from "../_agentTasks/helpers.js";
 import type * as _agentTasks_internal from "../_agentTasks/internal.js";
 import type * as _agentTasks_mutations from "../_agentTasks/mutations.js";
 import type * as _agentTasks_queries from "../_agentTasks/queries.js";
+import type * as _agentTasks_runSummary from "../_agentTasks/runSummary.js";
 import type * as _agentTasks_sandbox from "../_agentTasks/sandbox.js";
 import type * as _auth_currentUser from "../_auth/currentUser.js";
 import type * as _auth_experimentalFlags from "../_auth/experimentalFlags.js";
@@ -112,6 +113,7 @@ import type * as _pty_launchDevServerInVercelConsole from "../_pty/launchDevServ
 import type * as _pty_owners from "../_pty/owners.js";
 import type * as _pty_vercel from "../_pty/vercel.js";
 import type * as _queues_helpers from "../_queues/helpers.js";
+import type * as _repoSkills_content from "../_repoSkills/content.js";
 import type * as _repoSkills_decodeGitHubContent from "../_repoSkills/decodeGitHubContent.js";
 import type * as _repoSkills_skillMarkdown from "../_repoSkills/skillMarkdown.js";
 import type * as _repoSkills_sync from "../_repoSkills/sync.js";
@@ -157,6 +159,7 @@ import type * as _sandbox_runtime_swap from "../_sandbox_runtime/swap.js";
 import type * as _sandbox_runtime_vercelAppPorts from "../_sandbox_runtime/vercelAppPorts.js";
 import type * as _sessions_backgroundAgents from "../_sessions/backgroundAgents.js";
 import type * as _sessions_baseBranch from "../_sessions/baseBranch.js";
+import type * as _sessions_daemonState from "../_sessions/daemonState.js";
 import type * as _sessions_execution from "../_sessions/execution.js";
 import type * as _sessions_helpers from "../_sessions/helpers.js";
 import type * as _sessions_internal from "../_sessions/internal.js";
@@ -340,6 +343,7 @@ declare const fullApi: ApiFromModules<{
   "_agentTasks/internal": typeof _agentTasks_internal;
   "_agentTasks/mutations": typeof _agentTasks_mutations;
   "_agentTasks/queries": typeof _agentTasks_queries;
+  "_agentTasks/runSummary": typeof _agentTasks_runSummary;
   "_agentTasks/sandbox": typeof _agentTasks_sandbox;
   "_auth/currentUser": typeof _auth_currentUser;
   "_auth/experimentalFlags": typeof _auth_experimentalFlags;
@@ -435,6 +439,7 @@ declare const fullApi: ApiFromModules<{
   "_pty/owners": typeof _pty_owners;
   "_pty/vercel": typeof _pty_vercel;
   "_queues/helpers": typeof _queues_helpers;
+  "_repoSkills/content": typeof _repoSkills_content;
   "_repoSkills/decodeGitHubContent": typeof _repoSkills_decodeGitHubContent;
   "_repoSkills/skillMarkdown": typeof _repoSkills_skillMarkdown;
   "_repoSkills/sync": typeof _repoSkills_sync;
@@ -480,6 +485,7 @@ declare const fullApi: ApiFromModules<{
   "_sandbox_runtime/vercelAppPorts": typeof _sandbox_runtime_vercelAppPorts;
   "_sessions/backgroundAgents": typeof _sessions_backgroundAgents;
   "_sessions/baseBranch": typeof _sessions_baseBranch;
+  "_sessions/daemonState": typeof _sessions_daemonState;
   "_sessions/execution": typeof _sessions_execution;
   "_sessions/helpers": typeof _sessions_helpers;
   "_sessions/internal": typeof _sessions_internal;

--- a/packages/backend/convex/_mentions/listData.ts
+++ b/packages/backend/convex/_mentions/listData.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { authQuery, hasRepoAccess } from "../functions";
-import { entityVisible, filterActiveEntities, isEntityDeleted } from "../numId";
+import { entityVisible } from "../numId";
 import {
   DATA_MENTION_BADGE,
   DATA_MENTION_KINDS,
@@ -70,11 +70,12 @@ export const listData = authQuery({
 
     const docs = await ctx.db
       .query("docs")
-      .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
+      .withIndex("by_repo_and_deleted", (q) =>
+        q.eq("repoId", args.repoId).eq("deletedAt", undefined),
+      )
       .order("desc")
       .take(MENTION_LIST_CAP);
     for (const doc of docs) {
-      if (isEntityDeleted(doc)) continue;
       // Prefer stored description — avoid pulling the whole body into the
       // picker payload even though the document read already paid for it.
       const description = doc.description?.trim()
@@ -91,13 +92,13 @@ export const listData = authQuery({
     }
 
     // Include archived sessions — soft-deleted only are excluded below.
-    const sessions = filterActiveEntities(
-      await ctx.db
-        .query("sessions")
-        .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
-        .order("desc")
-        .take(MENTION_LIST_CAP),
-    );
+    const sessions = await ctx.db
+      .query("sessions")
+      .withIndex("by_repo_and_deleted", (q) =>
+        q.eq("repoId", args.repoId).eq("deletedAt", undefined),
+      )
+      .order("desc")
+      .take(MENTION_LIST_CAP);
     for (const session of sessions) {
       items.push({
         kind: "session",
@@ -108,13 +109,13 @@ export const listData = authQuery({
       });
     }
 
-    const projects = filterActiveEntities(
-      await ctx.db
-        .query("projects")
-        .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
-        .order("desc")
-        .take(MENTION_LIST_CAP),
-    );
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_repo_and_deleted", (q) =>
+        q.eq("repoId", args.repoId).eq("deletedAt", undefined),
+      )
+      .order("desc")
+      .take(MENTION_LIST_CAP);
     for (const project of projects) {
       const description = project.description?.trim();
       items.push({
@@ -135,13 +136,16 @@ export const listData = authQuery({
       taskStatuses.map((status) =>
         ctx.db
           .query("agentTasks")
-          .withIndex("by_repo_and_status", (q) =>
-            q.eq("repoId", args.repoId).eq("status", status),
+          .withIndex("by_repo_status_and_deleted", (q) =>
+            q
+              .eq("repoId", args.repoId)
+              .eq("status", status)
+              .eq("deletedAt", undefined),
           )
           .take(MENTION_LIST_CAP),
       ),
     );
-    for (const task of filterActiveEntities(taskArrays.flat())) {
+    for (const task of taskArrays.flat()) {
       const description = task.description?.trim();
       items.push({
         kind: "quickTask",

--- a/packages/backend/convex/_migrations/deleteRepos.ts
+++ b/packages/backend/convex/_migrations/deleteRepos.ts
@@ -131,6 +131,14 @@ export const deleteRepoStep = internalMutation({
       }
 
       case "tasks": {
+        const summaries = await ctx.db
+          .query("agentTaskRunSummaries")
+          .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+          .collect();
+        for (const summary of summaries) {
+          await ctx.db.delete(summary._id);
+          deleted++;
+        }
         const tasks = await ctx.db
           .query("agentTasks")
           .withIndex("by_repo", (q) => q.eq("repoId", repoId))
@@ -148,6 +156,14 @@ export const deleteRepoStep = internalMutation({
           .withIndex("by_repo", (q) => q.eq("repoId", repoId))
           .collect();
         for (const session of sessions) {
+          const daemonState = await ctx.db
+            .query("sessionDaemonStates")
+            .withIndex("by_session", (q) => q.eq("sessionId", session._id))
+            .unique();
+          if (daemonState) {
+            await ctx.db.delete(daemonState._id);
+            deleted++;
+          }
           const messages = await ctx.db
             .query("messages")
             .withIndex("by_parent", (q) => q.eq("parentId", session._id))
@@ -228,6 +244,20 @@ export const deleteRepoStep = internalMutation({
       }
 
       case "flatTables": {
+        const repoSkills = await ctx.db
+          .query("repoSkills")
+          .withIndex("by_repo", (q) => q.eq("repoId", repoId))
+          .collect();
+        for (const skill of repoSkills) {
+          const content = await ctx.db
+            .query("repoSkillContents")
+            .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+            .unique();
+          if (content) {
+            await ctx.db.delete(content._id);
+            deleted++;
+          }
+        }
         const tables = [
           "designPersonas",
           "repoSkills",

--- a/packages/backend/convex/_projects/development.ts
+++ b/packages/backend/convex/_projects/development.ts
@@ -10,6 +10,7 @@ import {
   buildProjectBranchName,
 } from "./helpers";
 import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
+import { createTaskRunSummary } from "../_agentTasks/runSummary";
 
 /** Converts a finalized project spec into tasks with dependencies and sets the project to business_review. */
 export const startDevelopment = authMutation({
@@ -54,6 +55,7 @@ export const startDevelopment = authMutation({
         baseBranch: projectBaseBranch,
         numId,
       });
+      await createTaskRunSummary(ctx, taskId, project.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
       taskIdMap.set(taskNumber, taskId);
     }

--- a/packages/backend/convex/_projects/sandbox.ts
+++ b/packages/backend/convex/_projects/sandbox.ts
@@ -12,6 +12,7 @@ import {
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
 import { clearPendingQuestionsForEntity } from "../pendingQuestions";
 import { normalizeAIModel } from "../validators";
+import { setTaskLastRunStartedAt } from "../_agentTasks/runSummary";
 
 const PREVIEW_ALLOWED_PHASES = [
   "in_progress",
@@ -244,11 +245,12 @@ export const resolveProjectConflicts = authMutation({
       project.baseBranch ?? repo.defaultBaseBranch ?? FALLBACK_GIT_BASE_BRANCH;
 
     const previousStatus = carrier.status;
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: carrier._id,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       mode: "resolve_conflicts",
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
@@ -257,6 +259,7 @@ export const resolveProjectConflicts = authMutation({
       ),
       model: normalizeAIModel(carrier.model),
     });
+    await setTaskLastRunStartedAt(ctx, carrier._id, project.repoId, startedAt);
     await ctx.db.patch(carrier._id, {
       status: "in_progress",
       updatedAt: Date.now(),

--- a/packages/backend/convex/_repoSkills/content.ts
+++ b/packages/backend/convex/_repoSkills/content.ts
@@ -1,0 +1,21 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+/** Stores a SKILL.md body outside the metadata row used by list subscriptions. */
+export async function upsertRepoSkillContent(
+  ctx: MutationCtx,
+  skillId: Id<"repoSkills">,
+  content: string,
+): Promise<void> {
+  const existing = await ctx.db
+    .query("repoSkillContents")
+    .withIndex("by_skill", (q) => q.eq("skillId", skillId))
+    .unique();
+  if (existing) {
+    if (existing.content !== content) {
+      await ctx.db.patch(existing._id, { content });
+    }
+    return;
+  }
+  await ctx.db.insert("repoSkillContents", { skillId, content });
+}

--- a/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
+++ b/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
@@ -1,6 +1,6 @@
 "use node";
 
-export const CALLBACK_SCRIPT = `// callback-src/index.ts
+export const CALLBACK_SCRIPT = `// packages/backend/callback-src/index.ts
 import {
   existsSync as existsSync9,
   mkdirSync as mkdirSync8,
@@ -9,8 +9,36 @@ import {
   writeFileSync as writeFileSync11
 } from "fs";
 
-// callback-src/config.ts
+// packages/backend/callback-src/config.ts
 import { existsSync } from "fs";
+
+// packages/backend/callback-src/evaMcp.ts
+function buildEvaMcpServers({
+  auth,
+  baseUrl
+}) {
+  if (!auth || !baseUrl) return {};
+  return {
+    eva: {
+      type: "http",
+      url: \`\${baseUrl}/mcp\`,
+      headers: { Authorization: \`Bearer \${auth}\` }
+    }
+  };
+}
+function consumeEvaMcpEnvironment(env) {
+  const servers = buildEvaMcpServers({
+    auth: env.EVA_MCP_AUTH,
+    baseUrl: env.EVA_MCP_BASE_URL
+  });
+  delete env.EVA_MCP_AUTH;
+  delete env.EVA_MCP_BASE_URL;
+  return servers;
+}
+var evaMcpServers = consumeEvaMcpEnvironment(process.env);
+var hasEvaMcpConfig = Object.keys(evaMcpServers).length > 0;
+
+// packages/backend/callback-src/config.ts
 var CONVEX_URL = process.env.CONVEX_URL;
 var CONVEX_SITE_URL = process.env.CONVEX_SITE_URL || CONVEX_URL;
 var CONVEX_TOKEN = process.env.CONVEX_TOKEN;
@@ -166,7 +194,7 @@ function buildSettingsJson() {
   return JSON.stringify(settings);
 }
 var settingsJson = buildSettingsJson();
-var hasMcpConfig = existsSync("/tmp/eva-mcp.json");
+var hasMcpConfig = hasEvaMcpConfig;
 var claudeModelBase = MODEL.startsWith("claude:") ? MODEL.slice("claude:".length) : MODEL;
 var normalizedClaudeModel = PROVIDER === "claude" && AI_CONTEXT_1M === "1" ? \`\${claudeModelBase}[1m]\` : claudeModelBase;
 var normalizedCodexModel = MODEL.startsWith("codex:") ? MODEL.slice("codex:".length) : MODEL;
@@ -261,10 +289,10 @@ var completedLabels = {
   "Asking a question...": "Asked a question"
 };
 
-// callback-src/providers/claudeSdkDaemon.ts
+// packages/backend/callback-src/providers/claudeSdkDaemon.ts
 import { unlinkSync as unlinkSync2, writeFileSync as writeFileSync9, readFileSync as readFileSync6 } from "fs";
 
-// callback-src/providers/daemonPaths.ts
+// packages/backend/callback-src/providers/daemonPaths.ts
 var LEGACY_DAEMON_PID = "/tmp/eva-daemon.pid";
 var LEGACY_DAEMON_ENTITY = "/tmp/eva-daemon.entity";
 var LEGACY_DAEMON_OPTS = "/tmp/eva-daemon.opts";
@@ -286,7 +314,7 @@ function resolveLegacySessionDaemonPaths() {
   };
 }
 
-// callback-src/utils.ts
+// packages/backend/callback-src/utils.ts
 import { spawnSync } from "child_process";
 import {
   cpSync,
@@ -298,7 +326,7 @@ import {
   writeFileSync
 } from "fs";
 
-// callback-src/runtime/state.ts
+// packages/backend/callback-src/runtime/state.ts
 function parsePriorStep(value) {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
@@ -468,7 +496,7 @@ function assignRawLogStream(stream) {
   callbackState.rawLogStream = stream;
 }
 
-// callback-src/utils.ts
+// packages/backend/callback-src/utils.ts
 function narrowJsonValue(value) {
   if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     return value;
@@ -639,7 +667,7 @@ function elapsedAttemptMs() {
   return attemptElapsedMs();
 }
 
-// callback-src/http/convexClient.ts
+// packages/backend/callback-src/http/convexClient.ts
 async function fetchWithTimeout(url, options, timeoutMs = CALLBACK_HTTP_TIMEOUT_MS) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -788,7 +816,7 @@ async function callStreamingHeartbeatTouch(entityId) {
   }
 }
 
-// callback-src/parse/stepBudget.ts
+// packages/backend/callback-src/parse/stepBudget.ts
 var STEP_FIELD_CAPS = {
   command: 600,
   output: 1200,
@@ -852,7 +880,7 @@ function serializeSteps(steps) {
   return JSON.stringify(enforceStepBudget(steps));
 }
 
-// callback-src/parse/toolResultCapture.ts
+// packages/backend/callback-src/parse/toolResultCapture.ts
 function capCommand(command) {
   return headCap(command, STEP_FIELD_CAPS.command).text;
 }
@@ -1035,7 +1063,7 @@ function probeOpencodeStateResult(state) {
   };
 }
 
-// callback-src/parse/toolSteps.ts
+// packages/backend/callback-src/parse/toolSteps.ts
 function opencodeToolToStep(part) {
   const tool = typeof part.tool === "string" ? part.tool : "tool";
   const stateObj = part.state && typeof part.state === "object" && !Array.isArray(part.state) ? part.state : null;
@@ -1677,7 +1705,7 @@ function codexItemToStep(item) {
   });
 }
 
-// callback-src/runtime/sandboxMedia.ts
+// packages/backend/callback-src/runtime/sandboxMedia.ts
 function mediaCandidateRoots(workDir, rootDirectory) {
   const roots = [workDir];
   const trimmed = rootDirectory?.trim() ?? "";
@@ -1697,7 +1725,7 @@ function mediaSearchDirs(workDir, rootDirectory) {
   };
 }
 
-// callback-src/runtime/completion.ts
+// packages/backend/callback-src/runtime/completion.ts
 import {
   existsSync as existsSync3,
   readFileSync as readFileSync2,
@@ -2150,7 +2178,7 @@ function hasToolActivity() {
   return callbackState.accumulatedSteps.some((step) => TOOL_STEP_TYPES.has(step.type));
 }
 
-// callback-src/session/claudeSession.ts
+// packages/backend/callback-src/session/claudeSession.ts
 import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync3 } from "fs";
 function buildClaudeStartupStep() {
   if (callbackState.waitingForFirstAssistantEvent && callbackState.claudeInitAt > 0) {
@@ -2355,7 +2383,7 @@ function prepareClaudeSessionState() {
   return sessionMode;
 }
 
-// callback-src/runtime/backgroundShells.ts
+// packages/backend/callback-src/runtime/backgroundShells.ts
 var PENDING_CAP = 200;
 var QUEUE_CAP = 20;
 var FLUSH_FAILURE_COOLDOWN_MS = 1e4;
@@ -2468,7 +2496,7 @@ async function flushBackgroundShellQueue() {
   }
 }
 
-// callback-src/parse/sdkTaxonomy.ts
+// packages/backend/callback-src/parse/sdkTaxonomy.ts
 var loggedUnknownKinds = /* @__PURE__ */ new Set();
 var knownBackgroundTaskIds = /* @__PURE__ */ new Set();
 function readString(value) {
@@ -2751,7 +2779,7 @@ function completeStatusOnNonStatusMessage(event) {
   completeActiveStatusStep();
 }
 
-// callback-src/providers/claude.ts
+// packages/backend/callback-src/providers/claude.ts
 function claudeToolCompleteResult(resultText, isError) {
   const output = buildStepOutput(resultText);
   if (!output && !isError) {
@@ -2974,10 +3002,10 @@ var claudeAdapter = {
   }
 };
 
-// callback-src/session/codexSession.ts
+// packages/backend/callback-src/session/codexSession.ts
 import { mkdirSync as mkdirSync4, writeFileSync as writeFileSync5 } from "fs";
 
-// callback-src/session/createSessionStore.ts
+// packages/backend/callback-src/session/createSessionStore.ts
 import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync4 } from "fs";
 function createSessionStore(config) {
   const readSessionState = () => {
@@ -3051,7 +3079,7 @@ function createSessionStore(config) {
   };
 }
 
-// callback-src/session/codexSession.ts
+// packages/backend/callback-src/session/codexSession.ts
 var store = createSessionStore({
   runtimeHomeDir: CODEX_RUNTIME_HOME_DIR,
   persistDir: CODEX_PERSIST_DIR,
@@ -3139,7 +3167,7 @@ function prepareCodexSessionState() {
   return persistedState && persistedState.resumeThreadId ? { mode: "resume", sessionId: persistedState.resumeThreadId } : { mode: "none", sessionId: null };
 }
 
-// callback-src/providers/codex.ts
+// packages/backend/callback-src/providers/codex.ts
 function codexParseLine(event) {
   const events = [];
   const threadId = getCodexThreadId(event);
@@ -3241,7 +3269,7 @@ var codexAdapter = {
   onStdoutText: inspectCodexStdout
 };
 
-// callback-src/session/cursorSession.ts
+// packages/backend/callback-src/session/cursorSession.ts
 var store2 = createSessionStore({
   runtimeHomeDir: CURSOR_RUNTIME_HOME_DIR,
   persistDir: CURSOR_PERSIST_DIR,
@@ -3279,7 +3307,7 @@ function prepareCursorSessionState() {
   return { mode: "none", sessionId: null };
 }
 
-// callback-src/providers/cursor.ts
+// packages/backend/callback-src/providers/cursor.ts
 function probeCursorSdkToolResult(status, result) {
   const eventIsError = status === "error";
   if (result === void 0 || result === null) {
@@ -3432,7 +3460,7 @@ var cursorAdapter = {
   }
 };
 
-// callback-src/session/opencodeSession.ts
+// packages/backend/callback-src/session/opencodeSession.ts
 import { mkdirSync as mkdirSync5, writeFileSync as writeFileSync6 } from "fs";
 var store3 = createSessionStore({
   runtimeHomeDir: OPENCODE_RUNTIME_HOME_DIR,
@@ -3493,7 +3521,7 @@ function prepareOpencodeSessionState() {
   return { mode: "none", sessionId: null };
 }
 
-// callback-src/providers/opencode.ts
+// packages/backend/callback-src/providers/opencode.ts
 function opencodeParseLine(event) {
   const events = [];
   if (event.type === "reasoning" && event.part && typeof event.part === "object" && !Array.isArray(event.part) && typeof event.part.text === "string" && event.part.text) {
@@ -3572,7 +3600,7 @@ var opencodeAdapter = {
   }
 };
 
-// callback-src/parse/canonical.ts
+// packages/backend/callback-src/parse/canonical.ts
 var stepStartedAt = /* @__PURE__ */ new WeakMap();
 function mergeToolResult(step, result) {
   if (result.output) {
@@ -3764,10 +3792,10 @@ function appendStreamedContent(text, isBlockBoundary = false) {
   callbackState.currentStreamedContent += nextText;
 }
 
-// callback-src/runtime/heartbeats.ts
+// packages/backend/callback-src/runtime/heartbeats.ts
 import { writeFileSync as writeFileSync7 } from "fs";
 
-// callback-src/runtime/processControl.ts
+// packages/backend/callback-src/runtime/processControl.ts
 import { spawnSync as spawnSync2 } from "child_process";
 function terminateAttemptProcess(child) {
   try {
@@ -3795,7 +3823,7 @@ function isChildZombie(pid) {
   }
 }
 
-// callback-src/runtime/heartbeats.ts
+// packages/backend/callback-src/runtime/heartbeats.ts
 var flushInterval = null;
 var heartbeatInterval = null;
 function buildStreamingPayload() {
@@ -3996,7 +4024,7 @@ async function runPreflightHeartbeat() {
   }
 }
 
-// callback-src/providers/index.ts
+// packages/backend/callback-src/providers/index.ts
 function getProviderAdapter(provider = PROVIDER) {
   if (provider === "codex") return codexAdapter;
   if (provider === "opencode") return opencodeAdapter;
@@ -4004,7 +4032,7 @@ function getProviderAdapter(provider = PROVIDER) {
   return claudeAdapter;
 }
 
-// callback-src/parse/streamRouter.ts
+// packages/backend/callback-src/parse/streamRouter.ts
 function processRealtimeStdoutChunk(text) {
   callbackState.realtimeOutputBuffer += text;
   while (true) {
@@ -4032,7 +4060,7 @@ function handleRealtimeStreamLine(line) {
   }
 }
 
-// callback-src/runtime/buffers.ts
+// packages/backend/callback-src/runtime/buffers.ts
 import { createWriteStream } from "fs";
 function trimBufferHead(buf) {
   if (buf.length <= OUTPUT_BUFFER_MAX_BYTES) return buf;
@@ -4070,11 +4098,11 @@ function appendToRawLogFile(text) {
   }
 }
 
-// callback-src/providers/claudeSdk.ts
+// packages/backend/callback-src/providers/claudeSdk.ts
 import { execSync } from "child_process";
 import { existsSync as existsSync6, readFileSync as readFileSync5 } from "fs";
 
-// callback-src/runtime/cliAttempt.ts
+// packages/backend/callback-src/runtime/cliAttempt.ts
 import { spawn } from "child_process";
 import { writeFileSync as writeFileSync8 } from "fs";
 function evaluateAttemptHealth(input) {
@@ -4254,7 +4282,7 @@ async function runCliAttempt(options) {
   });
 }
 
-// callback-src/runtime/pendingQuestion.ts
+// packages/backend/callback-src/runtime/pendingQuestion.ts
 var POLL_INTERVAL_MS = 300;
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -4328,10 +4356,9 @@ function buildCanUseTool() {
   };
 }
 
-// callback-src/providers/claudeSdk.ts
+// packages/backend/callback-src/providers/claudeSdk.ts
 var SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 var SDK_VERSION = "0.3.201";
-var MCP_CONFIG_PATH = "/tmp/eva-mcp.json";
 function globalNpmRoot() {
   return execSync("npm root -g", { encoding: "utf8" }).trim();
 }
@@ -4368,9 +4395,6 @@ function readPromptText() {
 }
 function buildSdkOptions(sessionMode) {
   const extraArgs = { settings: settingsJson };
-  if (existsSync6(MCP_CONFIG_PATH)) {
-    extraArgs["mcp-config"] = MCP_CONFIG_PATH;
-  }
   return buildSdkOptionsFromParts(sessionMode, extraArgs);
 }
 var EVA_SDK_SYSTEM_APPEND = "You are running inside Eva, a platform that runs coding agents in remote sandboxes against GitHub repos. Treat the workspace as the active repo checkout.";
@@ -4423,6 +4447,7 @@ function buildSdkOptionsFromParts(sessionMode, extraArgs, tools = "agent") {
     ...sessionMode.mode === "session" && sessionMode.sessionId ? { sessionId: sessionMode.sessionId } : {},
     ...sessionMode.mode === "resume" && sessionMode.sessionId ? { resume: sessionMode.sessionId } : {},
     extraArgs,
+    ...Object.keys(evaMcpServers).length > 0 ? { mcpServers: evaMcpServers } : {},
     ...effortOption
   };
 }
@@ -4536,7 +4561,7 @@ async function runClaudeSdkAttempt(sessionMode) {
   };
 }
 
-// callback-src/runtime/turnPersist.ts
+// packages/backend/callback-src/runtime/turnPersist.ts
 import { spawnSync as spawnSync3 } from "child_process";
 var GIT_STEP_TIMEOUT_MS = 2e4;
 var PUSH_TIMEOUT_MS = 6e4;
@@ -4686,7 +4711,7 @@ function persistTurnWork() {
   }
 }
 
-// callback-src/providers/claimPendingTurnParse.ts
+// packages/backend/callback-src/providers/claimPendingTurnParse.ts
 function readStopTaskToolUseIds(result) {
   if (typeof result !== "object" || result === null || Array.isArray(result)) {
     return [];
@@ -4708,7 +4733,7 @@ function readCancelRequested(result) {
   return payload.cancelRequested === true;
 }
 
-// callback-src/providers/claudeSdkDaemon.ts
+// packages/backend/callback-src/providers/claudeSdkDaemon.ts
 function sleep2(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -5735,7 +5760,7 @@ async function runSdkDaemon() {
   process.exit(0);
 }
 
-// callback-src/runtime/systemSkills.ts
+// packages/backend/callback-src/runtime/systemSkills.ts
 import {
   existsSync as existsSync7,
   mkdirSync as mkdirSync6,
@@ -5876,13 +5901,12 @@ function materializeSystemSkills() {
   }
 }
 
-// callback-src/providers/cursorSdk.ts
+// packages/backend/callback-src/providers/cursorSdk.ts
 import { execSync as execSync2 } from "child_process";
 import { existsSync as existsSync8, mkdirSync as mkdirSync7, readFileSync as readFileSync8 } from "fs";
 var SDK_PACKAGE2 = "@cursor/sdk";
 var SDK_VERSION2 = "1.0.26";
 var SDK_ENTRY_RELPATH = "/dist/esm/index.js";
-var MCP_CONFIG_PATH2 = "/tmp/eva-mcp.json";
 var SDK_LOCAL_PREFIX2 = "/home/eva/.eva-agent-sdk";
 function cursorModeParams(model, fastMode, use1mContext) {
   const params = [];
@@ -5927,38 +5951,6 @@ async function loadCursorSdk() {
   }
   const mod = await import(localEntry);
   return mod;
-}
-function parseCursorSdkMcpServers(raw) {
-  const servers = {};
-  const parsed = tryParseJson(raw);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !parsed.mcpServers || typeof parsed.mcpServers !== "object" || Array.isArray(parsed.mcpServers)) {
-    return servers;
-  }
-  for (const [name, server] of Object.entries(parsed.mcpServers)) {
-    if (!server || typeof server !== "object" || Array.isArray(server) || typeof server.url !== "string" || !server.url.trim()) {
-      continue;
-    }
-    const entry = { type: "http", url: server.url };
-    if (server.headers && typeof server.headers === "object" && !Array.isArray(server.headers)) {
-      const headers = {};
-      for (const [headerName, headerValue] of Object.entries(server.headers)) {
-        if (typeof headerValue === "string") {
-          headers[headerName] = headerValue;
-        }
-      }
-      if (Object.keys(headers).length > 0) entry.headers = headers;
-    }
-    servers[name] = entry;
-  }
-  return servers;
-}
-function readCursorSdkMcpServers() {
-  if (!existsSync8(MCP_CONFIG_PATH2)) return {};
-  try {
-    return parseCursorSdkMcpServers(readFileSync8(MCP_CONFIG_PATH2, "utf8"));
-  } catch {
-    return {};
-  }
 }
 function readPromptText2() {
   return readFileSync8("/tmp/design-prompt.txt", "utf8");
@@ -6080,12 +6072,11 @@ async function runCursorSdkAttempt(sessionMode) {
   const sdk = await loadCursorSdk();
   mkdirSync7(CURSOR_SDK_STORE_DIR, { recursive: true });
   const store4 = new sdk.JsonlLocalAgentStore(CURSOR_SDK_STORE_DIR);
-  const mcpServers = readCursorSdkMcpServers();
   const options = {
     apiKey: (process.env.CURSOR_API_KEY || "").trim(),
     model: await resolveCursorModelSelection(sdk),
     local: { cwd: WORK_DIR, store: store4 },
-    ...Object.keys(mcpServers).length > 0 ? { mcpServers } : {}
+    ...Object.keys(evaMcpServers).length > 0 ? { mcpServers: evaMcpServers } : {}
   };
   const persistAgentId = (agentId) => {
     callbackState.activeCursorSessionId = agentId;
@@ -6227,7 +6218,7 @@ async function runCursorSdkAttempt(sessionMode) {
   };
 }
 
-// callback-src/providers/attempts.ts
+// packages/backend/callback-src/providers/attempts.ts
 function prepareProviderSessionState() {
   if (PROVIDER === "codex") return prepareCodexSessionState();
   if (PROVIDER === "opencode") return prepareOpencodeSessionState();
@@ -6296,7 +6287,7 @@ async function runProviderAttempt(sessionMode) {
   return await runClaudeAttempt(sessionMode);
 }
 
-// callback-src/index.ts
+// packages/backend/callback-src/index.ts
 process.on("exit", (code) => {
   writeDoneFile("unexpected-exit", {
     exitCode: typeof code === "number" ? code : null

--- a/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
+++ b/packages/backend/convex/_sandbox_runtime/callbackScript.generated.ts
@@ -1,6 +1,6 @@
 "use node";
 
-export const CALLBACK_SCRIPT = `// packages/backend/callback-src/index.ts
+export const CALLBACK_SCRIPT = `// callback-src/index.ts
 import {
   existsSync as existsSync9,
   mkdirSync as mkdirSync8,
@@ -9,10 +9,10 @@ import {
   writeFileSync as writeFileSync11
 } from "fs";
 
-// packages/backend/callback-src/config.ts
+// callback-src/config.ts
 import { existsSync } from "fs";
 
-// packages/backend/callback-src/evaMcp.ts
+// callback-src/evaMcp.ts
 function buildEvaMcpServers({
   auth,
   baseUrl
@@ -38,7 +38,7 @@ function consumeEvaMcpEnvironment(env) {
 var evaMcpServers = consumeEvaMcpEnvironment(process.env);
 var hasEvaMcpConfig = Object.keys(evaMcpServers).length > 0;
 
-// packages/backend/callback-src/config.ts
+// callback-src/config.ts
 var CONVEX_URL = process.env.CONVEX_URL;
 var CONVEX_SITE_URL = process.env.CONVEX_SITE_URL || CONVEX_URL;
 var CONVEX_TOKEN = process.env.CONVEX_TOKEN;
@@ -289,10 +289,10 @@ var completedLabels = {
   "Asking a question...": "Asked a question"
 };
 
-// packages/backend/callback-src/providers/claudeSdkDaemon.ts
+// callback-src/providers/claudeSdkDaemon.ts
 import { unlinkSync as unlinkSync2, writeFileSync as writeFileSync9, readFileSync as readFileSync6 } from "fs";
 
-// packages/backend/callback-src/providers/daemonPaths.ts
+// callback-src/providers/daemonPaths.ts
 var LEGACY_DAEMON_PID = "/tmp/eva-daemon.pid";
 var LEGACY_DAEMON_ENTITY = "/tmp/eva-daemon.entity";
 var LEGACY_DAEMON_OPTS = "/tmp/eva-daemon.opts";
@@ -314,7 +314,7 @@ function resolveLegacySessionDaemonPaths() {
   };
 }
 
-// packages/backend/callback-src/utils.ts
+// callback-src/utils.ts
 import { spawnSync } from "child_process";
 import {
   cpSync,
@@ -326,7 +326,7 @@ import {
   writeFileSync
 } from "fs";
 
-// packages/backend/callback-src/runtime/state.ts
+// callback-src/runtime/state.ts
 function parsePriorStep(value) {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
@@ -496,7 +496,7 @@ function assignRawLogStream(stream) {
   callbackState.rawLogStream = stream;
 }
 
-// packages/backend/callback-src/utils.ts
+// callback-src/utils.ts
 function narrowJsonValue(value) {
   if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     return value;
@@ -667,7 +667,7 @@ function elapsedAttemptMs() {
   return attemptElapsedMs();
 }
 
-// packages/backend/callback-src/http/convexClient.ts
+// callback-src/http/convexClient.ts
 async function fetchWithTimeout(url, options, timeoutMs = CALLBACK_HTTP_TIMEOUT_MS) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -816,7 +816,7 @@ async function callStreamingHeartbeatTouch(entityId) {
   }
 }
 
-// packages/backend/callback-src/parse/stepBudget.ts
+// callback-src/parse/stepBudget.ts
 var STEP_FIELD_CAPS = {
   command: 600,
   output: 1200,
@@ -883,7 +883,7 @@ function serializeSteps(steps) {
   return JSON.stringify(enforceStepBudget(steps));
 }
 
-// packages/backend/callback-src/parse/toolResultCapture.ts
+// callback-src/parse/toolResultCapture.ts
 function capCommand(command) {
   return headCap(command, STEP_FIELD_CAPS.command).text;
 }
@@ -1066,7 +1066,7 @@ function probeOpencodeStateResult(state) {
   };
 }
 
-// packages/backend/callback-src/parse/toolSteps.ts
+// callback-src/parse/toolSteps.ts
 function opencodeToolToStep(part) {
   const tool = typeof part.tool === "string" ? part.tool : "tool";
   const stateObj = part.state && typeof part.state === "object" && !Array.isArray(part.state) ? part.state : null;
@@ -1708,7 +1708,7 @@ function codexItemToStep(item) {
   });
 }
 
-// packages/backend/callback-src/runtime/sandboxMedia.ts
+// callback-src/runtime/sandboxMedia.ts
 function mediaCandidateRoots(workDir, rootDirectory) {
   const roots = [workDir];
   const trimmed = rootDirectory?.trim() ?? "";
@@ -1728,7 +1728,7 @@ function mediaSearchDirs(workDir, rootDirectory) {
   };
 }
 
-// packages/backend/callback-src/runtime/completion.ts
+// callback-src/runtime/completion.ts
 import {
   existsSync as existsSync3,
   readFileSync as readFileSync2,
@@ -2181,7 +2181,7 @@ function hasToolActivity() {
   return callbackState.accumulatedSteps.some((step) => TOOL_STEP_TYPES.has(step.type));
 }
 
-// packages/backend/callback-src/session/claudeSession.ts
+// callback-src/session/claudeSession.ts
 import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync3 } from "fs";
 function buildClaudeStartupStep() {
   if (callbackState.waitingForFirstAssistantEvent && callbackState.claudeInitAt > 0) {
@@ -2386,7 +2386,7 @@ function prepareClaudeSessionState() {
   return sessionMode;
 }
 
-// packages/backend/callback-src/runtime/backgroundShells.ts
+// callback-src/runtime/backgroundShells.ts
 var PENDING_CAP = 200;
 var QUEUE_CAP = 20;
 var FLUSH_FAILURE_COOLDOWN_MS = 1e4;
@@ -2499,7 +2499,7 @@ async function flushBackgroundShellQueue() {
   }
 }
 
-// packages/backend/callback-src/parse/sdkTaxonomy.ts
+// callback-src/parse/sdkTaxonomy.ts
 var loggedUnknownKinds = /* @__PURE__ */ new Set();
 var knownBackgroundTaskIds = /* @__PURE__ */ new Set();
 function readString(value) {
@@ -2782,7 +2782,7 @@ function completeStatusOnNonStatusMessage(event) {
   completeActiveStatusStep();
 }
 
-// packages/backend/callback-src/providers/claude.ts
+// callback-src/providers/claude.ts
 function claudeToolCompleteResult(resultText, isError) {
   const output = buildStepOutput(resultText);
   if (!output && !isError) {
@@ -3005,10 +3005,10 @@ var claudeAdapter = {
   }
 };
 
-// packages/backend/callback-src/session/codexSession.ts
+// callback-src/session/codexSession.ts
 import { mkdirSync as mkdirSync4, writeFileSync as writeFileSync5 } from "fs";
 
-// packages/backend/callback-src/session/createSessionStore.ts
+// callback-src/session/createSessionStore.ts
 import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync4 } from "fs";
 function createSessionStore(config) {
   const readSessionState = () => {
@@ -3082,7 +3082,7 @@ function createSessionStore(config) {
   };
 }
 
-// packages/backend/callback-src/session/codexSession.ts
+// callback-src/session/codexSession.ts
 var store = createSessionStore({
   runtimeHomeDir: CODEX_RUNTIME_HOME_DIR,
   persistDir: CODEX_PERSIST_DIR,
@@ -3170,7 +3170,7 @@ function prepareCodexSessionState() {
   return persistedState && persistedState.resumeThreadId ? { mode: "resume", sessionId: persistedState.resumeThreadId } : { mode: "none", sessionId: null };
 }
 
-// packages/backend/callback-src/providers/codex.ts
+// callback-src/providers/codex.ts
 function codexParseLine(event) {
   const events = [];
   const threadId = getCodexThreadId(event);
@@ -3272,7 +3272,7 @@ var codexAdapter = {
   onStdoutText: inspectCodexStdout
 };
 
-// packages/backend/callback-src/session/cursorSession.ts
+// callback-src/session/cursorSession.ts
 var store2 = createSessionStore({
   runtimeHomeDir: CURSOR_RUNTIME_HOME_DIR,
   persistDir: CURSOR_PERSIST_DIR,
@@ -3310,7 +3310,7 @@ function prepareCursorSessionState() {
   return { mode: "none", sessionId: null };
 }
 
-// packages/backend/callback-src/providers/cursor.ts
+// callback-src/providers/cursor.ts
 function probeCursorSdkToolResult(status, result) {
   const eventIsError = status === "error";
   if (result === void 0 || result === null) {
@@ -3463,7 +3463,7 @@ var cursorAdapter = {
   }
 };
 
-// packages/backend/callback-src/session/opencodeSession.ts
+// callback-src/session/opencodeSession.ts
 import { mkdirSync as mkdirSync5, writeFileSync as writeFileSync6 } from "fs";
 var store3 = createSessionStore({
   runtimeHomeDir: OPENCODE_RUNTIME_HOME_DIR,
@@ -3524,7 +3524,7 @@ function prepareOpencodeSessionState() {
   return { mode: "none", sessionId: null };
 }
 
-// packages/backend/callback-src/providers/opencode.ts
+// callback-src/providers/opencode.ts
 function opencodeParseLine(event) {
   const events = [];
   if (event.type === "reasoning" && event.part && typeof event.part === "object" && !Array.isArray(event.part) && typeof event.part.text === "string" && event.part.text) {
@@ -3603,7 +3603,7 @@ var opencodeAdapter = {
   }
 };
 
-// packages/backend/callback-src/parse/canonical.ts
+// callback-src/parse/canonical.ts
 var stepStartedAt = /* @__PURE__ */ new WeakMap();
 function mergeToolResult(step, result) {
   if (result.output) {
@@ -3820,10 +3820,10 @@ function appendStreamedContent(text, isBlockBoundary = false) {
   callbackState.currentStreamedContent += nextText;
 }
 
-// packages/backend/callback-src/runtime/heartbeats.ts
+// callback-src/runtime/heartbeats.ts
 import { writeFileSync as writeFileSync7 } from "fs";
 
-// packages/backend/callback-src/runtime/processControl.ts
+// callback-src/runtime/processControl.ts
 import { spawnSync as spawnSync2 } from "child_process";
 function terminateAttemptProcess(child) {
   try {
@@ -3851,7 +3851,7 @@ function isChildZombie(pid) {
   }
 }
 
-// packages/backend/callback-src/runtime/heartbeats.ts
+// callback-src/runtime/heartbeats.ts
 var flushInterval = null;
 var heartbeatInterval = null;
 function buildStreamingPayload() {
@@ -4052,7 +4052,7 @@ async function runPreflightHeartbeat() {
   }
 }
 
-// packages/backend/callback-src/providers/index.ts
+// callback-src/providers/index.ts
 function getProviderAdapter(provider = PROVIDER) {
   if (provider === "codex") return codexAdapter;
   if (provider === "opencode") return opencodeAdapter;
@@ -4060,7 +4060,7 @@ function getProviderAdapter(provider = PROVIDER) {
   return claudeAdapter;
 }
 
-// packages/backend/callback-src/parse/streamRouter.ts
+// callback-src/parse/streamRouter.ts
 function processRealtimeStdoutChunk(text) {
   callbackState.realtimeOutputBuffer += text;
   while (true) {
@@ -4088,7 +4088,7 @@ function handleRealtimeStreamLine(line) {
   }
 }
 
-// packages/backend/callback-src/runtime/buffers.ts
+// callback-src/runtime/buffers.ts
 import { createWriteStream } from "fs";
 function trimBufferHead(buf) {
   if (buf.length <= OUTPUT_BUFFER_MAX_BYTES) return buf;
@@ -4126,11 +4126,11 @@ function appendToRawLogFile(text) {
   }
 }
 
-// packages/backend/callback-src/providers/claudeSdk.ts
+// callback-src/providers/claudeSdk.ts
 import { execSync } from "child_process";
 import { existsSync as existsSync6, readFileSync as readFileSync5 } from "fs";
 
-// packages/backend/callback-src/runtime/cliAttempt.ts
+// callback-src/runtime/cliAttempt.ts
 import { spawn } from "child_process";
 import { writeFileSync as writeFileSync8 } from "fs";
 function evaluateAttemptHealth(input) {
@@ -4310,7 +4310,7 @@ async function runCliAttempt(options) {
   });
 }
 
-// packages/backend/callback-src/runtime/pendingQuestion.ts
+// callback-src/runtime/pendingQuestion.ts
 var POLL_INTERVAL_MS = 300;
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -4384,7 +4384,7 @@ function buildCanUseTool() {
   };
 }
 
-// packages/backend/callback-src/providers/claudeSdk.ts
+// callback-src/providers/claudeSdk.ts
 var SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
 var SDK_VERSION = "0.3.201";
 function globalNpmRoot() {
@@ -4589,7 +4589,7 @@ async function runClaudeSdkAttempt(sessionMode) {
   };
 }
 
-// packages/backend/callback-src/runtime/turnPersist.ts
+// callback-src/runtime/turnPersist.ts
 import { spawnSync as spawnSync3 } from "child_process";
 var GIT_STEP_TIMEOUT_MS = 2e4;
 var PUSH_TIMEOUT_MS = 6e4;
@@ -4739,7 +4739,7 @@ function persistTurnWork() {
   }
 }
 
-// packages/backend/callback-src/providers/claimPendingTurnParse.ts
+// callback-src/providers/claimPendingTurnParse.ts
 function readStopTaskToolUseIds(result) {
   if (typeof result !== "object" || result === null || Array.isArray(result)) {
     return [];
@@ -4761,7 +4761,7 @@ function readCancelRequested(result) {
   return payload.cancelRequested === true;
 }
 
-// packages/backend/callback-src/providers/claudeSdkDaemon.ts
+// callback-src/providers/claudeSdkDaemon.ts
 function sleep2(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -5788,7 +5788,7 @@ async function runSdkDaemon() {
   process.exit(0);
 }
 
-// packages/backend/callback-src/runtime/systemSkills.ts
+// callback-src/runtime/systemSkills.ts
 import {
   existsSync as existsSync7,
   mkdirSync as mkdirSync6,
@@ -5929,7 +5929,7 @@ function materializeSystemSkills() {
   }
 }
 
-// packages/backend/callback-src/providers/cursorSdk.ts
+// callback-src/providers/cursorSdk.ts
 import { execSync as execSync2 } from "child_process";
 import { existsSync as existsSync8, mkdirSync as mkdirSync7, readFileSync as readFileSync8 } from "fs";
 var SDK_PACKAGE2 = "@cursor/sdk";
@@ -6070,12 +6070,11 @@ function readNum(value) {
 }
 function readUsageTokens(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const usage = value;
   return {
-    inputTokens: readNum(usage.inputTokens),
-    outputTokens: readNum(usage.outputTokens),
-    cacheReadTokens: readNum(usage.cacheReadTokens),
-    cacheWriteTokens: readNum(usage.cacheWriteTokens)
+    inputTokens: readNum(value.inputTokens),
+    outputTokens: readNum(value.outputTokens),
+    cacheReadTokens: readNum(value.cacheReadTokens),
+    cacheWriteTokens: readNum(value.cacheWriteTokens)
   };
 }
 async function runCursorSdkAttempt(sessionMode) {
@@ -6246,7 +6245,7 @@ async function runCursorSdkAttempt(sessionMode) {
   };
 }
 
-// packages/backend/callback-src/providers/attempts.ts
+// callback-src/providers/attempts.ts
 function prepareProviderSessionState() {
   if (PROVIDER === "codex") return prepareCodexSessionState();
   if (PROVIDER === "opencode") return prepareOpencodeSessionState();
@@ -6315,7 +6314,7 @@ async function runProviderAttempt(sessionMode) {
   return await runClaudeAttempt(sessionMode);
 }
 
-// packages/backend/callback-src/index.ts
+// callback-src/index.ts
 process.on("exit", (code) => {
   writeDoneFile("unexpected-exit", {
     exitCode: typeof code === "number" ? code : null

--- a/packages/backend/convex/_sandbox_runtime/launch.ts
+++ b/packages/backend/convex/_sandbox_runtime/launch.ts
@@ -167,23 +167,6 @@ export async function launchScript(
     ),
   ];
 
-  if (opts.mcpBaseUrl && opts.mcpToken) {
-    const mcpConfig = JSON.stringify({
-      mcpServers: {
-        eva: {
-          type: "http",
-          url: `${opts.mcpBaseUrl}/mcp`,
-          headers: {
-            Authorization: `Bearer ${opts.mcpToken}`,
-          },
-        },
-      },
-    });
-    uploadTasks.push(
-      uploadWithTiming("/tmp/eva-mcp.json", mcpConfig, "MCP config"),
-    );
-  }
-
   // Written on every launch, empty list included: the file persists on a reused
   // sandbox, so an unconditional write is what lets the callback prune stubs
   // for skills that have since been uninstalled.
@@ -266,6 +249,12 @@ export async function launchScript(
       envParts.push(`${key}=${quote([val])}`);
     }
   }
+  // Reserved Eva values are appended after repo/user env so they cannot be
+  // shadowed. The callback consumes and removes them before agent tools spawn.
+  if (opts.mcpBaseUrl && opts.mcpToken) {
+    envParts.push(`EVA_MCP_AUTH=${quote([opts.mcpToken])}`);
+    envParts.push(`EVA_MCP_BASE_URL=${quote([opts.mcpBaseUrl])}`);
+  }
   envParts.push(`CALLBACK_SCRIPT_FP=${quote([CALLBACK_SCRIPT_FINGERPRINT])}`);
   const exportLines = envParts.map((part) => `export ${part}`);
   // Kernel-enforced single-runner-per-entity: spawn under an exclusive flock
@@ -281,8 +270,11 @@ export async function launchScript(
     "#!/usr/bin/env bash",
     "set -euo pipefail",
     `[ -f ${EVA_ENV_FILE} ] && . ${EVA_ENV_FILE}`,
-    "rm -f /tmp/run-design.pid /tmp/run-design.ready",
+    "rm -f /tmp/run-design.pid /tmp/run-design.ready /tmp/eva-mcp.json",
     ...exportLines,
+    // The script carries per-launch credentials, so unlink it once this shell
+    // has loaded the exports and before the long-lived callback is spawned.
+    'rm -f "$0"',
     "if command -v flock >/dev/null 2>&1; then",
     `  nohup flock -n -E 217 ${runnerLockPath} node /tmp/run-design.mjs >> /tmp/design.log 2>&1 &`,
     "else",

--- a/packages/backend/convex/_sessions/daemonState.ts
+++ b/packages/backend/convex/_sessions/daemonState.ts
@@ -1,0 +1,53 @@
+import type { Doc } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+export type SessionDaemonPatch = Pick<
+  Doc<"sessions">,
+  | "pendingTurn"
+  | "pendingTaskStops"
+  | "cancelRequestedAt"
+  | "sandboxSetupPending"
+>;
+
+/** Mirrors daemon-only session fields into the small row polled by warm agents. */
+export async function syncSessionDaemonState(
+  ctx: MutationCtx,
+  session: Doc<"sessions">,
+  patch: Partial<SessionDaemonPatch>,
+): Promise<void> {
+  const state = await ctx.db
+    .query("sessionDaemonStates")
+    .withIndex("by_session", (q) => q.eq("sessionId", session._id))
+    .unique();
+
+  if (state) {
+    await ctx.db.patch(state._id, patch);
+    return;
+  }
+
+  await ctx.db.insert("sessionDaemonStates", {
+    sessionId: session._id,
+    repoId: session.repoId,
+    userId: session.userId,
+    pendingTurn: Object.hasOwn(patch, "pendingTurn")
+      ? patch.pendingTurn
+      : session.pendingTurn,
+    pendingTaskStops: Object.hasOwn(patch, "pendingTaskStops")
+      ? patch.pendingTaskStops
+      : session.pendingTaskStops,
+    cancelRequestedAt: Object.hasOwn(patch, "cancelRequestedAt")
+      ? patch.cancelRequestedAt
+      : session.cancelRequestedAt,
+    sandboxSetupPending: Object.hasOwn(patch, "sandboxSetupPending")
+      ? patch.sandboxSetupPending
+      : session.sandboxSetupPending,
+  });
+}
+
+/** Creates the small daemon row lazily for sessions predating this split. */
+export async function ensureSessionDaemonState(
+  ctx: MutationCtx,
+  session: Doc<"sessions">,
+): Promise<void> {
+  await syncSessionDaemonState(ctx, session, {});
+}

--- a/packages/backend/convex/_sessions/execution.ts
+++ b/packages/backend/convex/_sessions/execution.ts
@@ -13,6 +13,7 @@ import {
 import { trackSessionWorkflow } from "../workflowWatchdog";
 import { clearStreamingActivity } from "../_taskWorkflow/helpers";
 import { finalizeCancelledAssistantMessage } from "../streaming";
+import { syncSessionDaemonState } from "./daemonState";
 import { startNextQueuedSessionMessage } from "../_queues/helpers";
 import { buildSessionPrompt, MODE_TOOLS, resolveToolMode } from "./workflow";
 import {
@@ -145,17 +146,16 @@ export const startExecute = authMutation({
     // leftover Claude daemon mismatch-spam while launchOnExistingSandbox runs.
     const normalizedModel = normalizeAIModel(args.model);
     const usesDaemonPull = getAIModelProvider(normalizedModel) === "claude";
+    const pendingTurn = usesDaemonPull
+      ? {
+          prompt,
+          requestedAt: Date.now(),
+          attachmentStorageIds: args.attachmentStorageIds,
+          model: normalizedModel,
+        }
+      : undefined;
     await ctx.db.patch(args.sessionId, {
-      ...(usesDaemonPull
-        ? {
-            pendingTurn: {
-              prompt,
-              requestedAt: Date.now(),
-              attachmentStorageIds: args.attachmentStorageIds,
-              model: normalizedModel,
-            },
-          }
-        : { pendingTurn: undefined }),
+      pendingTurn,
       // Deliberately no cancelRequestedAt clear here: staging must never wipe
       // an undrained cancel for a still-running turn (the daemon drains the
       // flag via claimPendingTurn, and ignores it when no turn is active, so a
@@ -176,6 +176,7 @@ export const startExecute = authMutation({
       ...(args.fastMode !== undefined ? { lastFastMode: args.fastMode } : {}),
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, { pendingTurn });
 
     // Ensure a Claude daemon exists to claim the staged prompt. Skip for
     // one-shot providers (prewarmSessionDaemon already no-ops, but scheduling
@@ -375,7 +376,9 @@ export const cancelExecution = authMutation({
     await cancelTrackedWorkflow(ctx, workflowIdToCancel);
 
     if (getAIModelProvider(normalizeAIModel(session.lastModel)) === "claude") {
-      await ctx.db.patch(args.sessionId, { cancelRequestedAt: Date.now() });
+      const cancelRequestedAt = Date.now();
+      await ctx.db.patch(args.sessionId, { cancelRequestedAt });
+      await syncSessionDaemonState(ctx, session, { cancelRequestedAt });
     } else if (session.sandboxId) {
       await ctx.scheduler.runAfter(0, internal.sandbox.killSandboxProcess, {
         sandboxId: session.sandboxId,
@@ -435,10 +438,10 @@ export const cancelExecution = authMutation({
     ) {
       sessionPatch.activeWorkflowId = undefined;
     }
-    if (
+    const clearsPendingTurn =
       pendingRequestedAt !== undefined &&
-      latest.pendingTurn?.requestedAt === pendingRequestedAt
-    ) {
+      latest.pendingTurn?.requestedAt === pendingRequestedAt;
+    if (clearsPendingTurn) {
       sessionPatch.pendingTurn = undefined;
     }
     if (!newerTurnStaged && !newerWorkflowTracked) {
@@ -446,6 +449,9 @@ export const cancelExecution = authMutation({
     }
 
     await ctx.db.patch(args.sessionId, sessionPatch);
+    if (clearsPendingTurn) {
+      await syncSessionDaemonState(ctx, latest, { pendingTurn: undefined });
+    }
 
     await startNextQueuedSessionMessage(ctx, args.sessionId);
 

--- a/packages/backend/convex/_sessions/queries.ts
+++ b/packages/backend/convex/_sessions/queries.ts
@@ -101,13 +101,20 @@ export const list = authQuery({
   returns: v.array(sessionListItemValidator),
   handler: async (ctx, args) => {
     if (!(await hasRepoAccess(ctx.db, args.repoId, ctx.userId))) return [];
-    const sessions = filterActiveEntities(
-      await ctx.db
-        .query("sessions")
-        .withIndex("by_repo", (q) => q.eq("repoId", args.repoId))
-        .filter((q) => q.neq(q.field("archived"), true))
-        .collect(),
+    const sessionGroups = await Promise.all(
+      [undefined, false].map((archived) =>
+        ctx.db
+          .query("sessions")
+          .withIndex("by_repo_archived_and_deleted", (q) =>
+            q
+              .eq("repoId", args.repoId)
+              .eq("archived", archived)
+              .eq("deletedAt", undefined),
+          )
+          .collect(),
+      ),
     );
+    const sessions = sessionGroups.flat();
     return sessions.sort(byMostRecentlyUpdated).map(toSessionListItem);
   },
 });
@@ -118,14 +125,15 @@ export const listArchived = authQuery({
   returns: v.array(sessionListItemValidator),
   handler: async (ctx, args) => {
     if (!(await hasRepoAccess(ctx.db, args.repoId, ctx.userId))) return [];
-    const sessions = filterActiveEntities(
-      await ctx.db
-        .query("sessions")
-        .withIndex("by_repo_and_archived", (q) =>
-          q.eq("repoId", args.repoId).eq("archived", true),
-        )
-        .collect(),
-    );
+    const sessions = await ctx.db
+      .query("sessions")
+      .withIndex("by_repo_archived_and_deleted", (q) =>
+        q
+          .eq("repoId", args.repoId)
+          .eq("archived", true)
+          .eq("deletedAt", undefined),
+      )
+      .collect();
     return sessions.sort(byMostRecentlyUpdated).map(toSessionListItem);
   },
 });

--- a/packages/backend/convex/_sessions/sandbox.ts
+++ b/packages/backend/convex/_sessions/sandbox.ts
@@ -18,6 +18,7 @@ import { clearStreamingActivity } from "../_taskWorkflow/helpers";
 import { finalizeCancelledAssistantMessage } from "../streaming";
 import { clearPendingQuestionsForEntity } from "../pendingQuestions";
 import { startNextQueuedSessionMessage } from "../_queues/helpers";
+import { syncSessionDaemonState } from "./daemonState";
 
 /** How long to wait before re-issuing stop if finalize died with a Convex transient error. */
 const STUCK_STOPPING_RECOVER_MS = 20_000;
@@ -414,6 +415,11 @@ export const sandboxReady = internalMutation({
       ...(args.devCommand !== undefined ? { devCommand: args.devCommand } : {}),
       ...(args.markSetupPending ? { sandboxSetupPending: true } : {}),
     });
+    if (args.markSetupPending) {
+      await syncSessionDaemonState(ctx, session, {
+        sandboxSetupPending: true,
+      });
+    }
     // Drain first-message (and any other) queued turns now that chat can run.
     // Early + final ready both call this; second no-ops while activeWorkflowId is set.
     await startNextQueuedSessionMessage(ctx, args.sessionId);
@@ -434,6 +440,9 @@ export const clearSandboxSetupPending = internalMutation({
     const session = await ctx.db.get(args.sessionId);
     if (!session || session.sandboxSetupPending !== true) return null;
     await ctx.db.patch(args.sessionId, { sandboxSetupPending: undefined });
+    await syncSessionDaemonState(ctx, session, {
+      sandboxSetupPending: undefined,
+    });
     return null;
   },
 });

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -36,6 +36,10 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { finalizeCancelledAssistantMessage } from "../streaming";
 import { backgroundAgentEntryValidator } from "../_validators/tableFields";
 import { mergeBackgroundAgents } from "./backgroundAgents";
+import {
+  ensureSessionDaemonState,
+  syncSessionDaemonState,
+} from "./daemonState";
 
 // --- Completion event ---
 
@@ -558,7 +562,6 @@ export const sessionExecuteWorkflow = workflow.define({
         }
       }
     }
-
   },
 });
 
@@ -659,6 +662,9 @@ export const clearStuckWorkingState = internalMutation({
       syntheticTurnMessageId: undefined,
       updatedAt: Date.now(),
     });
+    if (session) {
+      await syncSessionDaemonState(ctx, session, { pendingTurn: undefined });
+    }
     return { deletedPlaceholders, clearedStreaming: true };
   },
 });
@@ -965,12 +971,24 @@ export const claimPendingTurn = authMutation({
       stopTaskToolUseIds: string[];
       cancelRequested: boolean;
     };
-    const session = await ctx.db.get(args.sessionId);
-    if (!session) return emptyClaim;
-    // Daemon polls this ~20×/s; skip the repo+membership join when the token
-    // is already the session owner (the normal sandbox CONVEX_TOKEN case).
-    if (session.userId !== ctx.userId) {
-      if (!(await hasRepoAccess(ctx.db, session.repoId, ctx.userId)))
+    let daemonState = await ctx.db
+      .query("sessionDaemonStates")
+      .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
+      .unique();
+    if (!daemonState) {
+      const session = await ctx.db.get(args.sessionId);
+      if (!session) return emptyClaim;
+      await ensureSessionDaemonState(ctx, session);
+      daemonState = await ctx.db
+        .query("sessionDaemonStates")
+        .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
+        .unique();
+      if (!daemonState) return emptyClaim;
+    }
+    // The normal owner path now reads only this small row, not the session's
+    // plan, terminal history, panes, and other UI state on every 50ms poll.
+    if (daemonState.userId !== ctx.userId) {
+      if (!(await hasRepoAccess(ctx.db, daemonState.repoId, ctx.userId)))
         throw new Error("Not authorized");
     }
 
@@ -979,28 +997,30 @@ export const claimPendingTurn = authMutation({
     // cleared when setup finishes). Returning an empty claim leaves pendingTurn
     // intact; the daemon keeps polling (45m idle budget) and claims the moment
     // the gate clears, so the agent never executes against a stale checkout.
-    if (session.sandboxSetupPending === true) {
+    if (daemonState.sandboxSetupPending === true) {
       return emptyClaim;
     }
 
-    const stopTaskToolUseIds = session.pendingTaskStops ?? [];
+    const stopTaskToolUseIds = daemonState.pendingTaskStops ?? [];
     if (stopTaskToolUseIds.length > 0) {
+      await ctx.db.patch(daemonState._id, { pendingTaskStops: undefined });
       await ctx.db.patch(args.sessionId, { pendingTaskStops: undefined });
     }
 
     // Cancel must drain the same way as stopTaskToolUseIds above: the daemon
     // polls this mutation continuously, including mid-turn, specifically to
     // notice an interrupt — gating the drain on pendingTurn would strand it.
-    const cancelRequested = session.cancelRequestedAt !== undefined;
+    const cancelRequested = daemonState.cancelRequestedAt !== undefined;
     if (cancelRequested) {
+      await ctx.db.patch(daemonState._id, { cancelRequestedAt: undefined });
       await ctx.db.patch(args.sessionId, { cancelRequestedAt: undefined });
     }
 
-    if (!session.pendingTurn) {
+    if (!daemonState.pendingTurn) {
       return { ...emptyClaim, stopTaskToolUseIds, cancelRequested };
     }
 
-    const pendingModel = session.pendingTurn.model;
+    const pendingModel = daemonState.pendingTurn.model;
     if (pendingModel !== undefined) {
       const claimModel = normalizeAIModel(args.model);
       if (normalizeAIModel(pendingModel) !== claimModel) {
@@ -1011,16 +1031,17 @@ export const claimPendingTurn = authMutation({
       }
     }
 
-    const prompt = session.pendingTurn.prompt;
-    const claimWaitMs = Date.now() - session.pendingTurn.requestedAt;
+    const prompt = daemonState.pendingTurn.prompt;
+    const claimWaitMs = Date.now() - daemonState.pendingTurn.requestedAt;
     const resolvedUrls = await Promise.all(
-      (session.pendingTurn.attachmentStorageIds ?? []).map((id) =>
+      (daemonState.pendingTurn.attachmentStorageIds ?? []).map((id) =>
         ctx.storage.getUrl(id),
       ),
     );
     const attachmentUrls = resolvedUrls.filter(
       (url): url is string => url !== null,
     );
+    await ctx.db.patch(daemonState._id, { pendingTurn: undefined });
     await ctx.db.patch(args.sessionId, { pendingTurn: undefined });
     console.log(
       `[sessionWorkflow] claimPendingTurn sessionId=${args.sessionId} claimWaitMs=${claimWaitMs} attachments=${attachmentUrls.length}`,
@@ -1074,6 +1095,9 @@ export const requestStopBackgroundAgent = authMutation({
       pendingTaskStops: [...pending, args.toolUseId],
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, {
+      pendingTaskStops: [...pending, args.toolUseId],
+    });
     return null;
   },
 });
@@ -1117,17 +1141,19 @@ export const ensurePendingTurn = internalMutation({
       return null;
     }
 
+    const pendingTurn = {
+      prompt: args.prompt,
+      requestedAt: Date.now(),
+      attachmentStorageIds: args.attachmentStorageIds,
+      ...(args.model !== undefined
+        ? { model: normalizeAIModel(args.model) }
+        : {}),
+    };
     await ctx.db.patch(args.sessionId, {
-      pendingTurn: {
-        prompt: args.prompt,
-        requestedAt: Date.now(),
-        attachmentStorageIds: args.attachmentStorageIds,
-        ...(args.model !== undefined
-          ? { model: normalizeAIModel(args.model) }
-          : {}),
-      },
+      pendingTurn,
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, { pendingTurn });
     console.log(
       `[sessionWorkflow] ensurePendingTurn restaged sessionId=${args.sessionId}`,
     );
@@ -1213,17 +1239,17 @@ export const restageOpenTurn = internalMutation({
       personaId: lastUser.personaId,
     });
 
+    const pendingTurn = {
+      prompt,
+      requestedAt: Date.now(),
+      attachmentStorageIds: lastUser.attachmentStorageIds,
+      ...(session.lastModel !== undefined ? { model: session.lastModel } : {}),
+    };
     await ctx.db.patch(args.sessionId, {
-      pendingTurn: {
-        prompt,
-        requestedAt: Date.now(),
-        attachmentStorageIds: lastUser.attachmentStorageIds,
-        ...(session.lastModel !== undefined
-          ? { model: session.lastModel }
-          : {}),
-      },
+      pendingTurn,
       updatedAt: Date.now(),
     });
+    await syncSessionDaemonState(ctx, session, { pendingTurn });
     console.log(
       `[sessionWorkflow] restageOpenTurn sessionId=${args.sessionId}`,
     );
@@ -1400,6 +1426,7 @@ export const handleCompletion = authMutation({
     // clear any leftover staged prompt here. Claude already cleared on claim.
     if (session.pendingTurn !== undefined) {
       await ctx.db.patch(args.sessionId, { pendingTurn: undefined });
+      await syncSessionDaemonState(ctx, session, { pendingTurn: undefined });
     }
 
     await sendCompletionEvent(

--- a/packages/backend/convex/_taskWorkflow/scheduling.ts
+++ b/packages/backend/convex/_taskWorkflow/scheduling.ts
@@ -8,6 +8,7 @@ import { buildProjectBranchName } from "../_projects/helpers";
 import { resolveTaskWorkflowBaseBranchForTask } from "./resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "../_userProviderAccounts/credentialSource";
 import { normalizeAIModel } from "../validators";
+import { setTaskLastRunStartedAt } from "../_agentTasks/runSummary";
 
 /** Schedules an automatic retry for a failed quick task if the failure looks transient. */
 export const maybeScheduleQuickTaskRetry = internalMutation({
@@ -148,6 +149,7 @@ export const executeScheduledTask = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, now);
 
     await ctx.db.patch(args.taskId, {
       ...clearSchedule,

--- a/packages/backend/convex/_validators/tableFields.ts
+++ b/packages/backend/convex/_validators/tableFields.ts
@@ -173,6 +173,17 @@ export const pendingTurnFields = {
 
 export const pendingTurnValidator = v.optional(v.object(pendingTurnFields));
 
+/** Small daemon-poll row kept separate from heavyweight session documents. */
+export const sessionDaemonStateFields = {
+  sessionId: v.id("sessions"),
+  repoId: v.id("githubRepos"),
+  userId: v.id("users"),
+  pendingTurn: pendingTurnValidator,
+  pendingTaskStops: v.optional(v.array(v.string())),
+  cancelRequestedAt: v.optional(v.number()),
+  sandboxSetupPending: v.optional(v.boolean()),
+};
+
 export const chatDaemonEntityFields = {
   pendingTurn: pendingTurnValidator,
   syntheticTurnMessageId: v.optional(v.id("messages")),
@@ -394,6 +405,12 @@ export const repoSkillFields = {
   unavailableSince: v.optional(v.number()),
   prompt: v.optional(v.string()),
   createdAt: v.number(),
+};
+
+/** Large SKILL.md body split from repoSkills so list queries read metadata only. */
+export const repoSkillContentFields = {
+  skillId: v.id("repoSkills"),
+  content: v.string(),
 };
 
 /**

--- a/packages/backend/convex/buildWorkflow.ts
+++ b/packages/backend/convex/buildWorkflow.ts
@@ -13,6 +13,7 @@ import { buildProjectBranchName } from "./_projects/helpers";
 import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
 import { resolveCredentialSourceLabel } from "./_userProviderAccounts/credentialSource";
 import { normalizeAIModel } from "./validators";
+import { setTaskLastRunStartedAt } from "./_agentTasks/runSummary";
 
 // --- Workflow ---
 
@@ -145,11 +146,12 @@ export const startTaskForBuild = internalMutation({
     // Create the run. When this build picks up a task a reviewer sent back via
     // "Make changes", link the parked change-request comment so the timeline
     // labels this run "made changes" rather than a bare "success".
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.taskId,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       triggeringCommentId: task.pendingChangeRequestCommentId,
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
@@ -158,6 +160,7 @@ export const startTaskForBuild = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, startedAt);
 
     await ctx.db.patch(args.taskId, {
       status: "in_progress",

--- a/packages/backend/convex/dataMigrations.ts
+++ b/packages/backend/convex/dataMigrations.ts
@@ -43,3 +43,50 @@ export const dataMigrations = new Migrations<DataModel, typeof schema>(
 
 /** Generic runner: `npx convex run dataMigrations:run '{fn:"dataMigrations:…"}'`. */
 export const run = dataMigrations.runner();
+
+/** Backfills compact task latest-run rows so list queries stop reading run logs. */
+export const backfillAgentTaskRunSummaries = dataMigrations.define({
+  table: "agentTasks",
+  migrateOne: async (ctx, task) => {
+    if (!task.repoId) return;
+    const existing = await ctx.db
+      .query("agentTaskRunSummaries")
+      .withIndex("by_task", (q) => q.eq("taskId", task._id))
+      .unique();
+    if (existing) return;
+
+    const latestRun = await ctx.db
+      .query("agentRuns")
+      .withIndex("by_task", (q) => q.eq("taskId", task._id))
+      .order("desc")
+      .first();
+    await ctx.db.insert("agentTaskRunSummaries", {
+      taskId: task._id,
+      repoId: task.repoId,
+      lastRunStartedAt: latestRun?.startedAt,
+    });
+  },
+});
+
+/** Moves large SKILL.md bodies out of rows read by repoSkills.listByRepo. */
+export const splitRepoSkillContent = dataMigrations.define({
+  table: "repoSkills",
+  migrateOne: async (ctx, skill) => {
+    if (!skill.content) return;
+    const existing = await ctx.db
+      .query("repoSkillContents")
+      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+      .unique();
+    if (existing) {
+      if (existing.content !== skill.content) {
+        await ctx.db.patch(existing._id, { content: skill.content });
+      }
+    } else {
+      await ctx.db.insert("repoSkillContents", {
+        skillId: skill._id,
+        content: skill.content,
+      });
+    }
+    await ctx.db.patch(skill._id, { content: undefined });
+  },
+});

--- a/packages/backend/convex/evaluationReports.ts
+++ b/packages/backend/convex/evaluationReports.ts
@@ -10,6 +10,10 @@ import { workflow } from "./workflowManager";
 import { FALLBACK_GIT_BASE_BRANCH } from "@eva/shared";
 import { resolveTaskWorkflowBaseBranchForTask } from "./_taskWorkflow/resolveBaseBranch";
 import { resolveCredentialSourceLabel } from "./_userProviderAccounts/credentialSource";
+import {
+  createTaskRunSummary,
+  setTaskLastRunStartedAt,
+} from "./_agentTasks/runSummary";
 
 const reportValidator = v.object({
   _id: v.id("evaluationReports"),
@@ -83,6 +87,7 @@ export const createTasksFromIssues = authMutation({
         model: repo.defaultModel,
         numId: await allocateNumId(ctx.db, report.repoId, "agentTasks"),
       });
+      await createTaskRunSummary(ctx, taskId, report.repoId);
       await ensureSubscribed(ctx, taskId, ctx.userId);
 
       updatedIssues[i] = { ...issue, taskId };
@@ -130,11 +135,12 @@ export const autoStartTask = internalMutation({
       return null;
     }
 
+    const startedAt = Date.now();
     const runId = await ctx.db.insert("agentRuns", {
       taskId: args.taskId,
       status: "queued",
       logs: [],
-      startedAt: Date.now(),
+      startedAt,
       credentialSourceLabel: await resolveCredentialSourceLabel(
         ctx.db,
         task.providerAccountId,
@@ -142,6 +148,7 @@ export const autoStartTask = internalMutation({
       ),
       model: normalizeAIModel(task.model),
     });
+    await setTaskLastRunStartedAt(ctx, args.taskId, task.repoId, startedAt);
 
     await ctx.db.patch(args.taskId, {
       status: "in_progress",

--- a/packages/backend/convex/functions.ts
+++ b/packages/backend/convex/functions.ts
@@ -406,6 +406,13 @@ export async function deleteTaskRelatedData(
   for (const event of activityEvents) {
     await ctx.db.delete(event._id);
   }
+  const runSummary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (runSummary) {
+    await ctx.db.delete(runSummary._id);
+  }
   await ctx.db.delete(taskId);
 }
 
@@ -430,6 +437,13 @@ export async function softDeleteAgentTask(
       sandboxId: task.sandboxId,
       repoId: task.repoId,
     });
+  }
+  const runSummary = await ctx.db
+    .query("agentTaskRunSummaries")
+    .withIndex("by_task", (q) => q.eq("taskId", taskId))
+    .unique();
+  if (runSummary) {
+    await ctx.db.delete(runSummary._id);
   }
   await ctx.db.patch(taskId, { deletedAt: Date.now() });
 }

--- a/packages/backend/convex/repoSkills.ts
+++ b/packages/backend/convex/repoSkills.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { internalMutation, internalQuery } from "./_generated/server";
 import { authQuery, hasRepoAccess } from "./functions";
 import { resolveCanonicalRepoId } from "./_githubRepos/helpers";
+import { upsertRepoSkillContent } from "./_repoSkills/content";
 
 export { syncFromGithub } from "./_repoSkills/sync";
 
@@ -79,12 +80,17 @@ export const getContentById = authQuery({
     if (!(await hasRepoAccess(ctx.db, skill.repoId, ctx.userId))) {
       return null;
     }
-    if (!skill.content) return null;
+    const splitContent = await ctx.db
+      .query("repoSkillContents")
+      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+      .unique();
+    const content = splitContent?.content ?? skill.content;
+    if (!content) return null;
 
     return {
       title: skill.title,
       sourcePath: skill.sourcePath,
-      content: skill.content,
+      content,
     };
   },
 });
@@ -211,10 +217,11 @@ export const applyGithubSync = internalMutation({
       syncedPaths.add(skill.sourcePath);
       const existingSkill = existingBySourcePath.get(skill.sourcePath);
       if (existingSkill) {
+        await upsertRepoSkillContent(ctx, existingSkill._id, skill.content);
         await ctx.db.patch(existingSkill._id, {
           title: skill.title,
           description: skill.description,
-          content: skill.content,
+          content: undefined,
           sourceSha: skill.sourceSha,
           available: true,
           lastSyncedAt: args.syncedAt,
@@ -222,17 +229,17 @@ export const applyGithubSync = internalMutation({
           prompt: undefined,
         });
       } else {
-        await ctx.db.insert("repoSkills", {
+        const skillId = await ctx.db.insert("repoSkills", {
           repoId: args.repoId,
           title: skill.title,
           description: skill.description,
-          content: skill.content,
           sourcePath: skill.sourcePath,
           sourceSha: skill.sourceSha,
           available: true,
           lastSyncedAt: args.syncedAt,
           createdAt: args.syncedAt,
         });
+        await upsertRepoSkillContent(ctx, skillId, skill.content);
       }
     }
 

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -24,6 +24,7 @@ import {
   taskReactionFields,
   taskSubscriberFields,
   repoSkillFields,
+  repoSkillContentFields,
   repoSystemSkillFields,
   sandboxGitCredentialsFields,
   appSettingsFields,
@@ -44,6 +45,7 @@ import {
   appTabFields,
   backgroundProcessFields,
   snapshotBuildFields,
+  sessionDaemonStateFields,
 } from "./validators";
 
 const schema = defineSchema({
@@ -57,6 +59,7 @@ const schema = defineSchema({
 
   projects: defineTable(projectFields)
     .index("by_repo", ["repoId"])
+    .index("by_repo_and_deleted", ["repoId", "deletedAt"])
     .index("by_user", ["userId"])
     .index("by_repo_and_phase", ["repoId", "phase"])
     .index("by_pr_url", ["prUrl"])
@@ -74,6 +77,7 @@ const schema = defineSchema({
   agentTasks: defineTable(agentTaskFields)
     .index("by_repo", ["repoId"])
     .index("by_repo_and_status", ["repoId", "status"])
+    .index("by_repo_status_and_deleted", ["repoId", "status", "deletedAt"])
     .index("by_repo_and_updatedAt", ["repoId", "updatedAt"])
     .index("by_project", ["projectId"])
     .index("by_project_and_status", ["projectId", "status"])
@@ -86,6 +90,14 @@ const schema = defineSchema({
     .index("by_task_and_status", ["taskId", "status"])
     .index("by_status", ["status"])
     .index("by_pr_url", ["prUrl"]),
+
+  agentTaskRunSummaries: defineTable({
+    taskId: v.id("agentTasks"),
+    repoId: v.id("githubRepos"),
+    lastRunStartedAt: v.optional(v.number()),
+  })
+    .index("by_task", ["taskId"])
+    .index("by_repo", ["repoId"]),
 
   agentRunActivityLogs: defineTable({
     runId: v.id("agentRuns"),
@@ -135,12 +147,18 @@ const schema = defineSchema({
     .index("by_parent_and_order", ["parentId", "order"]),
   sessions: defineTable(sessionFields)
     .index("by_repo", ["repoId"])
+    .index("by_repo_and_deleted", ["repoId", "deletedAt"])
     .index("by_user", ["userId"])
     .index("by_repo_and_status", ["repoId", "status"])
     .index("by_repo_and_archived", ["repoId", "archived"])
+    .index("by_repo_archived_and_deleted", ["repoId", "archived", "deletedAt"])
     .index("by_pr_url", ["prUrl"])
     .index("by_repo_and_numId", ["repoId", "numId"])
     .index("by_sandbox", ["sandboxId"]),
+  sessionDaemonStates: defineTable(sessionDaemonStateFields).index(
+    "by_session",
+    ["sessionId"],
+  ),
   backgroundProcesses: defineTable(backgroundProcessFields)
     .index("by_session_and_status", ["sessionId", "status"])
     .index("by_session_and_key", ["sessionId", "key"]),
@@ -184,6 +202,7 @@ const schema = defineSchema({
     .index("by_entity_tool", ["entityId", "toolUseId"]),
   docs: defineTable(docFields)
     .index("by_repo", ["repoId"])
+    .index("by_repo_and_deleted", ["repoId", "deletedAt"])
     .index("by_session", ["sessionId"])
     .index("by_repo_and_pr_url", ["repoId", "prUrl"])
     .index("by_repo_and_numId", ["repoId", "numId"]),
@@ -219,6 +238,9 @@ const schema = defineSchema({
   repoSkills: defineTable(repoSkillFields)
     .index("by_repo", ["repoId"])
     .index("by_repo_and_source_path", ["repoId", "sourcePath"]),
+  repoSkillContents: defineTable(repoSkillContentFields).index("by_skill", [
+    "skillId",
+  ]),
   repoSystemSkills: defineTable(repoSystemSkillFields)
     .index("by_repo", ["repoId"])
     .index("by_repo_and_name", ["repoId", "name"]),

--- a/packages/backend/convex/snapshotActions.ts
+++ b/packages/backend/convex/snapshotActions.ts
@@ -322,7 +322,7 @@ export const launchSeedRun = internalAction({
       "sudo mkdir -p /opt/git/etc",
       'sudo /usr/local/bin/git-lfs install --system || { echo "SEEDRUN-FAILED:git-lfs-filters"; exit 1; }',
       'sudo env GIT_CONFIG_SYSTEM=/etc/gitconfig /usr/local/bin/git-lfs install --system || { echo "SEEDRUN-FAILED:git-lfs-filters"; exit 1; }',
-      'command -v claude >/dev/null 2>&1 && command -v codex >/dev/null 2>&1 && command -v opencode >/dev/null 2>&1 && [ -d "$(npm root -g)/@cursor/sdk" ] || sudo npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai agent-browser convex agentation-mcp@1.2.0 @cursor/sdk@1.0.26 || { echo "SEEDRUN-FAILED:agent-clis"; exit 1; }',
+      'command -v claude >/dev/null 2>&1 && command -v codex >/dev/null 2>&1 && command -v opencode >/dev/null 2>&1 && [ -d "$(npm root -g)/@anthropic-ai/claude-agent-sdk" ] && [ -d "$(npm root -g)/@cursor/sdk" ] || sudo npm install -g @anthropic-ai/claude-code @anthropic-ai/claude-agent-sdk@0.3.201 @openai/codex opencode-ai agent-browser convex agentation-mcp@1.2.0 @cursor/sdk@1.0.26 || { echo "SEEDRUN-FAILED:agent-clis"; exit 1; }',
       'command -v code-server >/dev/null 2>&1 || curl -fsSL https://code-server.dev/install.sh | sh || { echo "SEEDRUN-FAILED:code-server"; exit 1; }',
       'command -v websockify >/dev/null 2>&1 || python3 -m pip install --user --break-system-packages websockify >/tmp/websockify-pip.log 2>&1 || python3 -m pip install --user websockify >/tmp/websockify-pip.log 2>&1 || { echo "SEEDRUN-FAILED:websockify"; exit 1; }',
       "sudo ln -sf $(python3 -m site --user-base)/bin/websockify /usr/local/bin/websockify 2>/dev/null || true",

--- a/packages/backend/docs/ARCHITECTURE.md
+++ b/packages/backend/docs/ARCHITECTURE.md
@@ -67,10 +67,11 @@ The callback owns seven core capabilities:
 
 ### 5. MCP-Config Injection
 
-- `/tmp/eva-mcp.json` written at launch (contains Convex-native HTTP MCP endpoint + auth token)
-- Passed to the Agent SDK via `extraArgs["mcp-config"]` as a `--mcp-config` CLI flag
-- Used because eva's MCP server is HTTP-based and requires authentication
-- **File:** `callback-src/index.ts:100`, `convex/_daytona/launch.ts:98`
+- The launcher exports `EVA_MCP_AUTH` and `EVA_MCP_BASE_URL` only to the callback process
+- The callback converts them into one typed in-memory HTTP server descriptor, then removes the variables before agent tools spawn
+- Claude and Cursor receive the same descriptor through their SDK `mcpServers` options; no MCP config file is written
+- The credential-bearing launch script unlinks itself before spawning the long-lived callback
+- **Files:** `callback-src/evaMcp.ts`, `callback-src/providers/claudeSdk.ts`, `callback-src/providers/cursorSdk.ts`, `convex/_sandbox_runtime/launch.ts`
 
 ### 6. Background-Task Disabling
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,7 @@
   "description": "",
   "dependencies": {
     "@ai-sdk/gateway": "^4.0.28",
+    "@anthropic-ai/claude-agent-sdk": "0.3.201",
     "@clerk/backend": "^2.33.3",
     "@convex-dev/action-cache": "^0.3.1",
     "@convex-dev/crons": "^0.2.0",
@@ -34,6 +35,7 @@
     "@convex-dev/presence": "^0.3.0",
     "@convex-dev/prosemirror-sync": "^0.2.1",
     "@convex-dev/workflow": "^0.3.4",
+    "@cursor/sdk": "1.0.26",
     "@eva/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@octokit/auth-app": "^8.1.2",

--- a/packages/backend/tests/convexHotPathIoContract.test.ts
+++ b/packages/backend/tests/convexHotPathIoContract.test.ts
@@ -1,0 +1,82 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const convexDir = join(dirname(fileURLToPath(import.meta.url)), "../convex");
+
+function source(path: string): string {
+  return readFileSync(join(convexDir, path), "utf8").replaceAll("\r\n", "\n");
+}
+
+function definitionBody(path: string, name: string): string {
+  const text = source(path);
+  const start = text.indexOf(`export const ${name} =`);
+  expect(start, `${path}:${name} moved or was renamed`).toBeGreaterThan(-1);
+  const end = text.indexOf("\n});", start);
+  return text.slice(start, end < 0 ? undefined : end);
+}
+
+describe("measured Convex I/O hot paths stay on compact reads", () => {
+  test("claimPendingTurn polls the compact daemon row", () => {
+    const body = definitionBody("_sessions/workflow.ts", "claimPendingTurn");
+    expect(body).toContain('.query("sessionDaemonStates")');
+    expect(body).toContain('withIndex("by_session"');
+    expect(body).toContain("daemonState.pendingTurn");
+    expect(body).not.toContain("session.pendingTurn");
+  });
+
+  test("every session daemon signal writer mirrors the compact row", () => {
+    for (const path of [
+      "_sessions/execution.ts",
+      "_sessions/sandbox.ts",
+      "_sessions/workflow.ts",
+      "_chat/surfaceAdapters.ts",
+    ]) {
+      expect(source(path), path).toContain("syncSessionDaemonState");
+    }
+  });
+
+  test("task lists use summaries and every run creator updates them", () => {
+    const list = definitionBody("_agentTasks/queries.ts", "getAllTasks");
+    expect(source("_agentTasks/queries.ts")).toContain(
+      '.query("agentTaskRunSummaries")',
+    );
+    expect(list).toContain('withIndex("by_repo_status_and_deleted"');
+
+    const runCreators = convexFiles().filter((path) =>
+      source(path).includes('insert("agentRuns"'),
+    );
+    expect(runCreators.length).toBeGreaterThan(0);
+    for (const path of runCreators) {
+      expect(source(path), path).toContain("setTaskLastRunStartedAt");
+    }
+  });
+
+  test("list filters are index ranges, not post-read filters", () => {
+    const sessions = definitionBody("_sessions/queries.ts", "list");
+    expect(sessions).toContain('withIndex("by_repo_archived_and_deleted"');
+    expect(sessions).not.toContain(".filter(");
+
+    const mentions = definitionBody("_mentions/listData.ts", "listData");
+    expect(mentions).toContain('withIndex("by_repo_and_deleted"');
+    expect(mentions).toContain('withIndex("by_repo_status_and_deleted"');
+    expect(mentions).not.toContain("filterActiveEntities");
+  });
+
+  test("skill list metadata no longer writes new SKILL.md bodies inline", () => {
+    const apply = definitionBody("repoSkills.ts", "applyGithubSync");
+    expect(apply).toContain("upsertRepoSkillContent");
+    expect(apply).toContain("content: undefined");
+    expect(source("repoSkills.ts")).toContain('.query("repoSkillContents")');
+    expect(source("dataMigrations.ts")).toContain("splitRepoSkillContent");
+  });
+});
+
+function convexFiles(): string[] {
+  return readdirSync(convexDir, { recursive: true })
+    .map((entry) => String(entry).replaceAll("\\", "/"))
+    .filter((path) => path.endsWith(".ts"))
+    .filter((path) => !path.includes("_generated"))
+    .filter((path) => !path.endsWith(".generated.ts"));
+}

--- a/packages/backend/tests/providerSdkDependenciesContract.test.ts
+++ b/packages/backend/tests/providerSdkDependenciesContract.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const testsDir = dirname(fileURLToPath(import.meta.url));
+
+const backendPackage = readFileSync(join(testsDir, "../package.json"), "utf8");
+const claudeLoader = readFileSync(
+  join(testsDir, "../callback-src/providers/claudeSdk.ts"),
+  "utf8",
+);
+const cursorLoader = readFileSync(
+  join(testsDir, "../callback-src/providers/cursorSdk.ts"),
+  "utf8",
+);
+const snapshotActions = readFileSync(
+  join(testsDir, "../convex/snapshotActions.ts"),
+  "utf8",
+);
+
+const sdkVersions = [
+  {
+    packageName: "@anthropic-ai/claude-agent-sdk",
+    version: "0.3.201",
+    loader: claudeLoader,
+  },
+  {
+    packageName: "@cursor/sdk",
+    version: "1.0.26",
+    loader: cursorLoader,
+  },
+];
+
+test("provider SDK dependencies match the callback loader versions", () => {
+  for (const sdk of sdkVersions) {
+    expect(backendPackage).toContain(
+      `"${sdk.packageName}": "${sdk.version}"`,
+    );
+    expect(sdk.loader).toContain(`const SDK_PACKAGE = "${sdk.packageName}"`);
+    expect(sdk.loader).toContain(`const SDK_VERSION = "${sdk.version}"`);
+  }
+});
+
+test("new snapshots preinstall both provider SDKs at the loader versions", () => {
+  for (const sdk of sdkVersions) {
+    expect(snapshotActions).toContain(
+      `[ -d "$(npm root -g)/${sdk.packageName}" ]`,
+    );
+    expect(snapshotActions).toContain(`${sdk.packageName}@${sdk.version}`);
+  }
+});
+
+test("older snapshots retain the user-local SDK fallback", () => {
+  for (const sdk of sdkVersions) {
+    expect(sdk.loader).toContain(
+      'const SDK_LOCAL_PREFIX = "/home/eva/.eva-agent-sdk"',
+    );
+    expect(sdk.loader).toContain("npm install --prefix");
+  }
+});

--- a/packages/backend/tests/providerSdkDependenciesContract.test.ts
+++ b/packages/backend/tests/providerSdkDependenciesContract.test.ts
@@ -42,6 +42,17 @@ test("provider SDK dependencies match the callback loader versions", () => {
   }
 });
 
+test("provider boundaries use official SDK declarations", () => {
+  expect(claudeLoader).toContain(
+    'from "@anthropic-ai/claude-agent-sdk"',
+  );
+  expect(claudeLoader).toContain(
+    'typeof import("@anthropic-ai/claude-agent-sdk")',
+  );
+  expect(cursorLoader).toContain('from "@cursor/sdk"');
+  expect(cursorLoader).toContain('typeof import("@cursor/sdk")');
+});
+
 test("new snapshots preinstall both provider SDKs at the loader versions", () => {
   for (const sdk of sdkVersions) {
     expect(snapshotActions).toContain(

--- a/packages/backend/tests/providerSdkDependenciesContract.test.ts
+++ b/packages/backend/tests/providerSdkDependenciesContract.test.ts
@@ -43,14 +43,12 @@ test("provider SDK dependencies match the callback loader versions", () => {
 });
 
 test("provider boundaries use official SDK declarations", () => {
-  expect(claudeLoader).toContain(
-    'from "@anthropic-ai/claude-agent-sdk"',
+  expect(claudeLoader).toMatch(
+    /import type \{[^}]*\} from "@anthropic-ai\/claude-agent-sdk"/,
   );
-  expect(claudeLoader).toContain(
-    'typeof import("@anthropic-ai/claude-agent-sdk")',
-  );
-  expect(cursorLoader).toContain('from "@cursor/sdk"');
-  expect(cursorLoader).toContain('typeof import("@cursor/sdk")');
+  expect(claudeLoader).toContain("SdkModule = { query: typeof query }");
+  expect(cursorLoader).toMatch(/import type \{[^}]*\} from "@cursor\/sdk"/);
+  expect(cursorLoader).toContain("Cursor: typeof Cursor");
 });
 
 test("new snapshots preinstall both provider SDKs at the loader versions", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       '@ai-sdk/gateway':
         specifier: ^4.0.28
         version: 4.0.30(zod@3.25.76)
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 0.3.201
+        version: 0.3.201(@anthropic-ai/sdk@0.115.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)
       '@clerk/backend':
         specifier: ^2.33.3
         version: 2.33.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5)
@@ -521,6 +524,9 @@ importers:
       '@convex-dev/workflow':
         specifier: ^0.3.4
         version: 0.3.10(@convex-dev/workpool@0.4.6(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(hono@4.12.25)(react@19.2.5)(typescript@7.0.1-rc)(zod@3.25.76))(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(hono@4.12.25)(react@19.2.5)(typescript@7.0.1-rc)(zod@3.25.76))(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))
+      '@cursor/sdk':
+        specifier: 1.0.26
+        version: 1.0.26
       '@eva/shared':
         specifier: workspace:*
         version: link:../shared
@@ -817,6 +823,67 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201':
+    resolution: {integrity: sha512-8Mcb3BDyKUGfJWFFTWwt+at37lbDH3ZwVtUNPWGG1toZ75RDCJry5U4kXRvQ2xokvJQlA0E+eNp6keWe5ZH22Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.201':
+    resolution: {integrity: sha512-TFR2bu0+ml3RHoMrtsgD0qDK5Oknw8kYGBV7qpQHn+IWmE96gnHhogG1LpJwpHtni08XkJIjfWk1DdlsUYtRkQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.201':
+    resolution: {integrity: sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.201':
+    resolution: {integrity: sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.201':
+    resolution: {integrity: sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.201':
+    resolution: {integrity: sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.201':
+    resolution: {integrity: sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.201':
+    resolution: {integrity: sha512-PhalN/0cWcqDfbx7iwoLNR2gurjTiqhBk1G6K+NRScxEcQjWuu5xKXCcdbX8ePVpT+nbEMmFEFpn2y+8V8hIdA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.201':
+    resolution: {integrity: sha512-InT1XLmf2QpldWdtznKDWEoGJT4p+sXh24yxbeBQ++lMJCzMrI0W27MEmmmDWx0otpa+ubdHCF5YQ6oiNt7cmg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.115.0':
+    resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1508,6 +1575,9 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bufbuild/protobuf@1.10.0':
+    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
   '@chevrotain/cst-dts-gen@12.0.0':
     resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
 
@@ -1571,6 +1641,24 @@ packages:
   '@coinbase/wallet-sdk@4.3.0':
     resolution: {integrity: sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw==}
 
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect-web@1.7.0':
+    resolution: {integrity: sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect@1.7.0':
+    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+
   '@convex-dev/action-cache@0.3.1':
     resolution: {integrity: sha512-HTN/GXyX4t89xxsMXeacMDtQi2jEzQrrlLTtTV1L87Odxz7N8EQHIuI9HOug0dIsz6Gd1VybYbjT1Buv8jarLw==}
     peerDependencies:
@@ -1633,6 +1721,40 @@ packages:
     peerDependencies:
       convex: ^1.31.7
       convex-helpers: 0.1.114
+
+  '@cursor/sdk-darwin-arm64@1.0.26':
+    resolution: {integrity: sha512-PPWtq/8ax4w3/5vh45lMbFpwnXsyvYMl3eR9uW4C2SXScgrtE2V2LfhEU66f1zAt9RKHi2BTTjkuZEnxKJEz+Q==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@cursor/sdk-darwin-x64@1.0.26':
+    resolution: {integrity: sha512-3WJGk1SV0tYTAQY2+PWSzNui6jGp9F7sLUm257EI3bhc7g6h6xCzrLY7wIpD03IEaNdM7emcgVySEN1D0QWsHg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@cursor/sdk-linux-arm64@1.0.26':
+    resolution: {integrity: sha512-DF+zZTn4mszX5q9J3rj9xk7rDu8/JEMfpdDA/UBp3CyaeLo1sPfB/vyoe4GUo1F3I1ZRAgUO8KdBizoHxfBEeQ==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@cursor/sdk-linux-x64@1.0.26':
+    resolution: {integrity: sha512-NnBvOzgGFXJpKygIdk6XzAcstBSdLjtKZyzLg2jLM0d7KkEDs3br94XsyNAvbVqnWhT18KPwHzrgP62ZEHEFxg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@cursor/sdk-win32-x64@1.0.26':
+    resolution: {integrity: sha512-C2PyFwmQNJH9qlqYF+Zhpdyh50500cNm2ortmrtzjqgGSFQ+t4WvzMKqSc/UadCT0oNGWFGyiyMnUpO3sLa0nA==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@cursor/sdk@1.0.26':
+    resolution: {integrity: sha512-dU3WpJwrxv8yoMjs0DxBgZr5btAJEO+NrvFutl08b6l2+jcuemfFWUlSPBQ2xZAH7zIZun+sqfHvjT5NxW8woQ==}
+    engines: {node: '>=22.13'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -3981,6 +4103,12 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@statsig/client-core@3.31.0':
+    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
+
+  '@statsig/js-client@3.31.0':
+    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
 
   '@streamdown/cjk@1.0.3':
     resolution: {integrity: sha512-WRg8HR/gHbBoTgsMd91OKFUClIoDcEFVofJvluvEAyjx3KpU0aGgD9tGDqHkHj14ShoMSkX0IYetWGegTcwIJw==}
@@ -6665,6 +6793,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -8475,6 +8607,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -9096,6 +9231,52 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.201':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.201(@anthropic-ai/sdk@0.115.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.115.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      zod: 3.25.76
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.201
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.201
+
+  '@anthropic-ai/sdk@0.115.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 3.25.76
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -9978,6 +10159,8 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bufbuild/protobuf@1.10.0': {}
+
   '@chevrotain/cst-dts-gen@12.0.0':
     dependencies:
       '@chevrotain/gast': 12.0.0
@@ -10137,6 +10320,21 @@ snapshots:
       eventemitter3: 5.0.4
       preact: 10.29.1
 
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      undici: 7.29.0
+
+  '@connectrpc/connect-web@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+
+  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
   '@convex-dev/action-cache@0.3.1(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))':
     dependencies:
       convex: 1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)
@@ -10192,6 +10390,36 @@ snapshots:
     dependencies:
       convex: 1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)
       convex-helpers: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.40.0(@clerk/clerk-react@5.61.6(react-dom@19.2.1(react@19.2.5))(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(hono@4.12.25)(react@19.2.5)(typescript@7.0.1-rc)(zod@3.25.76)
+
+  '@cursor/sdk-darwin-arm64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-darwin-x64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-linux-arm64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-linux-x64@1.0.26':
+    optional: true
+
+  '@cursor/sdk-win32-x64@1.0.26':
+    optional: true
+
+  '@cursor/sdk@1.0.26':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@connectrpc/connect-web': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@statsig/js-client': 3.31.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@cursor/sdk-darwin-arm64': 1.0.26
+      '@cursor/sdk-darwin-x64': 1.0.26
+      '@cursor/sdk-linux-arm64': 1.0.26
+      '@cursor/sdk-linux-x64': 1.0.26
+      '@cursor/sdk-win32-x64': 1.0.26
 
   '@date-fns/tz@1.4.1': {}
 
@@ -12315,6 +12543,12 @@ snapshots:
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@statsig/client-core@3.31.0': {}
+
+  '@statsig/js-client@3.31.0':
+    dependencies:
+      '@statsig/client-core': 3.31.0
 
   '@streamdown/cjk@1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.1)(unified@11.0.5)':
     dependencies:
@@ -15150,6 +15384,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -17460,6 +17699,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-dedent@2.2.0: {}
 


### PR DESCRIPTION
Combines four reviewed PRs into one integration branch (merge commits preserved):

- #578 — Axiom hosted Streamable HTTP MCP (auth via `AXIOM_MCP_PAT` / `AXIOM_ORG_ID` env)
- #577 — pin `@anthropic-ai/claude-agent-sdk@0.3.201` + `@cursor/sdk@1.0.26`, official SDK types
- #583 — MCP auth via `EVA_MCP_AUTH`/`EVA_MCP_BASE_URL` env, `/tmp/eva-mcp.json` removed
- #581 — `sessionDaemonStates` table, task latest-run summaries, `repoSkillContents` split, compound indexes (dual-write + fallback; backfills run post-deploy)

Conflict resolutions (reviewed graft points):
- `snapshotActions.ts`: SDK pin grafted onto main's split seed lines (opencode pin + code-server rpm retained)
- `claudeSdk.ts` / `cursorSdk.ts`: official SDK type aliases kept; `evaMcpServers` import from #583 kept
- `callbackScript.generated.ts` regenerated via `build:callback` (never hand-merged)

Post-merge fix: `typeof import(...)` module types rewritten as type-only named imports (new `consistent-type-imports` lint rule landed on main after these PRs branched); provider contract test updated to assert the new pattern.

Gates (all green): backend tsc, callback tsc, web tsc, backend vitest 702/702, web vitest 223/223, oxlint (0 new errors in diff), compiler-check (0 new bailouts in diff), banned-type scan, `git diff --check`.

Pre-existing main failures NOT addressed here (not in this diff): 15 files with `eva(no-value-block-in-try)` lint errors, 2 compiler-check bailouts (`FindingsList.tsx`, `IssuesList.tsx`).

Rollout after merge: `npx convex deploy` from `packages/backend`, then `dataMigrations:backfillAgentTaskRunSummaries` and `dataMigrations:splitRepoSkillContent` (dry-run first). Requires `AXIOM_MCP_PAT` + `AXIOM_ORG_ID` set in Eva repo env settings for the Axiom MCP to connect.
