### PR TITLE
fix: Type interactionMode as default|plan for Convex deploy

### DIFF
--- a/packages/backend/convex/_sessions/execution.ts
+++ b/packages/backend/convex/_sessions/execution.ts
@@ -107,7 +107,7 @@ async function stageAndStartSessionTurn(
         turnId,
         attachmentStorageIds: params.attachmentStorageIds,
         model: normalizedModel,
-        interactionMode: "default",
+        interactionMode: "default" as const,
       }
     : undefined;
   await ctx.db.patch(params.session._id, {

--- a/packages/backend/convex/_sessions/workflow.ts
+++ b/packages/backend/convex/_sessions/workflow.ts
@@ -147,9 +147,6 @@ function parseDesignResult(
   return parsed.success ? parsed.data : null;
 }
 
-const WORKSPACE_DIR = "/tmp/repo";
-const LEGACY_WORKSPACE_DIR = "/workspace/repo";
-
 /** Finalizes and clears an open synthetic-turn placeholder on session hygiene paths. */
 async function finalizeOpenSyntheticTurn(
   ctx: MutationCtx,
@@ -1142,7 +1139,7 @@ export const claimPendingTurn = authMutation({
       stopTaskToolUseIds,
       cancelRequested,
       usageRefreshRequested,
-      interactionMode: "default",
+      interactionMode: "default" as const,
     };
     if (turnLease === null) {
       const turnLifecycle = "legacy" as const;
@@ -1259,7 +1256,7 @@ export const ensurePendingTurn = internalMutation({
       ...(args.model !== undefined
         ? { model: normalizeAIModel(args.model) }
         : {}),
-      interactionMode: "default",
+      interactionMode: "default" as const,
     };
     await ctx.db.patch(args.sessionId, {
       pendingTurn,
@@ -1348,7 +1345,7 @@ export const restageOpenTurn = internalMutation({
       ...(openTurn ? { turnId: openTurn._id } : {}),
       attachmentStorageIds: lastUser.attachmentStorageIds,
       ...(session.lastModel !== undefined ? { model: session.lastModel } : {}),
-      interactionMode: "default",
+      interactionMode: "default" as const,
     };
     await ctx.db.patch(args.sessionId, {
       pendingTurn,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes Convex deploy TypeScript typecheck errors introduced by PR #723 (Eva: Implement t3code plan mode).

## Changes
- **`packages/backend/convex/_sessions/execution.ts`**: Added `as const` to `interactionMode: "default"` to satisfy the schema's union type (`"default" | "plan"`)
- **`packages/backend/convex/_sessions/workflow.ts`**:
  - Added `as const` to three `interactionMode: "default"` assignments
  - Removed unused `WORKSPACE_DIR` and `LEGACY_WORKSPACE_DIR` constants

## Why
The `interactionMode` property is typed as `"default" | "plan"` in the Convex schema validators, but TypeScript was inferring the literal `"default"` as `string`. Using `as const` narrows the type correctly.

## Testing
`npx convex typecheck` now passes (was failing with 9 errors).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad84eebd-eb78-4ead-8792-a90b0dc29b0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad84eebd-eb78-4ead-8792-a90b0dc29b0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

