### PR TITLE
ci: Wake Grok automerge on ready_for_review

### DIFF
--- a/.github/workflows/grok-automerge-ready.yml
+++ b/.github/workflows/grok-automerge-ready.yml
@@ -1,0 +1,32 @@
+# Secrets required (add in GitHub Settings → Secrets):
+#   GROK_BOT_WEBHOOK_URL — Grok Bot webhook routine POST URL
+#   GROK_BOT_WEBHOOK_KEY — sender key used as Bearer token
+
+name: Wake Grok Automerge
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  notify:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Send ready_for_review webhook
+        run: |
+          echo "Sending ready_for_review webhook for PR #${{ github.event.pull_request.number }}..."
+          curl -f -X POST "${{ secrets.GROK_BOT_WEBHOOK_URL }}" \
+            -H "Authorization: Bearer ${{ secrets.GROK_BOT_WEBHOOK_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "event": "ready_for_review",
+              "repo": "${{ github.repository }}",
+              "pr": ${{ github.event.pull_request.number }},
+              "title": ${{ toJSON(github.event.pull_request.title) }},
+              "html_url": "${{ github.event.pull_request.html_url }}",
+              "draft": false
+            }'
+          echo "Webhook sent successfully."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a GitHub Actions workflow that fires when a PR transitions from draft to ready for review.

## What it does

On `ready_for_review` event:
1. POSTs a JSON payload to the Grok Bot webhook URL
2. Authenticates with a Bearer token from secrets
3. Includes PR metadata: event type, repo, PR number, title, URL, draft status

## Setup required

Add these repository secrets in **Settings → Secrets and variables → Actions**:

| Secret | Description |
|--------|-------------|
| `GROK_BOT_WEBHOOK_URL` | Grok Bot webhook routine POST URL |
| `GROK_BOT_WEBHOOK_KEY` | Sender key used as Bearer token |

## Details

- Only fires for PRs from the base repo (skips forks)
- Uses `curl -f` to fail on HTTP errors
- Minimal permissions (`contents: read`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e070f95-a461-424f-9b1d-cf74a70f567f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e070f95-a461-424f-9b1d-cf74a70f567f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

