### PR TITLE
feat: Add presentation slides deck at /slides

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -46,13 +46,6 @@
         rel="stylesheet"
       />
     </noscript>
-    <!-- Instrument Serif for slide deck titles -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap"
-      rel="stylesheet"
-    />
     <title>Eva - Your New Coworker</title>
     <script>
       (function () {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -46,6 +46,13 @@
         rel="stylesheet"
       />
     </noscript>
+    <!-- Instrument Serif for slide deck titles -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap"
+      rel="stylesheet"
+    />
     <title>Eva - Your New Coworker</title>
     <script>
       (function () {

--- a/apps/web/src/routes/_components/slides/PresenterView.tsx
+++ b/apps/web/src/routes/_components/slides/PresenterView.tsx
@@ -115,17 +115,17 @@ export function PresenterView({
   return (
     <PresentationDeckProvider value={deckContext}>
       <div className="flex h-screen flex-col bg-background text-foreground">
-        <header className="flex shrink-0 items-center gap-2 px-4 py-2.5">
-          <IconNotes size={18} className="shrink-0 text-muted" />
+        <header className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2.5">
+          <IconNotes size={18} className="shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">
-            <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted">
+            <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Presenter view
             </p>
-            <p className="truncate text-sm font-medium">
+            <p className="truncate text-sm font-medium text-foreground">
               {current}. {slideTitle}
             </p>
           </div>
-          <span className="shrink-0 font-mono text-xs tabular-nums text-muted">
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
             {current}/{TOTAL}
           </span>
         </header>
@@ -135,8 +135,8 @@ export function PresenterView({
             <SlideMiniPreview slideNumber={current} />
           </div>
 
-          <div className="flex w-1/2 min-w-0 flex-col bg-surface-secondary/40">
-            <p className="shrink-0 px-4 pb-2 pt-4 text-xs font-medium uppercase tracking-[0.14em] text-muted">
+          <div className="flex w-1/2 min-w-0 flex-col border-l border-border bg-muted/30">
+            <p className="shrink-0 px-4 pb-2 pt-4 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Script
             </p>
             <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
@@ -145,7 +145,7 @@ export function PresenterView({
                   {notes}
                 </p>
               ) : (
-                <p className="text-sm leading-relaxed text-muted">
+                <p className="text-sm leading-relaxed text-muted-foreground">
                   No script for this slide — edit{" "}
                   <span className="font-mono text-xs">speakerNotes.ts</span>.
                 </p>
@@ -154,7 +154,7 @@ export function PresenterView({
           </div>
         </div>
 
-        <footer className="flex shrink-0 items-center justify-between gap-3 bg-surface-secondary/60 px-4 py-3">
+        <footer className="flex shrink-0 items-center justify-between gap-3 border-t border-border bg-muted/50 px-4 py-3">
           <Button
             size="sm"
             variant="secondary"
@@ -164,7 +164,7 @@ export function PresenterView({
             <IconChevronLeft size={16} />
             Back
           </Button>
-          <p className="text-center text-xs text-muted">
+          <p className="text-center text-xs text-muted-foreground">
             Arrow keys · Space to advance
           </p>
           <Button

--- a/apps/web/src/routes/_components/slides/PresenterView.tsx
+++ b/apps/web/src/routes/_components/slides/PresenterView.tsx
@@ -1,0 +1,183 @@
+import { useState, useSyncExternalStore } from "react";
+import { Button } from "@eva/ui";
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconNotes,
+} from "@tabler/icons-react";
+import { usePresentationSync } from "./usePresentationSync";
+import { PresentationDeckProvider } from "./_components/PresentationDeckContext";
+import { SlideMiniPreview } from "./_components/SlideMiniPreview";
+import { getSpeakerNotes } from "./speakerNotes";
+import { SLIDES } from "./slides/index";
+import { postPresenterMessage } from "./presenterWindowSync";
+
+const TOTAL = SLIDES.length;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+interface PresenterViewProps {
+  slide: number;
+  session: string | undefined;
+  updateSearch: (next: { slide?: number; session?: string }) => void;
+}
+
+export function PresenterView({
+  slide,
+  session,
+  updateSearch,
+}: PresenterViewProps) {
+  const sync = usePresentationSync({
+    slide,
+    sessionCode: session,
+    updateSearch,
+  });
+
+  const current = sync.effectiveSlide;
+  const { slideTitle, notes } = getSpeakerNotes(current);
+  const hasNotes = notes.trim().length > 0;
+
+  const navigate = (target: number) => {
+    const clamped = clamp(target, 1, TOTAL);
+    sync.onNavigate(clamped);
+    postPresenterMessage({ type: "slide", slide: clamped });
+  };
+
+  useSyncExternalStore(
+    () => {
+      postPresenterMessage({ type: "presenter-open" });
+      postPresenterMessage({ type: "slide", slide: current });
+      const onUnload = () => postPresenterMessage({ type: "presenter-closed" });
+      window.addEventListener("beforeunload", onUnload);
+      return () => {
+        window.removeEventListener("beforeunload", onUnload);
+        postPresenterMessage({ type: "presenter-closed" });
+      };
+    },
+    () => "static",
+    () => "static",
+  );
+
+  useSyncExternalStore(
+    () => {
+      postPresenterMessage({ type: "slide", slide: current });
+      return () => {};
+    },
+    () => current,
+    () => current,
+  );
+
+  useSyncExternalStore(
+    () => {
+      function onKey(e: KeyboardEvent) {
+        const tag = document.activeElement?.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+        switch (e.key) {
+          case "ArrowRight":
+          case " ":
+          case "PageDown":
+            e.preventDefault();
+            navigate(current + 1);
+            break;
+          case "ArrowLeft":
+          case "PageUp":
+            e.preventDefault();
+            navigate(current - 1);
+            break;
+          case "Home":
+            e.preventDefault();
+            navigate(1);
+            break;
+          case "End":
+            e.preventDefault();
+            navigate(TOTAL);
+            break;
+          default:
+            break;
+        }
+      }
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    },
+    () => current,
+    () => current,
+  );
+
+  const deckContext = {
+    sessionCode: session,
+    participantKey: sync.participantKey,
+    hostKey: sync.hostKey,
+  };
+
+  return (
+    <PresentationDeckProvider value={deckContext}>
+      <div className="flex h-screen flex-col bg-background text-foreground">
+        <header className="flex shrink-0 items-center gap-2 px-4 py-2.5">
+          <IconNotes size={18} className="shrink-0 text-muted" />
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted">
+              Presenter view
+            </p>
+            <p className="truncate text-sm font-medium">
+              {current}. {slideTitle}
+            </p>
+          </div>
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted">
+            {current}/{TOTAL}
+          </span>
+        </header>
+
+        <div className="flex min-h-0 flex-1">
+          <div className="flex w-1/2 min-w-0 flex-col justify-center p-4">
+            <SlideMiniPreview slideNumber={current} />
+          </div>
+
+          <div className="flex w-1/2 min-w-0 flex-col bg-surface-secondary/40">
+            <p className="shrink-0 px-4 pb-2 pt-4 text-xs font-medium uppercase tracking-[0.14em] text-muted">
+              Script
+            </p>
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+              {hasNotes ? (
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                  {notes}
+                </p>
+              ) : (
+                <p className="text-sm leading-relaxed text-muted">
+                  No script for this slide — edit{" "}
+                  <span className="font-mono text-xs">speakerNotes.ts</span>.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <footer className="flex shrink-0 items-center justify-between gap-3 bg-surface-secondary/60 px-4 py-3">
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={current <= 1}
+            onClick={() => navigate(current - 1)}
+          >
+            <IconChevronLeft size={16} />
+            Back
+          </Button>
+          <p className="text-center text-xs text-muted">
+            Arrow keys · Space to advance
+          </p>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={current >= TOTAL}
+            onClick={() => navigate(current + 1)}
+          >
+            Next
+            <IconChevronRight size={16} />
+          </Button>
+        </footer>
+      </div>
+    </PresentationDeckProvider>
+  );
+}

--- a/apps/web/src/routes/_components/slides/SlideDeck.tsx
+++ b/apps/web/src/routes/_components/slides/SlideDeck.tsx
@@ -1,0 +1,291 @@
+import { useRef, useState, useSyncExternalStore } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { motionBase, motionFast } from "@eva/ui";
+import { SLIDES } from "./slides/index";
+import { SlideStepContext, SlideThemeContext } from "./_components/SlideShell";
+import { SlideOutlinePanel } from "./_components/SlideOutlinePanel";
+
+const DESIGN_W = 1280;
+const DESIGN_H = 720;
+const TOTAL = SLIDES.length;
+const DEFAULT_STAGGER_MS = 1000;
+
+interface SlideDeckProps {
+  slide: number;
+  onNavigate: (slide: number) => void;
+  allowNavigation?: boolean;
+  showOutline?: boolean;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function SlideDeck({
+  slide,
+  onNavigate,
+  allowNavigation = true,
+  showOutline = true,
+}: SlideDeckProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const stageAreaRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const prevSlideRef = useRef(slide);
+  const direction = slide >= prevSlideRef.current ? 1 : -1;
+  const [step, setStep] = useState(0);
+
+  const index = clamp(slide - 1, 0, TOTAL - 1);
+
+  useSyncExternalStore(
+    () => {
+      prevSlideRef.current = slide;
+      return () => {};
+    },
+    () => slide,
+    () => slide,
+  );
+
+  useSyncExternalStore(
+    () => {
+      setStep(0);
+      const entry = SLIDES[clamp(slide - 1, 0, TOTAL - 1)];
+      if (entry.steps === 0) return () => {};
+      const stagger = entry.staggerMs ?? DEFAULT_STAGGER_MS;
+      const timers: number[] = [];
+      for (let s = 1; s <= entry.steps; s++) {
+        timers.push(window.setTimeout(() => setStep(s), stagger * s));
+      }
+      return () => timers.forEach((t) => window.clearTimeout(t));
+    },
+    () => slide,
+    () => slide,
+  );
+
+  const go = (next: number, opts?: { delta?: number }) => {
+    const delta = opts?.delta;
+    const target =
+      delta === 1
+        ? clamp(slide + 1, 1, TOTAL)
+        : delta === -1
+          ? clamp(slide - 1, 1, TOTAL)
+          : clamp(next, 1, TOTAL);
+    if (target === slide) return;
+    onNavigate(target);
+  };
+
+  useSyncExternalStore(
+    () => {
+      const el = stageAreaRef.current;
+      if (!el) return () => {};
+
+      function measure() {
+        const node = stageAreaRef.current;
+        if (!node) return;
+        const { width, height } = node.getBoundingClientRect();
+        setScale(Math.min(width / DESIGN_W, height / DESIGN_H));
+      }
+      measure();
+      const observer = new ResizeObserver(measure);
+      observer.observe(el);
+      return () => observer.disconnect();
+    },
+    () => scale,
+    () => scale,
+  );
+
+  useSyncExternalStore(
+    () => {
+      if (!allowNavigation) return () => {};
+      function onKey(e: KeyboardEvent) {
+        switch (e.key) {
+          case "ArrowRight":
+          case " ":
+          case "PageDown":
+            e.preventDefault();
+            go(0, { delta: 1 });
+            break;
+          case "ArrowLeft":
+          case "PageUp":
+            e.preventDefault();
+            go(0, { delta: -1 });
+            break;
+          case "Home":
+            e.preventDefault();
+            go(1);
+            break;
+          case "End":
+            e.preventDefault();
+            go(TOTAL);
+            break;
+          case "f":
+          case "F":
+            if (!document.fullscreenElement) {
+              containerRef.current?.requestFullscreen().catch(() => undefined);
+            } else {
+              document.exitFullscreen().catch(() => undefined);
+            }
+            break;
+        }
+      }
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    },
+    () => `${slide}-${allowNavigation}`,
+    () => `${slide}-${allowNavigation}`,
+  );
+
+  function handleStageClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (!allowNavigation) return;
+    if (
+      e.target instanceof Element &&
+      e.target.closest('button, a, [role="button"]')
+    ) {
+      return;
+    }
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const third = rect.width / 3;
+    if (x < third) {
+      go(0, { delta: -1 });
+    } else if (x > third * 2) {
+      go(0, { delta: 1 });
+    }
+  }
+
+  const { Component, theme, id } = SLIDES[index];
+  const showOrbs = id !== "00" && id !== "01";
+
+  useSyncExternalStore(
+    () => {
+      const root = document.documentElement;
+      const opposite = theme === "dark" ? "light" : "dark";
+      const enforce = () => {
+        if (
+          root.classList.contains(opposite) ||
+          !root.classList.contains(theme)
+        ) {
+          root.classList.remove("dark", "light");
+          root.classList.add(theme);
+        }
+      };
+      enforce();
+      const observer = new MutationObserver(enforce);
+      observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+      return () => {
+        observer.disconnect();
+        root.classList.remove("dark", "light");
+        root.classList.add("dark");
+      };
+    },
+    () => theme,
+    () => theme,
+  );
+
+  const variants = {
+    enter: (dir: number) => ({
+      opacity: 0,
+      x: dir > 0 ? 40 : -40,
+    }),
+    center: {
+      opacity: 1,
+      x: 0,
+      transition: { duration: motionBase.duration, ease: motionBase.ease },
+    },
+    exit: (dir: number) => ({
+      opacity: 0,
+      x: dir > 0 ? -24 : 24,
+      transition: { duration: motionFast.duration, ease: motionFast.ease },
+    }),
+  };
+
+  const progressPct = ((slide - 1) / Math.max(1, TOTAL - 1)) * 100;
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed inset-0 flex overflow-hidden bg-background"
+    >
+      <SlideOutlinePanel slide={slide} onNavigate={go} hidden={!showOutline} />
+
+      <div
+        ref={stageAreaRef}
+        className={`relative flex min-w-0 flex-1 items-center justify-center overflow-hidden ${theme}`}
+      >
+        <div
+          style={{
+            width: DESIGN_W,
+            height: DESIGN_H,
+            transform: `scale(${scale})`,
+            transformOrigin: "center center",
+          }}
+          className="relative shrink-0 cursor-pointer overflow-hidden"
+          onClick={handleStageClick}
+          role="presentation"
+        >
+          <div
+            className="pointer-events-none absolute inset-0 transition-opacity duration-[1600ms] ease-in-out"
+            aria-hidden
+            style={{ opacity: showOrbs ? 1 : 0 }}
+          >
+            <motion.div
+              className={`absolute -left-44 -top-40 h-[560px] w-[560px] rounded-full blur-[110px] ${
+                theme === "dark"
+                  ? "bg-foreground opacity-[0.14]"
+                  : "bg-[#e3d5b8] opacity-[0.26]"
+              }`}
+              animate={{ x: [0, 70, 0], y: [0, 50, 0] }}
+              transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
+            />
+            <motion.div
+              className={`absolute -bottom-52 -right-40 h-[640px] w-[640px] rounded-full blur-[120px] ${
+                theme === "dark"
+                  ? "bg-foreground opacity-[0.12]"
+                  : "bg-[#e8dcc4] opacity-[0.22]"
+              }`}
+              animate={{ x: [0, -80, 0], y: [0, -55, 0] }}
+              transition={{ duration: 28, repeat: Infinity, ease: "easeInOut" }}
+            />
+            <motion.div
+              className={`absolute left-[52%] top-[58%] h-[380px] w-[380px] rounded-full blur-[100px] ${
+                theme === "dark"
+                  ? "bg-foreground opacity-[0.09]"
+                  : "bg-[#e3d5b8] opacity-[0.16]"
+              }`}
+              animate={{ x: [0, 55, 0], y: [0, -65, 0] }}
+              transition={{ duration: 18, repeat: Infinity, ease: "easeInOut" }}
+            />
+          </div>
+
+          <AnimatePresence custom={direction} mode="wait">
+            <motion.div
+              key={slide}
+              custom={direction}
+              variants={variants}
+              initial="enter"
+              animate="center"
+              exit="exit"
+              className="absolute inset-0"
+            >
+              <SlideThemeContext value={theme}>
+                <SlideStepContext value={step}>
+                  <Component />
+                </SlideStepContext>
+              </SlideThemeContext>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-0.5 bg-foreground/5">
+          <div
+            className="h-full bg-foreground/25 transition-[width] duration-300"
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+
+        <div className="pointer-events-none absolute bottom-3 right-4 font-mono text-xs tabular-nums text-muted/40">
+          {slide} / {TOTAL}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_components/slides/SlideDeck.tsx
+++ b/apps/web/src/routes/_components/slides/SlideDeck.tsx
@@ -155,32 +155,6 @@ export function SlideDeck({
   const { Component, theme, id } = SLIDES[index];
   const showOrbs = id !== "00" && id !== "01";
 
-  useSyncExternalStore(
-    () => {
-      const root = document.documentElement;
-      const opposite = theme === "dark" ? "light" : "dark";
-      const enforce = () => {
-        if (
-          root.classList.contains(opposite) ||
-          !root.classList.contains(theme)
-        ) {
-          root.classList.remove("dark", "light");
-          root.classList.add(theme);
-        }
-      };
-      enforce();
-      const observer = new MutationObserver(enforce);
-      observer.observe(root, { attributes: true, attributeFilter: ["class"] });
-      return () => {
-        observer.disconnect();
-        root.classList.remove("dark", "light");
-        root.classList.add("dark");
-      };
-    },
-    () => theme,
-    () => theme,
-  );
-
   const variants = {
     enter: (dir: number) => ({
       opacity: 0,
@@ -209,7 +183,7 @@ export function SlideDeck({
 
       <div
         ref={stageAreaRef}
-        className={`relative flex min-w-0 flex-1 items-center justify-center overflow-hidden ${theme}`}
+        className="relative flex min-w-0 flex-1 items-center justify-center overflow-hidden bg-background"
       >
         <div
           style={{
@@ -218,43 +192,32 @@ export function SlideDeck({
             transform: `scale(${scale})`,
             transformOrigin: "center center",
           }}
-          className="relative shrink-0 cursor-pointer overflow-hidden"
+          className="relative shrink-0 cursor-pointer overflow-hidden rounded-lg"
           onClick={handleStageClick}
           role="presentation"
         >
-          <div
-            className="pointer-events-none absolute inset-0 transition-opacity duration-[1600ms] ease-in-out"
-            aria-hidden
-            style={{ opacity: showOrbs ? 1 : 0 }}
-          >
-            <motion.div
-              className={`absolute -left-44 -top-40 h-[560px] w-[560px] rounded-full blur-[110px] ${
-                theme === "dark"
-                  ? "bg-foreground opacity-[0.14]"
-                  : "bg-[#e3d5b8] opacity-[0.26]"
-              }`}
-              animate={{ x: [0, 70, 0], y: [0, 50, 0] }}
-              transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
-            />
-            <motion.div
-              className={`absolute -bottom-52 -right-40 h-[640px] w-[640px] rounded-full blur-[120px] ${
-                theme === "dark"
-                  ? "bg-foreground opacity-[0.12]"
-                  : "bg-[#e8dcc4] opacity-[0.22]"
-              }`}
-              animate={{ x: [0, -80, 0], y: [0, -55, 0] }}
-              transition={{ duration: 28, repeat: Infinity, ease: "easeInOut" }}
-            />
-            <motion.div
-              className={`absolute left-[52%] top-[58%] h-[380px] w-[380px] rounded-full blur-[100px] ${
-                theme === "dark"
-                  ? "bg-foreground opacity-[0.09]"
-                  : "bg-[#e3d5b8] opacity-[0.16]"
-              }`}
-              animate={{ x: [0, 55, 0], y: [0, -65, 0] }}
-              transition={{ duration: 18, repeat: Infinity, ease: "easeInOut" }}
-            />
-          </div>
+          {showOrbs && (
+            <div
+              className="pointer-events-none absolute inset-0"
+              aria-hidden
+            >
+              <motion.div
+                className="absolute -left-44 -top-40 h-[560px] w-[560px] rounded-full bg-primary/5 blur-[110px]"
+                animate={{ x: [0, 70, 0], y: [0, 50, 0] }}
+                transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
+              />
+              <motion.div
+                className="absolute -bottom-52 -right-40 h-[640px] w-[640px] rounded-full bg-primary/4 blur-[120px]"
+                animate={{ x: [0, -80, 0], y: [0, -55, 0] }}
+                transition={{ duration: 28, repeat: Infinity, ease: "easeInOut" }}
+              />
+              <motion.div
+                className="absolute left-[52%] top-[58%] h-[380px] w-[380px] rounded-full bg-primary/3 blur-[100px]"
+                animate={{ x: [0, 55, 0], y: [0, -65, 0] }}
+                transition={{ duration: 18, repeat: Infinity, ease: "easeInOut" }}
+              />
+            </div>
+          )}
 
           <AnimatePresence custom={direction} mode="wait">
             <motion.div
@@ -275,14 +238,14 @@ export function SlideDeck({
           </AnimatePresence>
         </div>
 
-        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-0.5 bg-foreground/5">
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-0.5 bg-border">
           <div
             className="h-full bg-foreground/25 transition-[width] duration-300"
             style={{ width: `${progressPct}%` }}
           />
         </div>
 
-        <div className="pointer-events-none absolute bottom-3 right-4 font-mono text-xs tabular-nums text-muted/40">
+        <div className="pointer-events-none absolute bottom-3 right-4 font-mono text-xs tabular-nums text-muted-foreground/60">
           {slide} / {TOTAL}
         </div>
       </div>

--- a/apps/web/src/routes/_components/slides/_components/BlurWordsTitle.tsx
+++ b/apps/web/src/routes/_components/slides/_components/BlurWordsTitle.tsx
@@ -1,0 +1,92 @@
+import { use } from "react";
+import type { ReactNode } from "react";
+import { motion } from "motion/react";
+import type { Variants } from "motion/react";
+import { SlideStepContext } from "./SlideShell";
+
+const EVA_WORD = /^(eva)([.,!?:;'"]*)$/i;
+
+function renderWord(word: string): ReactNode {
+  const match = EVA_WORD.exec(word);
+  if (!match) return word;
+  const [, eva, trailing] = match;
+  return (
+    <>
+      <span className="font-medium">{eva}</span>
+      {trailing}
+    </>
+  );
+}
+
+const wordVariants: Variants = {
+  hidden: { opacity: 0, y: 8, filter: "blur(8px)" },
+  show: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+interface BlurWordsTitleProps {
+  lines: string[];
+  size?: "xl" | "2xl" | "3xl" | "4xl";
+  step?: number;
+  delay?: number;
+}
+
+export function BlurWordsTitle({
+  lines,
+  size = "2xl",
+  step = 0,
+  delay = 0,
+}: BlurWordsTitleProps) {
+  const contextStep = use(SlideStepContext);
+  const isVisible = contextStep >= step;
+
+  const sizeClass =
+    size === "xl"
+      ? "text-5xl"
+      : size === "2xl"
+        ? "text-6xl"
+        : size === "3xl"
+          ? "text-7xl"
+          : "text-8xl";
+
+  const containerVariants: Variants = {
+    hidden: {},
+    show: {
+      transition: {
+        staggerChildren: 0.2,
+        delayChildren: delay,
+      },
+    },
+  };
+
+  return (
+    <motion.h1
+      className={`font-instrumentSerif ${sizeClass} font-normal leading-tight tracking-tight text-foreground`}
+      variants={containerVariants}
+      initial="hidden"
+      animate={isVisible ? "show" : "hidden"}
+    >
+      {lines.flatMap((line, lineIdx) => {
+        const words = line.split(" ").filter(Boolean);
+        const wordSpans = words.map((word, wordIdx) => (
+          <motion.span
+            key={`${lineIdx}-${wordIdx}`}
+            variants={wordVariants}
+            className="inline-block"
+            style={{ marginRight: "0.22em" }}
+          >
+            {renderWord(word)}
+          </motion.span>
+        ));
+        if (lineIdx < lines.length - 1) {
+          return [...wordSpans, <br key={`br-${lineIdx}`} />];
+        }
+        return wordSpans;
+      })}
+    </motion.h1>
+  );
+}

--- a/apps/web/src/routes/_components/slides/_components/BlurWordsTitle.tsx
+++ b/apps/web/src/routes/_components/slides/_components/BlurWordsTitle.tsx
@@ -12,7 +12,7 @@ function renderWord(word: string): ReactNode {
   const [, eva, trailing] = match;
   return (
     <>
-      <span className="font-medium">{eva}</span>
+      <span className="font-semibold">{eva}</span>
       {trailing}
     </>
   );
@@ -65,7 +65,7 @@ export function BlurWordsTitle({
 
   return (
     <motion.h1
-      className={`font-instrumentSerif ${sizeClass} font-normal leading-tight tracking-tight text-foreground`}
+      className={`font-sans ${sizeClass} font-semibold leading-tight tracking-tight text-foreground`}
       variants={containerVariants}
       initial="hidden"
       animate={isVisible ? "show" : "hidden"}

--- a/apps/web/src/routes/_components/slides/_components/PresentationControls.tsx
+++ b/apps/web/src/routes/_components/slides/_components/PresentationControls.tsx
@@ -1,0 +1,131 @@
+import { useState, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
+import { Button, cn } from "@eva/ui";
+import {
+  IconShare2,
+  IconLoader2,
+  IconEye,
+  IconArrowBackUp,
+  IconNotes,
+} from "@tabler/icons-react";
+import type { PresentationSync } from "../usePresentationSync";
+import { PresentationHostBar } from "./PresentationHostBar";
+
+interface PresentationControlsProps {
+  sync: PresentationSync;
+  canOpenPresenter?: boolean;
+  presenterDetached?: boolean;
+  onOpenPresenter?: () => void;
+}
+
+const PILL =
+  "inline-flex items-center gap-2 rounded-full bg-surface-secondary/90 px-3.5 py-2 text-sm text-foreground shadow-lg backdrop-blur";
+
+export function PresentationControls({
+  sync,
+  canOpenPresenter = false,
+  presenterDetached = false,
+  onOpenPresenter,
+}: PresentationControlsProps) {
+  const [revealed, setRevealed] = useState(true);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useSyncExternalStore(
+    () => {
+      let timer: number | undefined;
+      const show = () => {
+        setRevealed(true);
+        if (timer) window.clearTimeout(timer);
+        timer = window.setTimeout(() => setRevealed(false), 3000);
+      };
+      show();
+      window.addEventListener("mousemove", show);
+      window.addEventListener("keydown", show);
+      return () => {
+        window.removeEventListener("mousemove", show);
+        window.removeEventListener("keydown", show);
+        if (timer) window.clearTimeout(timer);
+      };
+    },
+    () => revealed,
+    () => revealed,
+  );
+
+  const visible = revealed || menuOpen;
+  const { sessionState, isHost, mode } = sync;
+
+  let body: ReactNode;
+  if (sessionState === "none") {
+    body = (
+      <Button
+        size="sm"
+        variant="secondary"
+        className="shadow-lg"
+        onClick={() => void sync.startSharing()}
+        disabled={sync.isStarting}
+      >
+        {sync.isStarting ? (
+          <IconLoader2 size={15} className="animate-spin" />
+        ) : (
+          <IconShare2 size={15} />
+        )}
+        Share
+      </Button>
+    );
+  } else if (isHost) {
+    body = <PresentationHostBar sync={sync} onOpenChange={setMenuOpen} />;
+  } else if (sessionState === "ended") {
+    body = <div className={PILL}>Presentation ended</div>;
+  } else if (sessionState === "notfound") {
+    body = <div className={PILL}>Presentation not found</div>;
+  } else if (sessionState === "loading") {
+    body = <div className={cn(PILL, "text-muted")}>Connecting…</div>;
+  } else if (mode === "private") {
+    body = (
+      <div className="inline-flex items-center gap-2 rounded-full bg-surface-secondary/90 py-1 pl-3.5 pr-1 text-sm text-foreground shadow-lg backdrop-blur">
+        <span>Viewing on your own</span>
+        <Button size="sm" variant="secondary" onClick={sync.backToLive}>
+          <IconArrowBackUp size={15} /> Back to live
+        </Button>
+      </div>
+    );
+  } else {
+    body = (
+      <div className={PILL}>
+        <IconEye size={15} className="text-muted" />
+        Following · live
+      </div>
+    );
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-50 flex items-start justify-end gap-2 p-4">
+      {canOpenPresenter && !presenterDetached && onOpenPresenter ? (
+        <div
+          className={cn(
+            "transition-opacity duration-300",
+            visible ? "pointer-events-auto opacity-100" : "opacity-0",
+          )}
+        >
+          <Button
+            size="sm"
+            variant="secondary"
+            className="shadow-lg"
+            onClick={onOpenPresenter}
+          >
+            <IconNotes size={15} />
+            Presenter view
+          </Button>
+        </div>
+      ) : null}
+      <div
+        className={cn(
+          "transition-opacity duration-300",
+          visible ? "pointer-events-auto opacity-100" : "opacity-0",
+        )}
+      >
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_components/slides/_components/PresentationControls.tsx
+++ b/apps/web/src/routes/_components/slides/_components/PresentationControls.tsx
@@ -19,7 +19,7 @@ interface PresentationControlsProps {
 }
 
 const PILL =
-  "inline-flex items-center gap-2 rounded-full bg-surface-secondary/90 px-3.5 py-2 text-sm text-foreground shadow-lg backdrop-blur";
+  "inline-flex items-center gap-2 rounded-full bg-card px-3.5 py-2 text-sm text-card-foreground shadow-lg backdrop-blur";
 
 export function PresentationControls({
   sync,
@@ -79,10 +79,10 @@ export function PresentationControls({
   } else if (sessionState === "notfound") {
     body = <div className={PILL}>Presentation not found</div>;
   } else if (sessionState === "loading") {
-    body = <div className={cn(PILL, "text-muted")}>Connecting…</div>;
+    body = <div className={cn(PILL, "text-muted-foreground")}>Connecting…</div>;
   } else if (mode === "private") {
     body = (
-      <div className="inline-flex items-center gap-2 rounded-full bg-surface-secondary/90 py-1 pl-3.5 pr-1 text-sm text-foreground shadow-lg backdrop-blur">
+      <div className="inline-flex items-center gap-2 rounded-full bg-card py-1 pl-3.5 pr-1 text-sm text-card-foreground shadow-lg backdrop-blur">
         <span>Viewing on your own</span>
         <Button size="sm" variant="secondary" onClick={sync.backToLive}>
           <IconArrowBackUp size={15} /> Back to live
@@ -92,7 +92,7 @@ export function PresentationControls({
   } else {
     body = (
       <div className={PILL}>
-        <IconEye size={15} className="text-muted" />
+        <IconEye size={15} className="text-muted-foreground" />
         Following · live
       </div>
     );

--- a/apps/web/src/routes/_components/slides/_components/PresentationDeckContext.tsx
+++ b/apps/web/src/routes/_components/slides/_components/PresentationDeckContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, use } from "react";
+
+export interface PresentationDeck {
+  sessionCode: string | undefined;
+  participantKey: string;
+  hostKey: string | null;
+}
+
+const PresentationDeckContext = createContext<PresentationDeck>({
+  sessionCode: undefined,
+  participantKey: "",
+  hostKey: null,
+});
+
+export const PresentationDeckProvider = PresentationDeckContext.Provider;
+
+export function usePresentationDeck(): PresentationDeck {
+  return use(PresentationDeckContext);
+}

--- a/apps/web/src/routes/_components/slides/_components/PresentationHostBar.tsx
+++ b/apps/web/src/routes/_components/slides/_components/PresentationHostBar.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import {
+  Button,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@eva/ui";
+import { IconCopy, IconCheck, IconPlayerStop } from "@tabler/icons-react";
+import { toast } from "sonner";
+import type { PresentationSync } from "../usePresentationSync";
+
+interface PresentationHostBarProps {
+  sync: PresentationSync;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function PresentationHostBar({
+  sync,
+  onOpenChange,
+}: PresentationHostBarProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = async () => {
+    if (!sync.shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(sync.shareUrl);
+      setCopied(true);
+      toast.success("Share link copied");
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Couldn't copy the link");
+    }
+  };
+
+  return (
+    <Popover onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-full bg-surface-secondary/90 px-3.5 py-2 text-sm font-medium text-foreground shadow-lg backdrop-blur transition-[background-color] hover:bg-surface-tertiary"
+        >
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/70" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
+          </span>
+          Live
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72 space-y-3">
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted">
+            Share link
+          </p>
+          <div className="flex gap-2">
+            <Input
+              readOnly
+              value={sync.shareUrl ?? ""}
+              className="h-9 font-mono text-xs"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <Button
+              size="icon-sm"
+              variant="secondary"
+              onClick={() => void copyLink()}
+              title={copied ? "Copied" : "Copy link"}
+            >
+              {copied ? <IconCheck size={15} /> : <IconCopy size={15} />}
+            </Button>
+          </div>
+        </div>
+
+        <p className="text-xs leading-relaxed text-muted">
+          Anyone with the link follows your slides live.
+        </p>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-center text-danger hover:text-danger"
+          onClick={() => void sync.stopSharing()}
+        >
+          <IconPlayerStop size={15} /> Stop sharing
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/routes/_components/slides/_components/PresentationHostBar.tsx
+++ b/apps/web/src/routes/_components/slides/_components/PresentationHostBar.tsx
@@ -38,7 +38,7 @@ export function PresentationHostBar({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-2 rounded-full bg-surface-secondary/90 px-3.5 py-2 text-sm font-medium text-foreground shadow-lg backdrop-blur transition-[background-color] hover:bg-surface-tertiary"
+          className="inline-flex items-center gap-2 rounded-full bg-card px-3.5 py-2 text-sm font-medium text-card-foreground shadow-lg backdrop-blur transition-[background-color] hover:bg-secondary"
         >
           <span className="relative flex h-2 w-2">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/70" />
@@ -49,7 +49,7 @@ export function PresentationHostBar({
       </PopoverTrigger>
       <PopoverContent align="end" className="w-72 space-y-3">
         <div className="space-y-1.5">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
             Share link
           </p>
           <div className="flex gap-2">
@@ -70,14 +70,14 @@ export function PresentationHostBar({
           </div>
         </div>
 
-        <p className="text-xs leading-relaxed text-muted">
+        <p className="text-xs leading-relaxed text-muted-foreground">
           Anyone with the link follows your slides live.
         </p>
 
         <Button
           variant="ghost"
           size="sm"
-          className="w-full justify-center text-danger hover:text-danger"
+          className="w-full justify-center text-destructive hover:text-destructive"
           onClick={() => void sync.stopSharing()}
         >
           <IconPlayerStop size={15} /> Stop sharing

--- a/apps/web/src/routes/_components/slides/_components/SlideMiniPreview.tsx
+++ b/apps/web/src/routes/_components/slides/_components/SlideMiniPreview.tsx
@@ -29,7 +29,7 @@ export function SlideMiniPreview({
   const { Component, theme } = entry;
 
   useSyncExternalStore(
-    (onStoreChange) => {
+    () => {
       const el = containerRef.current;
       if (!el) return () => {};
       function measure() {
@@ -49,10 +49,12 @@ export function SlideMiniPreview({
 
   return (
     <div className="space-y-1.5">
-      {label ? <p className="text-xs font-medium text-muted">{label}</p> : null}
+      {label ? (
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      ) : null}
       <div
         ref={containerRef}
-        className={`relative aspect-video w-full overflow-hidden rounded-xl bg-background text-foreground ${theme}`}
+        className="relative aspect-video w-full overflow-hidden rounded-xl border border-border bg-background"
       >
         <div
           className="pointer-events-none absolute left-0 top-0 origin-top-left"

--- a/apps/web/src/routes/_components/slides/_components/SlideMiniPreview.tsx
+++ b/apps/web/src/routes/_components/slides/_components/SlideMiniPreview.tsx
@@ -1,0 +1,74 @@
+import { useRef, useState, useSyncExternalStore } from "react";
+import { SLIDES } from "../slides/index";
+import { SlideStepContext, SlideThemeContext } from "./SlideShell";
+
+const DESIGN_W = 1280;
+const DESIGN_H = 720;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+interface SlideMiniPreviewProps {
+  slideNumber: number;
+  buildStep?: number;
+  label?: string;
+}
+
+export function SlideMiniPreview({
+  slideNumber,
+  buildStep,
+  label,
+}: SlideMiniPreviewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(0.25);
+
+  const index = clamp(slideNumber - 1, 0, SLIDES.length - 1);
+  const entry = SLIDES[index];
+  const step = buildStep ?? entry.steps;
+  const { Component, theme } = entry;
+
+  useSyncExternalStore(
+    (onStoreChange) => {
+      const el = containerRef.current;
+      if (!el) return () => {};
+      function measure() {
+        const node = containerRef.current;
+        if (!node) return;
+        const { width } = node.getBoundingClientRect();
+        setScale(width / DESIGN_W);
+      }
+      measure();
+      const observer = new ResizeObserver(measure);
+      observer.observe(el);
+      return () => observer.disconnect();
+    },
+    () => scale,
+    () => scale,
+  );
+
+  return (
+    <div className="space-y-1.5">
+      {label ? <p className="text-xs font-medium text-muted">{label}</p> : null}
+      <div
+        ref={containerRef}
+        className={`relative aspect-video w-full overflow-hidden rounded-xl bg-background text-foreground ${theme}`}
+      >
+        <div
+          className="pointer-events-none absolute left-0 top-0 origin-top-left"
+          style={{
+            width: DESIGN_W,
+            height: DESIGN_H,
+            transform: `scale(${scale})`,
+          }}
+        >
+          <SlideThemeContext value={theme}>
+            <SlideStepContext value={step}>
+              <Component />
+            </SlideStepContext>
+          </SlideThemeContext>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_components/slides/_components/SlideOutlinePanel.tsx
+++ b/apps/web/src/routes/_components/slides/_components/SlideOutlinePanel.tsx
@@ -1,0 +1,124 @@
+import { useRef, useState } from "react";
+import {
+  IconLayoutSidebarLeftCollapse,
+  IconLayoutSidebarLeftExpandFilled,
+} from "@tabler/icons-react";
+import { cn } from "@eva/ui";
+import { SLIDES } from "../slides/index";
+import { useSyncExternalStore } from "react";
+
+interface SlideOutlinePanelProps {
+  slide: number;
+  onNavigate: (slide: number) => void;
+  hidden?: boolean;
+}
+
+export function SlideOutlinePanel({
+  slide,
+  onNavigate,
+  hidden = false,
+}: SlideOutlinePanelProps) {
+  const [open, setOpen] = useState(true);
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  useSyncExternalStore(
+    (cb) => {
+      if (!open || hidden) return () => {};
+      const id = requestAnimationFrame(() => {
+        activeRef.current?.scrollIntoView({ block: "nearest" });
+      });
+      return () => cancelAnimationFrame(id);
+    },
+    () => `${slide}-${open}-${hidden}`,
+    () => `${slide}-${open}-${hidden}`,
+  );
+
+  if (hidden) return null;
+
+  if (!open) {
+    return (
+      <div className="flex w-11 shrink-0 flex-col items-center bg-background py-3">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-muted transition-[background-color] hover:bg-surface-tertiary/50 hover:text-foreground"
+          aria-label="Show slide list"
+        >
+          <IconLayoutSidebarLeftExpandFilled size={18} stroke={1.5} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <aside className="flex w-56 shrink-0 flex-col bg-background lg:w-60">
+      <div className="flex items-center justify-between px-3 py-3">
+        <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted">
+          Slides
+        </p>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-muted transition-[background-color] hover:bg-surface-tertiary/50 hover:text-foreground"
+          aria-label="Hide slide list"
+        >
+          <IconLayoutSidebarLeftCollapse size={17} stroke={1.5} />
+        </button>
+      </div>
+
+      <nav
+        className="min-h-0 flex-1 overflow-y-auto px-2 pb-4"
+        aria-label="Slide outline"
+      >
+        <ul className="space-y-1">
+          {SLIDES.map((entry, i) => {
+            const slideNumber = i + 1;
+            const isActive = slideNumber === slide;
+
+            return (
+              <li key={entry.id}>
+                <button
+                  ref={isActive ? activeRef : undefined}
+                  type="button"
+                  onClick={() => onNavigate(slideNumber)}
+                  className={cn(
+                    "flex w-full gap-2.5 rounded-xl px-2 py-2 text-left transition-[background-color]",
+                    isActive
+                      ? "bg-surface-tertiary"
+                      : "hover:bg-surface-tertiary/50",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "relative flex aspect-video w-[4.5rem] shrink-0 items-center justify-center overflow-hidden rounded-lg",
+                      entry.theme === "dark"
+                        ? "bg-foreground text-background"
+                        : "bg-surface-secondary text-foreground",
+                    )}
+                  >
+                    <span className="font-mono text-[10px] tabular-nums opacity-60">
+                      {slideNumber}
+                    </span>
+                  </span>
+                  <span className="min-w-0 flex-1 py-0.5">
+                    <span
+                      className={cn(
+                        "block truncate text-xs font-medium",
+                        isActive ? "text-foreground" : "text-muted",
+                      )}
+                    >
+                      {entry.title}
+                    </span>
+                    <span className="mt-0.5 block font-mono text-[10px] tabular-nums text-muted/70">
+                      {entry.id}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/apps/web/src/routes/_components/slides/_components/SlideOutlinePanel.tsx
+++ b/apps/web/src/routes/_components/slides/_components/SlideOutlinePanel.tsx
@@ -1,11 +1,10 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useSyncExternalStore } from "react";
 import {
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpandFilled,
 } from "@tabler/icons-react";
 import { cn } from "@eva/ui";
 import { SLIDES } from "../slides/index";
-import { useSyncExternalStore } from "react";
 
 interface SlideOutlinePanelProps {
   slide: number;
@@ -22,7 +21,7 @@ export function SlideOutlinePanel({
   const activeRef = useRef<HTMLButtonElement>(null);
 
   useSyncExternalStore(
-    (cb) => {
+    () => {
       if (!open || hidden) return () => {};
       const id = requestAnimationFrame(() => {
         activeRef.current?.scrollIntoView({ block: "nearest" });
@@ -41,7 +40,7 @@ export function SlideOutlinePanel({
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="flex h-9 w-9 items-center justify-center rounded-lg text-muted transition-[background-color] hover:bg-surface-tertiary/50 hover:text-foreground"
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition-[background-color] hover:bg-secondary hover:text-foreground"
           aria-label="Show slide list"
         >
           <IconLayoutSidebarLeftExpandFilled size={18} stroke={1.5} />
@@ -51,15 +50,15 @@ export function SlideOutlinePanel({
   }
 
   return (
-    <aside className="flex w-56 shrink-0 flex-col bg-background lg:w-60">
+    <aside className="flex w-56 shrink-0 flex-col border-r border-border bg-background lg:w-60">
       <div className="flex items-center justify-between px-3 py-3">
-        <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted">
+        <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
           Slides
         </p>
         <button
           type="button"
           onClick={() => setOpen(false)}
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-muted transition-[background-color] hover:bg-surface-tertiary/50 hover:text-foreground"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-[background-color] hover:bg-secondary hover:text-foreground"
           aria-label="Hide slide list"
         >
           <IconLayoutSidebarLeftCollapse size={17} stroke={1.5} />
@@ -83,17 +82,15 @@ export function SlideOutlinePanel({
                   onClick={() => onNavigate(slideNumber)}
                   className={cn(
                     "flex w-full gap-2.5 rounded-xl px-2 py-2 text-left transition-[background-color]",
-                    isActive
-                      ? "bg-surface-tertiary"
-                      : "hover:bg-surface-tertiary/50",
+                    isActive ? "bg-secondary" : "hover:bg-secondary/50",
                   )}
                 >
                   <span
                     className={cn(
                       "relative flex aspect-video w-[4.5rem] shrink-0 items-center justify-center overflow-hidden rounded-lg",
                       entry.theme === "dark"
-                        ? "bg-foreground text-background"
-                        : "bg-surface-secondary text-foreground",
+                        ? "bg-zinc-800 text-zinc-100"
+                        : "bg-secondary text-foreground",
                     )}
                   >
                     <span className="font-mono text-[10px] tabular-nums opacity-60">
@@ -104,12 +101,12 @@ export function SlideOutlinePanel({
                     <span
                       className={cn(
                         "block truncate text-xs font-medium",
-                        isActive ? "text-foreground" : "text-muted",
+                        isActive ? "text-foreground" : "text-muted-foreground",
                       )}
                     >
                       {entry.title}
                     </span>
-                    <span className="mt-0.5 block font-mono text-[10px] tabular-nums text-muted/70">
+                    <span className="mt-0.5 block font-mono text-[10px] tabular-nums text-muted-foreground/70">
                       {entry.id}
                     </span>
                   </span>

--- a/apps/web/src/routes/_components/slides/_components/SlideShell.tsx
+++ b/apps/web/src/routes/_components/slides/_components/SlideShell.tsx
@@ -1,0 +1,205 @@
+import { createContext, use } from "react";
+import type { ReactNode } from "react";
+import { motion } from "motion/react";
+import { motionBase } from "@eva/ui";
+
+/**
+ * The current build step for the active slide. 0 = initial state (no clicks
+ * yet). Provided by SlideDeck; defaults to 0 so slides are usable standalone.
+ */
+export const SlideStepContext = createContext<number>(0);
+
+/** Active slide theme — set by SlideDeck so children can theme-aware styling. */
+export const SlideThemeContext = createContext<"dark" | "light">("light");
+
+const fadeUpVariants = {
+  hidden: { opacity: 0, y: 12 },
+  show: { opacity: 1, y: 0 },
+};
+
+interface SlideRevealProps {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+  step?: number;
+}
+
+export function SlideReveal({
+  children,
+  delay = 0,
+  step = 0,
+  className = "",
+}: SlideRevealProps) {
+  const contextStep = use(SlideStepContext);
+  const isVisible = contextStep >= step;
+  return (
+    <motion.div
+      initial="hidden"
+      animate={isVisible ? "show" : "hidden"}
+      variants={fadeUpVariants}
+      transition={{
+        duration: motionBase.duration as number,
+        ease: motionBase.ease,
+        delay: isVisible ? delay : 0,
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+interface SlideStaggerProps {
+  children: ReactNode;
+  className?: string;
+  delayChildren?: number;
+  staggerChildren?: number;
+  step?: number;
+}
+
+export function SlideStagger({
+  children,
+  className = "",
+  delayChildren = 0.1,
+  staggerChildren = 0.07,
+  step = 0,
+}: SlideStaggerProps) {
+  const contextStep = use(SlideStepContext);
+  const isVisible = contextStep >= step;
+  return (
+    <motion.div
+      initial="hidden"
+      animate={isVisible ? "show" : "hidden"}
+      variants={{
+        hidden: {},
+        show: {
+          transition: {
+            staggerChildren,
+            delayChildren,
+          },
+        },
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+interface SlideItemProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function SlideItem({ children, className = "" }: SlideItemProps) {
+  return (
+    <motion.div
+      variants={fadeUpVariants}
+      transition={{ duration: motionBase.duration as number, ease: motionBase.ease }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+interface SlideShellProps {
+  children: ReactNode;
+  className?: string;
+  center?: boolean;
+}
+
+export function SlideShell({
+  children,
+  className = "",
+  center = false,
+}: SlideShellProps) {
+  return (
+    <div
+      className={`relative flex h-full w-full flex-col overflow-hidden px-20 py-16 ${center ? "items-center justify-center" : ""} ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface SlideKickerProps {
+  children: ReactNode;
+}
+
+export function SlideKicker({ children }: SlideKickerProps) {
+  return (
+    <p className="mb-4 text-xs font-medium uppercase tracking-[0.22em] text-muted">
+      {children}
+    </p>
+  );
+}
+
+interface SlideTitleProps {
+  children: ReactNode;
+  size?: "xl" | "2xl" | "3xl";
+}
+
+export function SlideTitle({ children, size = "2xl" }: SlideTitleProps) {
+  const sizeClass =
+    size === "xl" ? "text-5xl" : size === "2xl" ? "text-6xl" : "text-7xl";
+  return (
+    <h1
+      className={`font-instrumentSerif ${sizeClass} font-normal leading-tight tracking-tight text-foreground`}
+    >
+      {children}
+    </h1>
+  );
+}
+
+interface SlideBodyProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function SlideBody({ children, className = "" }: SlideBodyProps) {
+  return (
+    <p className={`text-lg leading-relaxed text-muted ${className}`}>
+      {children}
+    </p>
+  );
+}
+
+interface SlideBulletsProps {
+  items: string[];
+}
+
+export function SlideBullets({ items }: SlideBulletsProps) {
+  return (
+    <ul className="mt-6 space-y-4">
+      {items.map((item) => (
+        <li key={item} className="flex items-start gap-3">
+          <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+          <span className="text-base leading-relaxed text-foreground/80">
+            {item}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface SlideDividerProps {
+  className?: string;
+}
+
+export function SlideDivider({ className = "" }: SlideDividerProps) {
+  return <div className={`mt-8 ${className}`} />;
+}
+
+interface SlideTagProps {
+  children: ReactNode;
+}
+
+export function SlideTag({ children }: SlideTagProps) {
+  return (
+    <span className="inline-flex items-center rounded-full bg-surface-secondary px-3 py-1 text-xs font-medium text-foreground/70">
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/routes/_components/slides/_components/SlideShell.tsx
+++ b/apps/web/src/routes/_components/slides/_components/SlideShell.tsx
@@ -129,7 +129,7 @@ interface SlideKickerProps {
 
 export function SlideKicker({ children }: SlideKickerProps) {
   return (
-    <p className="mb-4 text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+    <p className="mb-4 text-xs font-medium uppercase tracking-[0.22em] text-foreground/60">
       {children}
     </p>
   );
@@ -159,7 +159,7 @@ interface SlideBodyProps {
 
 export function SlideBody({ children, className = "" }: SlideBodyProps) {
   return (
-    <p className={`text-lg leading-relaxed text-muted-foreground ${className}`}>
+    <p className={`text-lg leading-relaxed text-foreground/70 ${className}`}>
       {children}
     </p>
   );

--- a/apps/web/src/routes/_components/slides/_components/SlideShell.tsx
+++ b/apps/web/src/routes/_components/slides/_components/SlideShell.tsx
@@ -9,7 +9,7 @@ import { motionBase } from "@eva/ui";
  */
 export const SlideStepContext = createContext<number>(0);
 
-/** Active slide theme — set by SlideDeck so children can theme-aware styling. */
+/** Active slide theme — set by SlideDeck so children can apply theme-aware styling. */
 export const SlideThemeContext = createContext<"dark" | "light">("light");
 
 const fadeUpVariants = {
@@ -129,7 +129,7 @@ interface SlideKickerProps {
 
 export function SlideKicker({ children }: SlideKickerProps) {
   return (
-    <p className="mb-4 text-xs font-medium uppercase tracking-[0.22em] text-muted">
+    <p className="mb-4 text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
       {children}
     </p>
   );
@@ -145,7 +145,7 @@ export function SlideTitle({ children, size = "2xl" }: SlideTitleProps) {
     size === "xl" ? "text-5xl" : size === "2xl" ? "text-6xl" : "text-7xl";
   return (
     <h1
-      className={`font-instrumentSerif ${sizeClass} font-normal leading-tight tracking-tight text-foreground`}
+      className={`font-sans ${sizeClass} font-semibold leading-tight tracking-tight text-foreground`}
     >
       {children}
     </h1>
@@ -159,7 +159,7 @@ interface SlideBodyProps {
 
 export function SlideBody({ children, className = "" }: SlideBodyProps) {
   return (
-    <p className={`text-lg leading-relaxed text-muted ${className}`}>
+    <p className={`text-lg leading-relaxed text-muted-foreground ${className}`}>
       {children}
     </p>
   );
@@ -198,7 +198,7 @@ interface SlideTagProps {
 
 export function SlideTag({ children }: SlideTagProps) {
   return (
-    <span className="inline-flex items-center rounded-full bg-surface-secondary px-3 py-1 text-xs font-medium text-foreground/70">
+    <span className="inline-flex items-center rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground">
       {children}
     </span>
   );

--- a/apps/web/src/routes/_components/slides/presenterWindowSync.ts
+++ b/apps/web/src/routes/_components/slides/presenterWindowSync.ts
@@ -1,0 +1,48 @@
+export const PRESENTER_CHANNEL = "eva-slides-presenter";
+export const PRESENTER_WINDOW_NAME = "eva-presenter";
+
+export type PresenterChannelMessage =
+  | { type: "slide"; slide: number }
+  | { type: "presenter-open" }
+  | { type: "presenter-closed" };
+
+export function postPresenterMessage(message: PresenterChannelMessage): void {
+  if (typeof BroadcastChannel === "undefined") return;
+  const channel = new BroadcastChannel(PRESENTER_CHANNEL);
+  channel.postMessage(message);
+  channel.close();
+}
+
+export function openPresenterWindow(): void {
+  if (typeof window === "undefined") return;
+
+  const url = new URL(window.location.href);
+  url.searchParams.set("view", "presenter");
+  const opened = window.open(
+    url.toString(),
+    PRESENTER_WINDOW_NAME,
+    "popup,width=960,height=640,menubar=no,toolbar=no,location=no,status=no",
+  );
+  opened?.focus();
+}
+
+interface PresenterChannelHandlers {
+  onSlide?: (slide: number) => void;
+  onPresenterOpen?: () => void;
+  onPresenterClosed?: () => void;
+}
+
+export function subscribePresenterChannel(
+  handlers: PresenterChannelHandlers,
+): () => void {
+  if (typeof BroadcastChannel === "undefined") return () => undefined;
+
+  const channel = new BroadcastChannel(PRESENTER_CHANNEL);
+  channel.onmessage = (event: MessageEvent<PresenterChannelMessage>) => {
+    const message = event.data;
+    if (message.type === "slide") handlers.onSlide?.(message.slide);
+    if (message.type === "presenter-open") handlers.onPresenterOpen?.();
+    if (message.type === "presenter-closed") handlers.onPresenterClosed?.();
+  };
+  return () => channel.close();
+}

--- a/apps/web/src/routes/_components/slides/slides/00-black.tsx
+++ b/apps/web/src/routes/_components/slides/slides/00-black.tsx
@@ -1,7 +1,3 @@
-/**
- * Empty black opener. Lets the presenter start on a blank screen and click
- * forward into slide 01, so the title's entrance animation plays live.
- */
 export function Slide00Black() {
-  return <div className="h-full w-full" />;
+  return <div className="h-full w-full bg-zinc-950" />;
 }

--- a/apps/web/src/routes/_components/slides/slides/00-black.tsx
+++ b/apps/web/src/routes/_components/slides/slides/00-black.tsx
@@ -1,0 +1,7 @@
+/**
+ * Empty black opener. Lets the presenter start on a blank screen and click
+ * forward into slide 01, so the title's entrance animation plays live.
+ */
+export function Slide00Black() {
+  return <div className="h-full w-full" />;
+}

--- a/apps/web/src/routes/_components/slides/slides/01-title.tsx
+++ b/apps/web/src/routes/_components/slides/slides/01-title.tsx
@@ -1,0 +1,61 @@
+import { use } from "react";
+import { motion } from "motion/react";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+import {
+  SlideShell,
+  SlideBody,
+  SlideStepContext,
+} from "../_components/SlideShell";
+
+export function Slide01Title() {
+  const step = use(SlideStepContext);
+  const settled = step >= 1;
+
+  return (
+    <SlideShell center>
+      <div className="relative z-10 flex flex-col items-center text-center">
+        <motion.div
+          layout
+          transition={{ layout: { duration: 0.7, ease: [0.4, 0, 0.2, 1] } }}
+          className={settled ? "mb-6" : ""}
+        >
+          <span className="text-4xl font-semibold tracking-tight">Eva</span>
+        </motion.div>
+
+        {settled && (
+          <>
+            <BlurWordsTitle
+              lines={["AI agents that", "actually ship code."]}
+              size="3xl"
+              delay={0.3}
+            />
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: [0.4, 0, 0.2, 1], delay: 0.5 }}
+              className="mt-6 max-w-xl"
+            >
+              <SlideBody>
+                Connect your GitHub repos. Describe the work. Eva spins up a
+                sandbox, makes the changes, runs your tests, and opens a PR.
+              </SlideBody>
+            </motion.div>
+          </>
+        )}
+      </div>
+
+      {settled && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.6 }}
+          className="absolute bottom-10 left-0 right-0 flex justify-center"
+        >
+          <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted/60">
+            Vedant Bhopatrao
+          </p>
+        </motion.div>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/01-title.tsx
+++ b/apps/web/src/routes/_components/slides/slides/01-title.tsx
@@ -1,61 +1,30 @@
 import { use } from "react";
 import { motion } from "motion/react";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
-import {
-  SlideShell,
-  SlideBody,
-  SlideStepContext,
-} from "../_components/SlideShell";
+import { SlideStepContext } from "../_components/SlideShell";
 
 export function Slide01Title() {
   const step = use(SlideStepContext);
-  const settled = step >= 1;
-
   return (
-    <SlideShell center>
-      <div className="relative z-10 flex flex-col items-center text-center">
-        <motion.div
-          layout
-          transition={{ layout: { duration: 0.7, ease: [0.4, 0, 0.2, 1] } }}
-          className={settled ? "mb-6" : ""}
-        >
-          <span className="text-4xl font-semibold tracking-tight">Eva</span>
-        </motion.div>
+    <div className="relative flex h-full w-full flex-col items-center justify-center bg-zinc-950 px-20 py-16">
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+        className="text-center"
+      >
+        <span className="font-sans text-8xl font-semibold tracking-tight text-zinc-50">
+          Eva
+        </span>
+      </motion.div>
 
-        {settled && (
-          <>
-            <BlurWordsTitle
-              lines={["AI agents that", "actually ship code."]}
-              size="3xl"
-              delay={0.3}
-            />
-            <motion.div
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, ease: [0.4, 0, 0.2, 1], delay: 0.5 }}
-              className="mt-6 max-w-xl"
-            >
-              <SlideBody>
-                Connect your GitHub repos. Describe the work. Eva spins up a
-                sandbox, makes the changes, runs your tests, and opens a PR.
-              </SlideBody>
-            </motion.div>
-          </>
-        )}
-      </div>
-
-      {settled && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.5, delay: 0.6 }}
-          className="absolute bottom-10 left-0 right-0 flex justify-center"
-        >
-          <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted/60">
-            Vedant Bhopatrao
-          </p>
-        </motion.div>
-      )}
-    </SlideShell>
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={step >= 1 ? { opacity: 1 } : { opacity: 0 }}
+        transition={{ duration: 0.5, delay: 0.2 }}
+        className="mt-8 text-center font-sans text-2xl font-normal text-zinc-400"
+      >
+        An open-source AI dev platform
+      </motion.p>
+    </div>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/02-gap.tsx
+++ b/apps/web/src/routes/_components/slides/slides/02-gap.tsx
@@ -1,0 +1,50 @@
+import { use } from "react";
+import {
+  SlideShell,
+  SlideKicker,
+  SlideStagger,
+  SlideItem,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+const PROBLEMS = [
+  {
+    label: "Context",
+    desc: "Agents need your codebase, style guide, and CI — not a blank prompt.",
+  },
+  {
+    label: "Execution",
+    desc: "They need to run commands, not just generate text.",
+  },
+  {
+    label: "Review",
+    desc: "You need to see the diff, not trust a summary.",
+  },
+];
+
+export function Slide02Gap() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell>
+      <SlideKicker>The gap</SlideKicker>
+      <BlurWordsTitle lines={["AI demos vs.", "real engineering work."]} />
+
+      {step >= 1 && (
+        <SlideStagger className="mt-12 grid grid-cols-3 gap-8">
+          {PROBLEMS.map((p) => (
+            <SlideItem key={p.label}>
+              <div className="rounded-2xl bg-surface-secondary/60 p-6">
+                <p className="text-lg font-medium text-foreground">{p.label}</p>
+                <p className="mt-2 text-sm leading-relaxed text-muted">
+                  {p.desc}
+                </p>
+              </div>
+            </SlideItem>
+          ))}
+        </SlideStagger>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/02-gap.tsx
+++ b/apps/web/src/routes/_components/slides/slides/02-gap.tsx
@@ -18,7 +18,7 @@ export function Slide02Gap() {
         delay={0.15}
       />
       <SlideReveal step={2} delay={0.3}>
-        <p className="mt-10 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+        <p className="mt-10 max-w-2xl text-lg leading-relaxed text-foreground/70">
           Your context is scattered across chat windows, browser tabs, and
           terminal sessions. Eva brings it together in one unified workspace.
         </p>

--- a/apps/web/src/routes/_components/slides/slides/02-gap.tsx
+++ b/apps/web/src/routes/_components/slides/slides/02-gap.tsx
@@ -1,50 +1,28 @@
-import { use } from "react";
 import {
   SlideShell,
+  SlideReveal,
   SlideKicker,
-  SlideStagger,
-  SlideItem,
-  SlideStepContext,
 } from "../_components/SlideShell";
 import { BlurWordsTitle } from "../_components/BlurWordsTitle";
 
-const PROBLEMS = [
-  {
-    label: "Context",
-    desc: "Agents need your codebase, style guide, and CI — not a blank prompt.",
-  },
-  {
-    label: "Execution",
-    desc: "They need to run commands, not just generate text.",
-  },
-  {
-    label: "Review",
-    desc: "You need to see the diff, not trust a summary.",
-  },
-];
-
 export function Slide02Gap() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell>
-      <SlideKicker>The gap</SlideKicker>
-      <BlurWordsTitle lines={["AI demos vs.", "real engineering work."]} />
-
-      {step >= 1 && (
-        <SlideStagger className="mt-12 grid grid-cols-3 gap-8">
-          {PROBLEMS.map((p) => (
-            <SlideItem key={p.label}>
-              <div className="rounded-2xl bg-surface-secondary/60 p-6">
-                <p className="text-lg font-medium text-foreground">{p.label}</p>
-                <p className="mt-2 text-sm leading-relaxed text-muted">
-                  {p.desc}
-                </p>
-              </div>
-            </SlideItem>
-          ))}
-        </SlideStagger>
-      )}
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>The Problem</SlideKicker>
+      </SlideReveal>
+      <BlurWordsTitle
+        lines={["AI coding tools", "are siloed."]}
+        size="2xl"
+        step={1}
+        delay={0.15}
+      />
+      <SlideReveal step={2} delay={0.3}>
+        <p className="mt-10 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+          Your context is scattered across chat windows, browser tabs, and
+          terminal sessions. Eva brings it together in one unified workspace.
+        </p>
+      </SlideReveal>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/02-gap.tsx
+++ b/apps/web/src/routes/_components/slides/slides/02-gap.tsx
@@ -14,10 +14,10 @@ export function Slide02Gap() {
       <BlurWordsTitle
         lines={["AI coding tools", "are siloed."]}
         size="2xl"
-        step={1}
+        step={0}
         delay={0.15}
       />
-      <SlideReveal step={2} delay={0.3}>
+      <SlideReveal step={0} delay={0.8}>
         <p className="mt-10 max-w-2xl text-lg leading-relaxed text-foreground/70">
           Your context is scattered across chat windows, browser tabs, and
           terminal sessions. Eva brings it together in one unified workspace.

--- a/apps/web/src/routes/_components/slides/slides/03-quick-tasks.tsx
+++ b/apps/web/src/routes/_components/slides/slides/03-quick-tasks.tsx
@@ -1,0 +1,44 @@
+import { use } from "react";
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+  SlideStagger,
+  SlideItem,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+const EXAMPLES = [
+  "Fix this bug",
+  "Add a test for edge case",
+  "Update the copy here",
+  "Refactor this function",
+];
+
+export function Slide03QuickTasks() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell>
+      <SlideKicker>Quick tasks</SlideKicker>
+      <BlurWordsTitle lines={["Small changes,", "shipped fast."]} />
+      <SlideBody className="mt-6 max-w-2xl">
+        Describe the work. Eva spins up an isolated sandbox, makes the change,
+        and shows you the result. No boilerplate. No PR dance.
+      </SlideBody>
+
+      {step >= 1 && (
+        <SlideStagger className="mt-10 flex flex-wrap gap-3">
+          {EXAMPLES.map((ex) => (
+            <SlideItem key={ex}>
+              <span className="inline-flex items-center rounded-full bg-surface-secondary px-4 py-2 text-sm font-medium text-foreground/80">
+                "{ex}"
+              </span>
+            </SlideItem>
+          ))}
+        </SlideStagger>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/03-quick-tasks.tsx
+++ b/apps/web/src/routes/_components/slides/slides/03-quick-tasks.tsx
@@ -17,7 +17,7 @@ export function Slide03QuickTasks() {
       <SlideReveal delay={0.1}>
         <SlideTitle>Fire-and-forget prompts</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} delayChildren={0.2}>
+      <SlideStagger step={0} delayChildren={0.3}>
         <SlideItem>
           <SlideBullets
             items={[

--- a/apps/web/src/routes/_components/slides/slides/03-quick-tasks.tsx
+++ b/apps/web/src/routes/_components/slides/slides/03-quick-tasks.tsx
@@ -1,44 +1,33 @@
-import { use } from "react";
 import {
   SlideShell,
+  SlideReveal,
   SlideKicker,
-  SlideBody,
+  SlideTitle,
+  SlideBullets,
   SlideStagger,
   SlideItem,
-  SlideStepContext,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
-
-const EXAMPLES = [
-  "Fix this bug",
-  "Add a test for edge case",
-  "Update the copy here",
-  "Refactor this function",
-];
 
 export function Slide03QuickTasks() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell>
-      <SlideKicker>Quick tasks</SlideKicker>
-      <BlurWordsTitle lines={["Small changes,", "shipped fast."]} />
-      <SlideBody className="mt-6 max-w-2xl">
-        Describe the work. Eva spins up an isolated sandbox, makes the change,
-        and shows you the result. No boilerplate. No PR dance.
-      </SlideBody>
-
-      {step >= 1 && (
-        <SlideStagger className="mt-10 flex flex-wrap gap-3">
-          {EXAMPLES.map((ex) => (
-            <SlideItem key={ex}>
-              <span className="inline-flex items-center rounded-full bg-surface-secondary px-4 py-2 text-sm font-medium text-foreground/80">
-                "{ex}"
-              </span>
-            </SlideItem>
-          ))}
-        </SlideStagger>
-      )}
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>Quick Tasks</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle>Fire-and-forget prompts</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} delayChildren={0.2}>
+        <SlideItem>
+          <SlideBullets
+            items={[
+              "Write a prompt, Eva spins up a sandboxed agent",
+              "No context switching — return when it's done",
+              "Perfect for small refactors, docs, and experiments",
+            ]}
+          />
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/04-sessions.tsx
+++ b/apps/web/src/routes/_components/slides/slides/04-sessions.tsx
@@ -1,0 +1,43 @@
+import { use } from "react";
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+  SlideReveal,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+export function Slide04Sessions() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell>
+      <SlideKicker>Sessions</SlideKicker>
+      <BlurWordsTitle lines={["Long-lived", "dev environments."]} />
+      <SlideBody className="mt-6 max-w-2xl">
+        Describe what you're building. Eva sets up a sandbox with your app
+        running — preview, logs, terminal — and you iterate together.
+      </SlideBody>
+
+      {step >= 1 && (
+        <SlideReveal className="mt-10 rounded-2xl bg-surface-secondary/60 p-8">
+          <div className="grid grid-cols-3 gap-6 text-center">
+            <div>
+              <p className="text-3xl font-semibold text-foreground">Preview</p>
+              <p className="mt-1 text-sm text-muted">See your app running</p>
+            </div>
+            <div>
+              <p className="text-3xl font-semibold text-foreground">Logs</p>
+              <p className="mt-1 text-sm text-muted">Watch what happens</p>
+            </div>
+            <div>
+              <p className="text-3xl font-semibold text-foreground">Terminal</p>
+              <p className="mt-1 text-sm text-muted">Run any command</p>
+            </div>
+          </div>
+        </SlideReveal>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/04-sessions.tsx
+++ b/apps/web/src/routes/_components/slides/slides/04-sessions.tsx
@@ -1,43 +1,33 @@
-import { use } from "react";
 import {
   SlideShell,
-  SlideKicker,
-  SlideBody,
   SlideReveal,
-  SlideStepContext,
+  SlideKicker,
+  SlideTitle,
+  SlideBullets,
+  SlideStagger,
+  SlideItem,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
 
 export function Slide04Sessions() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell>
-      <SlideKicker>Sessions</SlideKicker>
-      <BlurWordsTitle lines={["Long-lived", "dev environments."]} />
-      <SlideBody className="mt-6 max-w-2xl">
-        Describe what you're building. Eva sets up a sandbox with your app
-        running — preview, logs, terminal — and you iterate together.
-      </SlideBody>
-
-      {step >= 1 && (
-        <SlideReveal className="mt-10 rounded-2xl bg-surface-secondary/60 p-8">
-          <div className="grid grid-cols-3 gap-6 text-center">
-            <div>
-              <p className="text-3xl font-semibold text-foreground">Preview</p>
-              <p className="mt-1 text-sm text-muted">See your app running</p>
-            </div>
-            <div>
-              <p className="text-3xl font-semibold text-foreground">Logs</p>
-              <p className="mt-1 text-sm text-muted">Watch what happens</p>
-            </div>
-            <div>
-              <p className="text-3xl font-semibold text-foreground">Terminal</p>
-              <p className="mt-1 text-sm text-muted">Run any command</p>
-            </div>
-          </div>
-        </SlideReveal>
-      )}
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>Sessions</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle>Persistent pair-programming</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} delayChildren={0.2}>
+        <SlideItem>
+          <SlideBullets
+            items={[
+              "Agent session that survives page reloads",
+              "Talk, iterate, branch, revert — full conversation history",
+              "Desktop-quality experience in the browser",
+            ]}
+          />
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/04-sessions.tsx
+++ b/apps/web/src/routes/_components/slides/slides/04-sessions.tsx
@@ -17,7 +17,7 @@ export function Slide04Sessions() {
       <SlideReveal delay={0.1}>
         <SlideTitle>Persistent pair-programming</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} delayChildren={0.2}>
+      <SlideStagger step={0} delayChildren={0.3}>
         <SlideItem>
           <SlideBullets
             items={[

--- a/apps/web/src/routes/_components/slides/slides/05-projects.tsx
+++ b/apps/web/src/routes/_components/slides/slides/05-projects.tsx
@@ -1,0 +1,42 @@
+import { use } from "react";
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+  SlideStagger,
+  SlideItem,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+const PHASES = ["Define the spec", "Break into phases", "Execute & track"];
+
+export function Slide05Projects() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell>
+      <SlideKicker>Projects</SlideKicker>
+      <BlurWordsTitle lines={["Larger features,", "planned and tracked."]} />
+      <SlideBody className="mt-6 max-w-2xl">
+        For work that spans multiple sessions or tasks. A product spec, broken
+        into phases, executed piece by piece.
+      </SlideBody>
+
+      {step >= 1 && (
+        <SlideStagger className="mt-10 flex gap-6">
+          {PHASES.map((phase, i) => (
+            <SlideItem key={phase}>
+              <div className="flex items-center gap-4 rounded-2xl bg-surface-secondary/60 px-6 py-4">
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-foreground/10 text-sm font-medium">
+                  {i + 1}
+                </span>
+                <p className="text-base font-medium text-foreground">{phase}</p>
+              </div>
+            </SlideItem>
+          ))}
+        </SlideStagger>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/05-projects.tsx
+++ b/apps/web/src/routes/_components/slides/slides/05-projects.tsx
@@ -17,7 +17,7 @@ export function Slide05Projects() {
       <SlideReveal delay={0.1}>
         <SlideTitle>Organize your work</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} delayChildren={0.2}>
+      <SlideStagger step={0} delayChildren={0.3}>
         <SlideItem>
           <SlideBullets
             items={[

--- a/apps/web/src/routes/_components/slides/slides/05-projects.tsx
+++ b/apps/web/src/routes/_components/slides/slides/05-projects.tsx
@@ -1,42 +1,33 @@
-import { use } from "react";
 import {
   SlideShell,
+  SlideReveal,
   SlideKicker,
-  SlideBody,
+  SlideTitle,
+  SlideBullets,
   SlideStagger,
   SlideItem,
-  SlideStepContext,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
-
-const PHASES = ["Define the spec", "Break into phases", "Execute & track"];
 
 export function Slide05Projects() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell>
-      <SlideKicker>Projects</SlideKicker>
-      <BlurWordsTitle lines={["Larger features,", "planned and tracked."]} />
-      <SlideBody className="mt-6 max-w-2xl">
-        For work that spans multiple sessions or tasks. A product spec, broken
-        into phases, executed piece by piece.
-      </SlideBody>
-
-      {step >= 1 && (
-        <SlideStagger className="mt-10 flex gap-6">
-          {PHASES.map((phase, i) => (
-            <SlideItem key={phase}>
-              <div className="flex items-center gap-4 rounded-2xl bg-surface-secondary/60 px-6 py-4">
-                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-foreground/10 text-sm font-medium">
-                  {i + 1}
-                </span>
-                <p className="text-base font-medium text-foreground">{phase}</p>
-              </div>
-            </SlideItem>
-          ))}
-        </SlideStagger>
-      )}
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>Projects</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle>Organize your work</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} delayChildren={0.2}>
+        <SlideItem>
+          <SlideBullets
+            items={[
+              "Group tasks, sessions, and documents by project",
+              "Per-project settings and credentials",
+              "Team visibility and collaboration",
+            ]}
+          />
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/06-documents.tsx
+++ b/apps/web/src/routes/_components/slides/slides/06-documents.tsx
@@ -1,19 +1,33 @@
 import {
   SlideShell,
+  SlideReveal,
   SlideKicker,
-  SlideBody,
+  SlideTitle,
+  SlideBullets,
+  SlideStagger,
+  SlideItem,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
 
 export function Slide06Documents() {
   return (
-    <SlideShell>
-      <SlideKicker>Documents</SlideKicker>
-      <BlurWordsTitle lines={["Specs, notes, context.", "First-class."]} />
-      <SlideBody className="mt-6 max-w-2xl">
-        Eva reads your documents while working. No copy-pasting into prompts.
-        Write it once, the agent knows what you're building.
-      </SlideBody>
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>Documents</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle>Structured context</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} delayChildren={0.2}>
+        <SlideItem>
+          <SlideBullets
+            items={[
+              "Attach PRDs, specs, and notes to any session",
+              "Markdown editor with live preview",
+              "Reference docs from prompts with @-mentions",
+            ]}
+          />
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/06-documents.tsx
+++ b/apps/web/src/routes/_components/slides/slides/06-documents.tsx
@@ -1,0 +1,19 @@
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+export function Slide06Documents() {
+  return (
+    <SlideShell>
+      <SlideKicker>Documents</SlideKicker>
+      <BlurWordsTitle lines={["Specs, notes, context.", "First-class."]} />
+      <SlideBody className="mt-6 max-w-2xl">
+        Eva reads your documents while working. No copy-pasting into prompts.
+        Write it once, the agent knows what you're building.
+      </SlideBody>
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/06-documents.tsx
+++ b/apps/web/src/routes/_components/slides/slides/06-documents.tsx
@@ -17,7 +17,7 @@ export function Slide06Documents() {
       <SlideReveal delay={0.1}>
         <SlideTitle>Structured context</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} delayChildren={0.2}>
+      <SlideStagger step={0} delayChildren={0.3}>
         <SlideItem>
           <SlideBullets
             items={[

--- a/apps/web/src/routes/_components/slides/slides/07-prs.tsx
+++ b/apps/web/src/routes/_components/slides/slides/07-prs.tsx
@@ -17,7 +17,7 @@ export function Slide07PRs() {
       <SlideReveal delay={0.1}>
         <SlideTitle>Ship without friction</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} delayChildren={0.2}>
+      <SlideStagger step={0} delayChildren={0.3}>
         <SlideItem>
           <SlideBullets
             items={[

--- a/apps/web/src/routes/_components/slides/slides/07-prs.tsx
+++ b/apps/web/src/routes/_components/slides/slides/07-prs.tsx
@@ -1,42 +1,33 @@
-import { use } from "react";
 import {
   SlideShell,
-  SlideKicker,
-  SlideBody,
   SlideReveal,
-  SlideStepContext,
+  SlideKicker,
+  SlideTitle,
+  SlideBullets,
+  SlideStagger,
+  SlideItem,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
 
 export function Slide07PRs() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell>
-      <SlideKicker>GitHub flow</SlideKicker>
-      <BlurWordsTitle lines={["Real PRs.", "Real review."]} />
-      <SlideBody className="mt-6 max-w-2xl">
-        When Eva finishes a task, it opens a PR. You review it like any other —
-        code, tests, CI status. No magic. Just code you can read.
-      </SlideBody>
-
-      {step >= 1 && (
-        <SlideReveal className="mt-10 rounded-2xl bg-surface-secondary/60 p-6">
-          <div className="flex items-center gap-4">
-            <div className="h-10 w-10 rounded-full bg-green-500/20 flex items-center justify-center">
-              <span className="text-green-600">✓</span>
-            </div>
-            <div>
-              <p className="font-medium text-foreground">
-                eva-bot opened a pull request
-              </p>
-              <p className="text-sm text-muted">
-                feat: Add user avatar to profile page
-              </p>
-            </div>
-          </div>
-        </SlideReveal>
-      )}
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>Pull Requests</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle>Ship without friction</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} delayChildren={0.2}>
+        <SlideItem>
+          <SlideBullets
+            items={[
+              "One-click PR creation from any task",
+              "Automatic branch naming and commit messages",
+              "Review diffs, CI status, and merge — all in Eva",
+            ]}
+          />
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/07-prs.tsx
+++ b/apps/web/src/routes/_components/slides/slides/07-prs.tsx
@@ -1,0 +1,42 @@
+import { use } from "react";
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+  SlideReveal,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+export function Slide07PRs() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell>
+      <SlideKicker>GitHub flow</SlideKicker>
+      <BlurWordsTitle lines={["Real PRs.", "Real review."]} />
+      <SlideBody className="mt-6 max-w-2xl">
+        When Eva finishes a task, it opens a PR. You review it like any other —
+        code, tests, CI status. No magic. Just code you can read.
+      </SlideBody>
+
+      {step >= 1 && (
+        <SlideReveal className="mt-10 rounded-2xl bg-surface-secondary/60 p-6">
+          <div className="flex items-center gap-4">
+            <div className="h-10 w-10 rounded-full bg-green-500/20 flex items-center justify-center">
+              <span className="text-green-600">✓</span>
+            </div>
+            <div>
+              <p className="font-medium text-foreground">
+                eva-bot opened a pull request
+              </p>
+              <p className="text-sm text-muted">
+                feat: Add user avatar to profile page
+              </p>
+            </div>
+          </div>
+        </SlideReveal>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/08-stack.tsx
+++ b/apps/web/src/routes/_components/slides/slides/08-stack.tsx
@@ -1,50 +1,48 @@
-import { use } from "react";
 import {
   SlideShell,
+  SlideReveal,
   SlideKicker,
+  SlideTitle,
   SlideStagger,
   SlideItem,
-  SlideReveal,
-  SlideStepContext,
+  SlideTag,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
-
-const STACK = [
-  { name: "React + Vite", desc: "Frontend" },
-  { name: "Convex", desc: "Real-time backend" },
-  { name: "Vercel", desc: "Sandboxes" },
-  { name: "Clerk", desc: "Auth" },
-  { name: "GitHub App", desc: "Repo access" },
-];
 
 export function Slide08Stack() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell>
-      <SlideKicker>Tech stack</SlideKicker>
-      <BlurWordsTitle lines={["Built on modern", "infrastructure."]} />
-
-      {step >= 1 && (
-        <SlideStagger className="mt-10 grid grid-cols-5 gap-4">
-          {STACK.map((s) => (
-            <SlideItem key={s.name}>
-              <div className="rounded-2xl bg-surface-secondary/60 p-4 text-center">
-                <p className="font-medium text-foreground">{s.name}</p>
-                <p className="mt-1 text-xs text-muted">{s.desc}</p>
-              </div>
-            </SlideItem>
-          ))}
-        </SlideStagger>
-      )}
-
-      {step >= 2 && (
-        <SlideReveal step={2} className="mt-8">
-          <p className="text-center text-lg font-medium text-foreground">
-            MIT open source
-          </p>
-        </SlideReveal>
-      )}
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>Tech Stack</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle size="xl">Built on proven foundations</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} className="mt-10 flex flex-wrap gap-3">
+        <SlideItem>
+          <SlideTag>React</SlideTag>
+        </SlideItem>
+        <SlideItem>
+          <SlideTag>Vite</SlideTag>
+        </SlideItem>
+        <SlideItem>
+          <SlideTag>Convex</SlideTag>
+        </SlideItem>
+        <SlideItem>
+          <SlideTag>TailwindCSS</SlideTag>
+        </SlideItem>
+        <SlideItem>
+          <SlideTag>Clerk</SlideTag>
+        </SlideItem>
+        <SlideItem>
+          <SlideTag>GitHub App</SlideTag>
+        </SlideItem>
+        <SlideItem>
+          <SlideTag>Vercel Sandboxes</SlideTag>
+        </SlideItem>
+        <SlideItem>
+          <SlideTag>TypeScript</SlideTag>
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/08-stack.tsx
+++ b/apps/web/src/routes/_components/slides/slides/08-stack.tsx
@@ -17,7 +17,7 @@ export function Slide08Stack() {
       <SlideReveal delay={0.1}>
         <SlideTitle size="xl">Built on proven foundations</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} className="mt-10 flex flex-wrap gap-3">
+      <SlideStagger step={0} delayChildren={0.3} className="mt-10 flex flex-wrap gap-3">
         <SlideItem>
           <SlideTag>React</SlideTag>
         </SlideItem>

--- a/apps/web/src/routes/_components/slides/slides/08-stack.tsx
+++ b/apps/web/src/routes/_components/slides/slides/08-stack.tsx
@@ -1,0 +1,50 @@
+import { use } from "react";
+import {
+  SlideShell,
+  SlideKicker,
+  SlideStagger,
+  SlideItem,
+  SlideReveal,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+const STACK = [
+  { name: "React + Vite", desc: "Frontend" },
+  { name: "Convex", desc: "Real-time backend" },
+  { name: "Vercel", desc: "Sandboxes" },
+  { name: "Clerk", desc: "Auth" },
+  { name: "GitHub App", desc: "Repo access" },
+];
+
+export function Slide08Stack() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell>
+      <SlideKicker>Tech stack</SlideKicker>
+      <BlurWordsTitle lines={["Built on modern", "infrastructure."]} />
+
+      {step >= 1 && (
+        <SlideStagger className="mt-10 grid grid-cols-5 gap-4">
+          {STACK.map((s) => (
+            <SlideItem key={s.name}>
+              <div className="rounded-2xl bg-surface-secondary/60 p-4 text-center">
+                <p className="font-medium text-foreground">{s.name}</p>
+                <p className="mt-1 text-xs text-muted">{s.desc}</p>
+              </div>
+            </SlideItem>
+          ))}
+        </SlideStagger>
+      )}
+
+      {step >= 2 && (
+        <SlideReveal step={2} className="mt-8">
+          <p className="text-center text-lg font-medium text-foreground">
+            MIT open source
+          </p>
+        </SlideReveal>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/09-github.tsx
+++ b/apps/web/src/routes/_components/slides/slides/09-github.tsx
@@ -17,7 +17,7 @@ export function Slide09GitHub() {
       <SlideReveal delay={0.1}>
         <SlideTitle>Native GitHub flow</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} delayChildren={0.2}>
+      <SlideStagger step={0} delayChildren={0.3}>
         <SlideItem>
           <SlideBullets
             items={[

--- a/apps/web/src/routes/_components/slides/slides/09-github.tsx
+++ b/apps/web/src/routes/_components/slides/slides/09-github.tsx
@@ -1,0 +1,19 @@
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+export function Slide09GitHub() {
+  return (
+    <SlideShell>
+      <SlideKicker>GitHub integration</SlideKicker>
+      <BlurWordsTitle lines={["Your repos.", "Your control."]} />
+      <SlideBody className="mt-6 max-w-2xl">
+        Eva connects via GitHub App. It clones your code, respects .gitignore,
+        and pushes to branches. You control what it can access.
+      </SlideBody>
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/09-github.tsx
+++ b/apps/web/src/routes/_components/slides/slides/09-github.tsx
@@ -1,19 +1,33 @@
 import {
   SlideShell,
+  SlideReveal,
   SlideKicker,
-  SlideBody,
+  SlideTitle,
+  SlideBullets,
+  SlideStagger,
+  SlideItem,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
 
 export function Slide09GitHub() {
   return (
-    <SlideShell>
-      <SlideKicker>GitHub integration</SlideKicker>
-      <BlurWordsTitle lines={["Your repos.", "Your control."]} />
-      <SlideBody className="mt-6 max-w-2xl">
-        Eva connects via GitHub App. It clones your code, respects .gitignore,
-        and pushes to branches. You control what it can access.
-      </SlideBody>
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>GitHub Integration</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle>Native GitHub flow</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} delayChildren={0.2}>
+        <SlideItem>
+          <SlideBullets
+            items={[
+              "GitHub App for secure repo access",
+              "Clone, branch, commit, push — all automated",
+              "Works with any GitHub org or personal account",
+            ]}
+          />
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/10-sandboxes.tsx
+++ b/apps/web/src/routes/_components/slides/slides/10-sandboxes.tsx
@@ -1,44 +1,33 @@
-import { use } from "react";
 import {
   SlideShell,
+  SlideReveal,
   SlideKicker,
-  SlideBody,
+  SlideTitle,
+  SlideBullets,
   SlideStagger,
   SlideItem,
-  SlideStepContext,
 } from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
-
-const FEATURES = [
-  "Full Linux environment",
-  "Your dependencies installed",
-  "Your tests run",
-  "Ephemeral — gone when done",
-];
 
 export function Slide10Sandboxes() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell>
-      <SlideKicker>Sandboxes</SlideKicker>
-      <BlurWordsTitle lines={["Isolated execution", "for every task."]} />
-      <SlideBody className="mt-6 max-w-2xl">
-        Each task or session gets its own isolated environment. Your code runs,
-        your tests run, your app runs — then it's gone.
-      </SlideBody>
-
-      {step >= 1 && (
-        <SlideStagger className="mt-10 flex flex-wrap gap-3">
-          {FEATURES.map((f) => (
-            <SlideItem key={f}>
-              <span className="inline-flex items-center rounded-full bg-surface-secondary px-4 py-2 text-sm font-medium text-foreground/80">
-                {f}
-              </span>
-            </SlideItem>
-          ))}
-        </SlideStagger>
-      )}
+    <SlideShell className="bg-background">
+      <SlideReveal>
+        <SlideKicker>Sandboxes</SlideKicker>
+      </SlideReveal>
+      <SlideReveal delay={0.1}>
+        <SlideTitle>Isolated execution</SlideTitle>
+      </SlideReveal>
+      <SlideStagger step={1} delayChildren={0.2}>
+        <SlideItem>
+          <SlideBullets
+            items={[
+              "Vercel-powered sandboxes for every task",
+              "Full Linux environment with shell access",
+              "Safe to experiment — nothing touches prod",
+            ]}
+          />
+        </SlideItem>
+      </SlideStagger>
     </SlideShell>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/10-sandboxes.tsx
+++ b/apps/web/src/routes/_components/slides/slides/10-sandboxes.tsx
@@ -17,7 +17,7 @@ export function Slide10Sandboxes() {
       <SlideReveal delay={0.1}>
         <SlideTitle>Isolated execution</SlideTitle>
       </SlideReveal>
-      <SlideStagger step={1} delayChildren={0.2}>
+      <SlideStagger step={0} delayChildren={0.3}>
         <SlideItem>
           <SlideBullets
             items={[

--- a/apps/web/src/routes/_components/slides/slides/10-sandboxes.tsx
+++ b/apps/web/src/routes/_components/slides/slides/10-sandboxes.tsx
@@ -1,0 +1,44 @@
+import { use } from "react";
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+  SlideStagger,
+  SlideItem,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+const FEATURES = [
+  "Full Linux environment",
+  "Your dependencies installed",
+  "Your tests run",
+  "Ephemeral — gone when done",
+];
+
+export function Slide10Sandboxes() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell>
+      <SlideKicker>Sandboxes</SlideKicker>
+      <BlurWordsTitle lines={["Isolated execution", "for every task."]} />
+      <SlideBody className="mt-6 max-w-2xl">
+        Each task or session gets its own isolated environment. Your code runs,
+        your tests run, your app runs — then it's gone.
+      </SlideBody>
+
+      {step >= 1 && (
+        <SlideStagger className="mt-10 flex flex-wrap gap-3">
+          {FEATURES.map((f) => (
+            <SlideItem key={f}>
+              <span className="inline-flex items-center rounded-full bg-surface-secondary px-4 py-2 text-sm font-medium text-foreground/80">
+                {f}
+              </span>
+            </SlideItem>
+          ))}
+        </SlideStagger>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/11-insight.tsx
+++ b/apps/web/src/routes/_components/slides/slides/11-insight.tsx
@@ -1,21 +1,76 @@
-import {
-  SlideShell,
-  SlideBody,
-} from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+import { use } from "react";
+import { motion } from "motion/react";
+import { SlideStepContext } from "../_components/SlideShell";
+
+const wordVariants = {
+  hidden: { opacity: 0, y: 8, filter: "blur(8px)" },
+  show: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
+  },
+};
 
 export function Slide11Insight() {
+  const step = use(SlideStepContext);
   return (
-    <SlideShell center>
-      <BlurWordsTitle
-        lines={["Agents need execution,", "not just generation."]}
-        size="3xl"
-      />
-      <SlideBody className="mt-8 max-w-xl text-center">
-        They need to run npm install. Run your build. See if the tests pass.
-        That's what makes the difference between "here's a diff" and "here's
-        working code".
-      </SlideBody>
-    </SlideShell>
+    <div className="relative flex h-full w-full flex-col items-start justify-center bg-zinc-950 px-20 py-16">
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+        className="mb-4 text-xs font-medium uppercase tracking-[0.22em] text-zinc-500"
+      >
+        Why Eva?
+      </motion.p>
+
+      <motion.h1
+        className="font-sans text-6xl font-semibold leading-tight tracking-tight text-zinc-50"
+        initial="hidden"
+        animate="show"
+        variants={{
+          hidden: {},
+          show: {
+            transition: {
+              staggerChildren: 0.2,
+              delayChildren: 0.15,
+            },
+          },
+        }}
+      >
+        {["Code", "is", "cheap."].map((word, i) => (
+          <motion.span
+            key={i}
+            variants={wordVariants}
+            className="inline-block"
+            style={{ marginRight: "0.22em" }}
+          >
+            {word}
+          </motion.span>
+        ))}
+        <br />
+        {["Context", "is", "expensive."].map((word, i) => (
+          <motion.span
+            key={i + 3}
+            variants={wordVariants}
+            className="inline-block"
+            style={{ marginRight: "0.22em" }}
+          >
+            {word}
+          </motion.span>
+        ))}
+      </motion.h1>
+
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={step >= 1 ? { opacity: 1 } : { opacity: 0 }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        className="mt-10 max-w-2xl text-lg leading-relaxed text-zinc-400"
+      >
+        Eva preserves your context across tasks, sessions, and projects — so
+        you spend less time re-explaining and more time shipping.
+      </motion.p>
+    </div>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/11-insight.tsx
+++ b/apps/web/src/routes/_components/slides/slides/11-insight.tsx
@@ -1,0 +1,21 @@
+import {
+  SlideShell,
+  SlideBody,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+export function Slide11Insight() {
+  return (
+    <SlideShell center>
+      <BlurWordsTitle
+        lines={["Agents need execution,", "not just generation."]}
+        size="3xl"
+      />
+      <SlideBody className="mt-8 max-w-xl text-center">
+        They need to run npm install. Run your build. See if the tests pass.
+        That's what makes the difference between "here's a diff" and "here's
+        working code".
+      </SlideBody>
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/12-demo.tsx
+++ b/apps/web/src/routes/_components/slides/slides/12-demo.tsx
@@ -1,18 +1,24 @@
-import {
-  SlideShell,
-  SlideKicker,
-  SlideBody,
-} from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+import { motion } from "motion/react";
 
 export function Slide12Demo() {
   return (
-    <SlideShell center>
-      <SlideKicker>Demo</SlideKicker>
-      <BlurWordsTitle lines={["Let's see it work."]} size="3xl" />
-      <SlideBody className="mt-6 max-w-xl text-center">
-        One quick task. Sandbox. Change. Tests. PR.
-      </SlideBody>
-    </SlideShell>
+    <div className="relative flex h-full w-full flex-col items-center justify-center bg-zinc-950 px-20 py-16">
+      <motion.h1
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+        className="font-sans text-7xl font-semibold tracking-tight text-zinc-50"
+      >
+        Demo
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.2 }}
+        className="mt-6 text-xl text-zinc-400"
+      >
+        Let's see it in action.
+      </motion.p>
+    </div>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/12-demo.tsx
+++ b/apps/web/src/routes/_components/slides/slides/12-demo.tsx
@@ -1,0 +1,18 @@
+import {
+  SlideShell,
+  SlideKicker,
+  SlideBody,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+export function Slide12Demo() {
+  return (
+    <SlideShell center>
+      <SlideKicker>Demo</SlideKicker>
+      <BlurWordsTitle lines={["Let's see it work."]} size="3xl" />
+      <SlideBody className="mt-6 max-w-xl text-center">
+        One quick task. Sandbox. Change. Tests. PR.
+      </SlideBody>
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/13-closing.tsx
+++ b/apps/web/src/routes/_components/slides/slides/13-closing.tsx
@@ -1,0 +1,31 @@
+import { use } from "react";
+import { motion } from "motion/react";
+import {
+  SlideShell,
+  SlideBody,
+  SlideStepContext,
+} from "../_components/SlideShell";
+import { BlurWordsTitle } from "../_components/BlurWordsTitle";
+
+export function Slide13Closing() {
+  const step = use(SlideStepContext);
+
+  return (
+    <SlideShell center>
+      <BlurWordsTitle lines={["Thank you."]} size="4xl" />
+
+      {step >= 1 && (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.3 }}
+          className="mt-10 space-y-3 text-center"
+        >
+          <SlideBody>eva.vedantb.com</SlideBody>
+          <SlideBody>github.com/vvedantb/eva</SlideBody>
+          <p className="text-sm text-muted">MIT open source</p>
+        </motion.div>
+      )}
+    </SlideShell>
+  );
+}

--- a/apps/web/src/routes/_components/slides/slides/13-closing.tsx
+++ b/apps/web/src/routes/_components/slides/slides/13-closing.tsx
@@ -1,31 +1,36 @@
-import { use } from "react";
 import { motion } from "motion/react";
-import {
-  SlideShell,
-  SlideBody,
-  SlideStepContext,
-} from "../_components/SlideShell";
-import { BlurWordsTitle } from "../_components/BlurWordsTitle";
 
 export function Slide13Closing() {
-  const step = use(SlideStepContext);
-
   return (
-    <SlideShell center>
-      <BlurWordsTitle lines={["Thank you."]} size="4xl" />
+    <div className="relative flex h-full w-full flex-col items-center justify-center bg-zinc-950 px-20 py-16">
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+        className="text-center"
+      >
+        <span className="font-sans text-7xl font-semibold tracking-tight text-zinc-50">
+          Eva
+        </span>
+      </motion.div>
 
-      {step >= 1 && (
-        <motion.div
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.3 }}
-          className="mt-10 space-y-3 text-center"
-        >
-          <SlideBody>eva.vedantb.com</SlideBody>
-          <SlideBody>github.com/vvedantb/eva</SlideBody>
-          <p className="text-sm text-muted">MIT open source</p>
-        </motion.div>
-      )}
-    </SlideShell>
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        className="mt-8 text-center font-sans text-xl font-normal text-zinc-400"
+      >
+        Open source · MIT licensed
+      </motion.p>
+
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.5 }}
+        className="mt-4 font-mono text-sm text-zinc-500"
+      >
+        github.com/vvedantb/eva
+      </motion.p>
+    </div>
   );
 }

--- a/apps/web/src/routes/_components/slides/slides/index.ts
+++ b/apps/web/src/routes/_components/slides/slides/index.ts
@@ -1,0 +1,133 @@
+import type { ComponentType } from "react";
+import { Slide00Black } from "./00-black";
+import { Slide01Title } from "./01-title";
+import { Slide02Gap } from "./02-gap";
+import { Slide03QuickTasks } from "./03-quick-tasks";
+import { Slide04Sessions } from "./04-sessions";
+import { Slide05Projects } from "./05-projects";
+import { Slide06Documents } from "./06-documents";
+import { Slide07PRs } from "./07-prs";
+import { Slide08Stack } from "./08-stack";
+import { Slide09GitHub } from "./09-github";
+import { Slide10Sandboxes } from "./10-sandboxes";
+import { Slide11Insight } from "./11-insight";
+import { Slide12Demo } from "./12-demo";
+import { Slide13Closing } from "./13-closing";
+
+export interface SlideEntry {
+  id: string;
+  title: string;
+  theme: "dark" | "light";
+  Component: ComponentType;
+  steps: number;
+  staggerMs?: number;
+}
+
+export const SLIDES: SlideEntry[] = [
+  // ── Act 1 · Open (dark) ──────────────────────────────────────────────
+  {
+    id: "00",
+    title: "Start",
+    theme: "dark",
+    Component: Slide00Black,
+    steps: 0,
+  },
+  {
+    id: "01",
+    title: "Title",
+    theme: "dark",
+    Component: Slide01Title,
+    steps: 1,
+  },
+
+  // ── Act 2 · The problem + features (light) ───────────────────────────
+  {
+    id: "02",
+    title: "The gap",
+    theme: "light",
+    Component: Slide02Gap,
+    steps: 1,
+  },
+  {
+    id: "03",
+    title: "Quick tasks",
+    theme: "light",
+    Component: Slide03QuickTasks,
+    steps: 1,
+  },
+  {
+    id: "04",
+    title: "Sessions",
+    theme: "light",
+    Component: Slide04Sessions,
+    steps: 1,
+  },
+  {
+    id: "05",
+    title: "Projects",
+    theme: "light",
+    Component: Slide05Projects,
+    steps: 1,
+  },
+  {
+    id: "06",
+    title: "Documents",
+    theme: "light",
+    Component: Slide06Documents,
+    steps: 0,
+  },
+  {
+    id: "07",
+    title: "GitHub flow",
+    theme: "light",
+    Component: Slide07PRs,
+    steps: 1,
+  },
+
+  // ── Act 3 · Tech + how it works (light) ──────────────────────────────
+  {
+    id: "08",
+    title: "Tech stack",
+    theme: "light",
+    Component: Slide08Stack,
+    steps: 2,
+    staggerMs: 1200,
+  },
+  {
+    id: "09",
+    title: "GitHub integration",
+    theme: "light",
+    Component: Slide09GitHub,
+    steps: 0,
+  },
+  {
+    id: "10",
+    title: "Sandboxes",
+    theme: "light",
+    Component: Slide10Sandboxes,
+    steps: 1,
+  },
+
+  // ── Act 4 · Key insight + demo + close (dark) ────────────────────────
+  {
+    id: "11",
+    title: "Key insight",
+    theme: "dark",
+    Component: Slide11Insight,
+    steps: 0,
+  },
+  {
+    id: "12",
+    title: "Demo",
+    theme: "dark",
+    Component: Slide12Demo,
+    steps: 0,
+  },
+  {
+    id: "13",
+    title: "Closing",
+    theme: "dark",
+    Component: Slide13Closing,
+    steps: 1,
+  },
+];

--- a/apps/web/src/routes/_components/slides/slides/index.ts
+++ b/apps/web/src/routes/_components/slides/slides/index.ts
@@ -37,7 +37,7 @@ export const SLIDES: SlideEntry[] = [
     title: "Title",
     theme: "dark",
     Component: Slide01Title,
-    steps: 1,
+    steps: 0,
   },
 
   // ── Act 2 · The problem + features (light) ───────────────────────────
@@ -46,28 +46,28 @@ export const SLIDES: SlideEntry[] = [
     title: "The gap",
     theme: "light",
     Component: Slide02Gap,
-    steps: 1,
+    steps: 0,
   },
   {
     id: "03",
     title: "Quick tasks",
     theme: "light",
     Component: Slide03QuickTasks,
-    steps: 1,
+    steps: 0,
   },
   {
     id: "04",
     title: "Sessions",
     theme: "light",
     Component: Slide04Sessions,
-    steps: 1,
+    steps: 0,
   },
   {
     id: "05",
     title: "Projects",
     theme: "light",
     Component: Slide05Projects,
-    steps: 1,
+    steps: 0,
   },
   {
     id: "06",
@@ -81,7 +81,7 @@ export const SLIDES: SlideEntry[] = [
     title: "GitHub flow",
     theme: "light",
     Component: Slide07PRs,
-    steps: 1,
+    steps: 0,
   },
 
   // ── Act 3 · Tech + how it works (light) ──────────────────────────────
@@ -90,8 +90,7 @@ export const SLIDES: SlideEntry[] = [
     title: "Tech stack",
     theme: "light",
     Component: Slide08Stack,
-    steps: 2,
-    staggerMs: 1200,
+    steps: 0,
   },
   {
     id: "09",
@@ -105,7 +104,7 @@ export const SLIDES: SlideEntry[] = [
     title: "Sandboxes",
     theme: "light",
     Component: Slide10Sandboxes,
-    steps: 1,
+    steps: 0,
   },
 
   // ── Act 4 · Key insight + demo + close (dark) ────────────────────────
@@ -128,6 +127,6 @@ export const SLIDES: SlideEntry[] = [
     title: "Closing",
     theme: "dark",
     Component: Slide13Closing,
-    steps: 1,
+    steps: 0,
   },
 ];

--- a/apps/web/src/routes/_components/slides/speakerNotes.ts
+++ b/apps/web/src/routes/_components/slides/speakerNotes.ts
@@ -1,0 +1,86 @@
+import { SLIDES } from "./slides/index";
+
+interface SpeakerNotes {
+  slideTitle: string;
+  notes: string;
+}
+
+const NOTES: Record<string, string> = {
+  "00": "",
+  "01": `Welcome — this is Eva.
+
+Eva is a platform for AI agents that actually ship code.
+Not a chatbot that suggests diffs. Not an autocomplete.
+Agents that clone your repo, run your tests, and open real PRs.`,
+
+  "02": `The gap between AI demos and real work is:
+- Context: the agent needs your codebase, your style, your CI.
+- Execution: it needs a place to run commands, not just generate text.
+- Review: you need to see what it did, not just trust a summary.`,
+
+  "03": `Quick tasks are the simplest unit.
+"Fix this bug", "Add a test", "Update this copy".
+Eva spins up an isolated sandbox, does the work, and shows you the result.
+No boilerplate. No PR dance. Just a diff you can merge.`,
+
+  "04": `Sessions are longer-lived dev environments.
+You describe what you're building, Eva sets up a sandbox with your app running.
+You iterate together — you can see the preview, the logs, the terminal.
+It's like pairing with someone who never gets tired.`,
+
+  "05": `Projects are for larger features that span multiple sessions or tasks.
+A product spec, broken into phases, tracked over time.
+Eva reads your docs, plans the work, and executes it piece by piece.`,
+
+  "06": `Documents are first-class. Specs, notes, context.
+Eva reads them while working, so the agent knows what you're building.
+No copy-pasting into prompts. Just write it once.`,
+
+  "07": `When Eva finishes a task, it opens a PR.
+You review it like any other PR — code, tests, CI status.
+No magic. No hidden prompts. Just code you can read.`,
+
+  "08": `The stack:
+- React + Vite for the frontend
+- Convex for the backend (real-time, type-safe)
+- Vercel sandboxes for isolated execution
+- Clerk for auth
+- GitHub App for repo access
+
+It's MIT open source.`,
+
+  "09": `Eva connects to your GitHub repos.
+It clones the code, respects your .gitignore, and pushes to branches.
+You control what it can access.`,
+
+  "10": `Sandboxes are ephemeral VMs.
+Each task or session gets its own isolated environment.
+Your code runs, your tests run, your app runs — then it's gone.`,
+
+  "11": `The key insight: agents need execution, not just generation.
+They need to run npm install. Run your build. See if the tests pass.
+That's what makes the difference between "here's a diff" and "here's working code".`,
+
+  "12": `The demo: you'll see Eva take a quick task, spin up a sandbox,
+make the change, run the tests, and open a PR.
+All from a one-line description.`,
+
+  "13": `Thank you.
+
+Eva is live at eva.vedantb.com
+GitHub: github.com/vvedantb/eva
+MIT open source — run it yourself.`,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function getSpeakerNotes(slideNumber: number): SpeakerNotes {
+  const index = clamp(slideNumber - 1, 0, SLIDES.length - 1);
+  const entry = SLIDES[index];
+  return {
+    slideTitle: entry.title,
+    notes: NOTES[entry.id] ?? "",
+  };
+}

--- a/apps/web/src/routes/_components/slides/usePresentationSync.ts
+++ b/apps/web/src/routes/_components/slides/usePresentationSync.ts
@@ -1,0 +1,161 @@
+import { useState, useSyncExternalStore } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@eva/backend";
+
+const PARTICIPANT_KEY_STORAGE = "eva:presentation-participant-key";
+const hostKeyStorage = (code: string) => `eva:presentation-host:${code}`;
+
+function readParticipantKey(): string {
+  if (typeof window === "undefined") return "";
+  const existing = window.localStorage.getItem(PARTICIPANT_KEY_STORAGE);
+  if (existing) return existing;
+  const key = crypto.randomUUID();
+  window.localStorage.setItem(PARTICIPANT_KEY_STORAGE, key);
+  return key;
+}
+
+interface UsePresentationSyncArgs {
+  slide: number;
+  sessionCode: string | undefined;
+  updateSearch: (next: { slide?: number; session?: string }) => void;
+}
+
+export type SessionState =
+  | "none"
+  | "loading"
+  | "live"
+  | "ended"
+  | "notfound";
+
+export function usePresentationSync({
+  slide,
+  sessionCode,
+  updateSearch,
+}: UsePresentationSyncArgs) {
+  const [participantKey] = useState(readParticipantKey);
+
+  const [hostKey, setHostKey] = useState<string | null>(() =>
+    typeof window !== "undefined" && sessionCode
+      ? window.localStorage.getItem(hostKeyStorage(sessionCode))
+      : null,
+  );
+
+  useSyncExternalStore(
+    (onStoreChange) => {
+      if (typeof window === "undefined" || !sessionCode) {
+        setHostKey(null);
+        return () => {};
+      }
+      setHostKey(window.localStorage.getItem(hostKeyStorage(sessionCode)));
+      return () => {};
+    },
+    () => sessionCode ?? "",
+    () => sessionCode ?? "",
+  );
+
+  const isHost = hostKey !== null;
+
+  const [mode, setMode] = useState<"following" | "private">("following");
+
+  useSyncExternalStore(
+    () => {
+      setMode("following");
+      return () => {};
+    },
+    () => sessionCode ?? "",
+    () => sessionCode ?? "",
+  );
+
+  const session = useQuery(
+    api.presentations.getSession,
+    sessionCode && !isHost ? { code: sessionCode } : "skip",
+  );
+
+  const createSessionMut = useMutation(api.presentations.createSession);
+  const setSlideMut = useMutation(api.presentations.setSlide);
+  const stopSharingMut = useMutation(api.presentations.stopSharing);
+
+  const [isStarting, setIsStarting] = useState(false);
+
+  const sessionState: SessionState = !sessionCode
+    ? "none"
+    : isHost
+      ? "live"
+      : session === undefined
+        ? "loading"
+        : session === null
+          ? "notfound"
+          : session.status;
+
+  const isFollowing =
+    !isHost && mode === "following" && sessionState === "live";
+  const effectiveSlide =
+    isFollowing && session && session.status === "live" ? session.slide : slide;
+
+  const onNavigate = (target: number) => {
+    if (isHost && hostKey && sessionCode) {
+      updateSearch({ slide: target });
+      void setSlideMut({ code: sessionCode, hostKey, slide: target }).catch(
+        () => undefined,
+      );
+      return;
+    }
+    if (sessionCode && mode === "following") {
+      setMode("private");
+    }
+    updateSearch({ slide: target });
+  };
+
+  const startSharing = async () => {
+    setIsStarting(true);
+    try {
+      const result = await createSessionMut({ slide });
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(
+          hostKeyStorage(result.code),
+          result.hostKey,
+        );
+      }
+      setHostKey(result.hostKey);
+      updateSearch({ session: result.code });
+    } finally {
+      setIsStarting(false);
+    }
+  };
+
+  const stopSharing = async () => {
+    if (!sessionCode || !hostKey) return;
+    await stopSharingMut({ code: sessionCode, hostKey }).catch(() => undefined);
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(hostKeyStorage(sessionCode));
+    }
+    setHostKey(null);
+    updateSearch({ session: undefined });
+  };
+
+  const backToLive = () => {
+    setMode("following");
+  };
+
+  const shareUrl =
+    sessionCode && typeof window !== "undefined"
+      ? `${window.location.origin}/slides?session=${sessionCode}`
+      : null;
+
+  return {
+    isHost,
+    mode,
+    sessionState,
+    effectiveSlide,
+    onNavigate,
+    participantKey,
+    hostKey,
+    startSharing,
+    stopSharing,
+    backToLive,
+    shareUrl,
+    isStarting,
+  };
+}
+
+export type PresentationSync = ReturnType<typeof usePresentationSync>;

--- a/apps/web/src/routes/slides.tsx
+++ b/apps/web/src/routes/slides.tsx
@@ -1,0 +1,114 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
+import { useMemo, useState, useSyncExternalStore } from "react";
+import { SlideDeck } from "./_components/slides/SlideDeck";
+import { usePresentationSync } from "./_components/slides/usePresentationSync";
+import { PresentationControls } from "./_components/slides/_components/PresentationControls";
+import { PresentationDeckProvider } from "./_components/slides/_components/PresentationDeckContext";
+import { PresenterView } from "./_components/slides/PresenterView";
+import {
+  openPresenterWindow,
+  subscribePresenterChannel,
+} from "./_components/slides/presenterWindowSync";
+
+const searchSchema = z.object({
+  slide: z.number().int().min(1).optional().default(1),
+  session: z.coerce.string().optional(),
+  view: z.enum(["presenter"]).optional(),
+});
+
+export const Route = createFileRoute("/slides")({
+  validateSearch: searchSchema,
+  component: SlidesPage,
+});
+
+function SlidesPage() {
+  const { slide, session, view } = Route.useSearch();
+  const navigate = useNavigate({ from: "/slides" });
+
+  const updateSearch = (next: { slide?: number; session?: string }) => {
+    void navigate({
+      search: (prev) => ({ ...prev, ...next }),
+      replace: true,
+    });
+  };
+
+  if (view === "presenter") {
+    return (
+      <PresenterView
+        slide={slide}
+        session={session}
+        updateSearch={updateSearch}
+      />
+    );
+  }
+
+  return (
+    <StageView slide={slide} session={session} updateSearch={updateSearch} />
+  );
+}
+
+interface StageViewProps {
+  slide: number;
+  session: string | undefined;
+  updateSearch: (next: { slide?: number; session?: string }) => void;
+}
+
+function StageView({ slide, session, updateSearch }: StageViewProps) {
+  const [presenterDetached, setPresenterDetached] = useState(false);
+
+  useSyncExternalStore(
+    () => {
+      return subscribePresenterChannel({
+        onSlide: (nextSlide) => updateSearch({ slide: nextSlide }),
+        onPresenterOpen: () => setPresenterDetached(true),
+        onPresenterClosed: () => setPresenterDetached(false),
+      });
+    },
+    () => presenterDetached,
+    () => presenterDetached,
+  );
+
+  const sync = usePresentationSync({
+    slide,
+    sessionCode: session,
+    updateSearch,
+  });
+
+  const deckContext = useMemo(
+    () => ({
+      sessionCode: session,
+      participantKey: sync.participantKey,
+      hostKey: sync.hostKey,
+    }),
+    [session, sync.participantKey, sync.hostKey],
+  );
+
+  const isFollower =
+    session !== undefined &&
+    sync.sessionState !== "none" &&
+    sync.sessionState !== "notfound" &&
+    !sync.isHost;
+  const canDrive = !isFollower;
+  const canOpenPresenter = session === undefined || sync.isHost;
+  const stageNavigation = canDrive && !presenterDetached;
+
+  return (
+    <>
+      <PresentationDeckProvider value={deckContext}>
+        <SlideDeck
+          slide={sync.effectiveSlide}
+          onNavigate={sync.onNavigate}
+          allowNavigation={stageNavigation}
+          showOutline={!presenterDetached}
+        />
+      </PresentationDeckProvider>
+      <PresentationControls
+        sync={sync}
+        canOpenPresenter={canOpenPresenter}
+        presenterDetached={presenterDetached}
+        onOpenPresenter={openPresenterWindow}
+      />
+    </>
+  );
+}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -136,7 +136,6 @@ export const themeExtend = {
   fontFamily: {
     sans: ["var(--font-sans)"],
     mono: ["var(--font-mono)"],
-    instrumentSerif: ['"Instrument Serif"', "Georgia", "serif"],
   },
   // Do NOT add `transitionDuration.DEFAULT` / `transitionTimingFunction.DEFAULT`
   // here. A v3-config override of either one makes Tailwind v4 drop its own

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -136,6 +136,7 @@ export const themeExtend = {
   fontFamily: {
     sans: ["var(--font-sans)"],
     mono: ["var(--font-mono)"],
+    instrumentSerif: ['"Instrument Serif"', "Georgia", "serif"],
   },
   // Do NOT add `transitionDuration.DEFAULT` / `transitionTimingFunction.DEFAULT`
   // here. A v3-config override of either one makes Tailwind v4 drop its own

--- a/packages/backend/convex/presentations.ts
+++ b/packages/backend/convex/presentations.ts
@@ -1,0 +1,352 @@
+import { v } from "convex/values";
+import {
+  mutation,
+  query,
+  internalMutation,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+
+/**
+ * Live sharing for the `/slides` deck — "follow the presenter" (Teams-style),
+ * without take-control. The presenter is the sole driver: only the browser
+ * holding the secret `hostKey` (returned once from `createSession`) may move
+ * the deck. Viewers are anonymous — they subscribe to `getSession` and either
+ * follow `slide` live or detach to browse on their own.
+ *
+ * Every function is PUBLIC (the `/slides` route is reachable without sign-in).
+ * Deliberately lean: no auth, no presence, no names — just a session row,
+ * pruned daily.
+ */
+
+const SESSION_MAX_IDLE_MS = 24 * 60 * 60 * 1000;
+const CODE_LENGTH = 7;
+
+function tallyPollVotes(
+  votes: Array<{
+    participantKey: string;
+    optionId: string;
+  }>,
+): { counts: Map<string, number>; total: number } {
+  const seen = new Set<string>();
+  const counts = new Map<string, number>();
+  for (const vote of votes) {
+    const key = `${vote.participantKey}\0${vote.optionId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    counts.set(vote.optionId, (counts.get(vote.optionId) ?? 0) + 1);
+  }
+  return { counts, total: seen.size };
+}
+
+async function getSessionByCode(
+  ctx: QueryCtx | MutationCtx,
+  code: string,
+): Promise<Doc<"presentationSessions"> | null> {
+  return await ctx.db
+    .query("presentationSessions")
+    .withIndex("by_code", (q) => q.eq("code", code))
+    .first();
+}
+
+async function patchSession(
+  ctx: MutationCtx,
+  session: Doc<"presentationSessions">,
+  patch: Partial<Pick<Doc<"presentationSessions">, "slide" | "status">>,
+): Promise<void> {
+  await ctx.db.patch(session._id, { ...patch, lastActiveAt: Date.now() });
+}
+
+async function deleteParticipantOptionVotes(
+  ctx: MutationCtx,
+  args: {
+    code: string;
+    pollId: string;
+    participantKey: string;
+    optionId: string;
+  },
+): Promise<void> {
+  const rows = await ctx.db
+    .query("presentationVotes")
+    .withIndex("by_code_poll_participant_option", (q) =>
+      q
+        .eq("code", args.code)
+        .eq("pollId", args.pollId)
+        .eq("participantKey", args.participantKey)
+        .eq("optionId", args.optionId),
+    )
+    .collect();
+  for (const row of rows) {
+    await ctx.db.delete(row._id);
+  }
+}
+
+function isNumberLikeCode(code: string): boolean {
+  return /^\d+(e\d+)?$/.test(code);
+}
+
+async function generateUniqueCode(ctx: MutationCtx): Promise<string> {
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const code = crypto.randomUUID().replace(/-/g, "").slice(0, CODE_LENGTH);
+    if (isNumberLikeCode(code)) continue;
+    const existing = await getSessionByCode(ctx, code);
+    if (!existing) return code;
+  }
+  throw new Error("Could not generate a unique session code");
+}
+
+export const createSession = mutation({
+  args: { slide: v.number() },
+  returns: v.object({ code: v.string(), hostKey: v.string() }),
+  handler: async (ctx, args) => {
+    const code = await generateUniqueCode(ctx);
+    const hostKey = crypto.randomUUID();
+    await ctx.db.insert("presentationSessions", {
+      code,
+      hostKey,
+      slide: args.slide,
+      status: "live",
+      lastActiveAt: Date.now(),
+    });
+    return { code, hostKey };
+  },
+});
+
+export const getSession = query({
+  args: { code: v.string() },
+  returns: v.union(
+    v.object({
+      slide: v.number(),
+      status: v.union(v.literal("live"), v.literal("ended")),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const session = await getSessionByCode(ctx, args.code);
+    if (!session) return null;
+    return { slide: session.slide, status: session.status };
+  },
+});
+
+export const setSlide = mutation({
+  args: { code: v.string(), hostKey: v.string(), slide: v.number() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const session = await getSessionByCode(ctx, args.code);
+    if (
+      !session ||
+      session.hostKey !== args.hostKey ||
+      session.status !== "live"
+    ) {
+      return null;
+    }
+    await patchSession(ctx, session, { slide: args.slide });
+    return null;
+  },
+});
+
+export const stopSharing = mutation({
+  args: { code: v.string(), hostKey: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const session = await getSessionByCode(ctx, args.code);
+    if (!session || session.hostKey !== args.hostKey) return null;
+    await patchSession(ctx, session, { status: "ended" });
+    return null;
+  },
+});
+
+export const sendVote = mutation({
+  args: {
+    code: v.string(),
+    pollId: v.string(),
+    participantKey: v.string(),
+    optionId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const session = await getSessionByCode(ctx, args.code);
+    if (!session || session.status !== "live") return null;
+
+    const prior = await ctx.db
+      .query("presentationVotes")
+      .withIndex("by_code_poll_participant", (q) =>
+        q
+          .eq("code", args.code)
+          .eq("pollId", args.pollId)
+          .eq("participantKey", args.participantKey),
+      )
+      .collect();
+    for (const vote of prior) {
+      await ctx.db.delete(vote._id);
+    }
+    await ctx.db.insert("presentationVotes", {
+      code: args.code,
+      pollId: args.pollId,
+      participantKey: args.participantKey,
+      optionId: args.optionId,
+    });
+    await patchSession(ctx, session, {});
+    return null;
+  },
+});
+
+export const togglePollOption = mutation({
+  args: {
+    code: v.string(),
+    pollId: v.string(),
+    participantKey: v.string(),
+    optionId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const session = await getSessionByCode(ctx, args.code);
+    if (!session || session.status !== "live") return null;
+
+    const existing = await ctx.db
+      .query("presentationVotes")
+      .withIndex("by_code_poll_participant_option", (q) =>
+        q
+          .eq("code", args.code)
+          .eq("pollId", args.pollId)
+          .eq("participantKey", args.participantKey)
+          .eq("optionId", args.optionId),
+      )
+      .first();
+    if (existing) {
+      await deleteParticipantOptionVotes(ctx, args);
+    } else {
+      await ctx.db.insert("presentationVotes", {
+        code: args.code,
+        pollId: args.pollId,
+        participantKey: args.participantKey,
+        optionId: args.optionId,
+      });
+    }
+    await patchSession(ctx, session, {});
+    return null;
+  },
+});
+
+export const getMyPollSelections = query({
+  args: {
+    code: v.string(),
+    pollId: v.string(),
+    participantKey: v.string(),
+  },
+  returns: v.array(v.string()),
+  handler: async (ctx, args) => {
+    const votes = await ctx.db
+      .query("presentationVotes")
+      .withIndex("by_code_poll_participant", (q) =>
+        q
+          .eq("code", args.code)
+          .eq("pollId", args.pollId)
+          .eq("participantKey", args.participantKey),
+      )
+      .collect();
+    const seen = new Set<string>();
+    const optionIds: string[] = [];
+    for (const vote of votes) {
+      if (seen.has(vote.optionId)) continue;
+      seen.add(vote.optionId);
+      optionIds.push(vote.optionId);
+    }
+    return optionIds;
+  },
+});
+
+export const clearPollVotes = mutation({
+  args: { code: v.string(), hostKey: v.string(), pollId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const session = await getSessionByCode(ctx, args.code);
+    if (
+      !session ||
+      session.hostKey !== args.hostKey ||
+      session.status !== "live"
+    ) {
+      return null;
+    }
+
+    const votes = await ctx.db
+      .query("presentationVotes")
+      .withIndex("by_code_poll", (q) =>
+        q.eq("code", args.code).eq("pollId", args.pollId),
+      )
+      .collect();
+    for (const vote of votes) {
+      await ctx.db.delete(vote._id);
+    }
+    await patchSession(ctx, session, {});
+    return null;
+  },
+});
+
+export const pollResults = query({
+  args: { code: v.string(), pollId: v.string() },
+  returns: v.object({
+    options: v.array(v.object({ optionId: v.string(), count: v.number() })),
+    total: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const votes = await ctx.db
+      .query("presentationVotes")
+      .withIndex("by_code_poll", (q) =>
+        q.eq("code", args.code).eq("pollId", args.pollId),
+      )
+      .collect();
+    const { counts, total } = tallyPollVotes(votes);
+    return {
+      options: [...counts.entries()].map(([optionId, count]) => ({
+        optionId,
+        count,
+      })),
+      total,
+    };
+  },
+});
+
+export const dedupePollVotesInternal = internalMutation({
+  args: {},
+  returns: v.object({ removed: v.number() }),
+  handler: async (ctx) => {
+    const votes = await ctx.db.query("presentationVotes").collect();
+    const seen = new Set<string>();
+    let removed = 0;
+    for (const vote of votes) {
+      const key = `${vote.code}\0${vote.pollId}\0${vote.participantKey}\0${vote.optionId}`;
+      if (seen.has(key)) {
+        await ctx.db.delete(vote._id);
+        removed += 1;
+      } else {
+        seen.add(key);
+      }
+    }
+    return { removed };
+  },
+});
+
+export const pruneStaleInternal = internalMutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const cutoff = Date.now() - SESSION_MAX_IDLE_MS;
+    const sessions = await ctx.db.query("presentationSessions").collect();
+    for (const session of sessions) {
+      if (session.status !== "ended" && session.lastActiveAt >= cutoff) {
+        continue;
+      }
+      const votes = await ctx.db
+        .query("presentationVotes")
+        .withIndex("by_code_poll", (q) => q.eq("code", session.code))
+        .collect();
+      for (const vote of votes) {
+        await ctx.db.delete(vote._id);
+      }
+      await ctx.db.delete(session._id);
+    }
+    return null;
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -468,6 +468,33 @@ const schema = defineSchema({
     "userId",
     "repoId",
   ]),
+
+  // Live sharing for the `/slides` deck — "follow the presenter" (Teams-style).
+  // The presenter is the sole driver: only the browser holding the secret
+  // `hostKey` (returned once from `createSession`) may move the deck.
+  presentationSessions: defineTable({
+    code: v.string(),
+    hostKey: v.string(),
+    slide: v.number(),
+    status: v.union(v.literal("live"), v.literal("ended")),
+    lastActiveAt: v.number(),
+  }).index("by_code", ["code"]),
+
+  // Per-participant poll votes within a presentation session.
+  presentationVotes: defineTable({
+    code: v.string(),
+    pollId: v.string(),
+    participantKey: v.string(),
+    optionId: v.string(),
+  })
+    .index("by_code_poll", ["code", "pollId"])
+    .index("by_code_poll_participant", ["code", "pollId", "participantKey"])
+    .index("by_code_poll_participant_option", [
+      "code",
+      "pollId",
+      "participantKey",
+      "optionId",
+    ]),
 });
 
 export default schema;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Eva Presentation Deck

A `/slides` route for presenting Eva's features, adapted from vmem's slide system.

### Features
- 14 Eva-specific slides covering: quick tasks, sessions, projects, documents, PRs, tech stack, GitHub integration, sandboxes
- Keyboard navigation (arrows, space, home/end, F for fullscreen)
- Click navigation (left third = back, right third = forward)
- Slide outline panel (collapsible)
- Presenter view with speaker notes
- Live sharing via Convex (Teams-style "follow the presenter")
- Iframe-friendly (no auth wall, no X-Frame-Options DENY)

### Technical Details
- Uses Eva's Inter font (via `font-sans`)
- Respects Eva's theme system — light slides adapt to user's theme, dark slides (opener/closer) use explicit zinc colors
- Eva design tokens: `bg-background`, `text-foreground`, `text-muted-foreground`, `bg-card`, `border-border`, etc.
- Animations via `motion/react` with Eva's motion tokens
- Convex tables: `presentationSessions`, `presentationVotes`

### Routes
- `/slides` — main deck view
- `/slides?view=presenter` — presenter notes view
- `/slides?session=CODE` — join a live session

### Fixes (latest commit)
- Removed Instrument Serif font, now uses Inter
- Removed theme enforcement that was fighting Eva's theme system
- Updated all components to use proper Eva design tokens
- Fixed invisible text contrast issues in both light and dark modes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d0fd64e-6c82-495f-93ac-16a3805f43e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d0fd64e-6c82-495f-93ac-16a3805f43e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

