### PR TITLE
ci: Also wake Grok automerge on PR synchronize

### DIFF
--- a/.github/workflows/grok-automerge-ready.yml
+++ b/.github/workflows/grok-automerge-ready.yml
@@ -1,3 +1,4 @@
+# Wake Grok automerge bot on ready_for_review (mark active) and synchronize (push/rebase).
 # Secrets required (add in GitHub Settings → Secrets):
 #   GROK_BOT_WEBHOOK_URL — Grok Bot webhook routine POST URL
 #   GROK_BOT_WEBHOOK_KEY — sender key used as Bearer token
@@ -6,27 +7,27 @@ name: Wake Grok Automerge
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [ready_for_review, synchronize]
 
 jobs:
   notify:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Send ready_for_review webhook
+      - name: Send webhook to Grok automerge bot
         run: |
-          echo "Sending ready_for_review webhook for PR #${{ github.event.pull_request.number }}..."
+          echo "Sending ${{ github.event.action }} webhook for PR #${{ github.event.pull_request.number }}..."
           curl -f -X POST "${{ secrets.GROK_BOT_WEBHOOK_URL }}" \
             -H "Authorization: Bearer ${{ secrets.GROK_BOT_WEBHOOK_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{
-              "event": "ready_for_review",
+              "event": "${{ github.event.action }}",
               "repo": "${{ github.repository }}",
               "pr": ${{ github.event.pull_request.number }},
               "title": ${{ toJSON(github.event.pull_request.title) }},
               "html_url": "${{ github.event.pull_request.html_url }}",
-              "draft": false
+              "draft": ${{ github.event.pull_request.draft }}
             }'
           echo "Webhook sent successfully."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Add workflow to wake Grok automerge bot on both `ready_for_review` and `synchronize` PR events.

## Why
Automerge is now webhook-only (no GitHub pr-pushed Grok listener). After Eva rebases a conflicted PR, the `synchronize` event must wake the bot to continue the automerge flow.

## Changes
- **Trigger**: `ready_for_review` (mark active) + `synchronize` (conflict rebase pushes)
- **Condition**: Skip forks and draft PRs
- **Body**: Includes `event` field (`github.event.action` → ready_for_review or synchronize), plus repo, pr, title, html_url, draft
- **Auth**: Bearer token via secrets `GROK_BOT_WEBHOOK_URL` and `GROK_BOT_WEBHOOK_KEY`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5167714-9710-4d64-97f1-291906fad393?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5167714-9710-4d64-97f1-291906fad393&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

